### PR TITLE
small qol fix : add pre-commit config with ruff v0.15.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.15.12
     hooks:
       # Lint first, then format (order matters)
       - id: ruff


### PR DESCRIPTION
Adds .pre-commit-config.yaml so contributors get automatic lint and format checks on every commit without needing to remember to run ruff manually.

Hooks:
  - ruff --fix   (lint with auto-fix)
  - ruff-format  (formatter)

Hook order follows the Ruff docs recommendation: lint before format. Pinned to v0.15.12 (current stable release as of May 2025).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pre-commit configuration to automatically run code linting and formatting checks on each commit, ensuring consistent code quality across the project.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/8)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->