### PR TITLE
test: verify bundled graph assets are packaged

### DIFF
--- a/tests/test_distribution_cli.py
+++ b/tests/test_distribution_cli.py
@@ -60,6 +60,7 @@ def test_json_client_writers_use_packaged_stdio_command(
     relative_path: str,
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setattr("waggle.server.sys.platform", "linux")
 
     config_path = writer(str(tmp_path / "memory.db"), "/tmp/fake-python")

--- a/tests/test_distribution_cli.py
+++ b/tests/test_distribution_cli.py
@@ -35,6 +35,7 @@ def test_parser_exposes_graph_studio_aliases(command_name: str) -> None:
 
 def test_write_codex_config_uses_packaged_stdio_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_codex(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -58,3 +58,16 @@ def test_app_package_manifests_exist_in_new_locations() -> None:
     assert (ROOT / "apps" / "vscode-extension" / "package.json").exists()
     assert (ROOT / "apps" / "mcp" / "claude-desktop-extension" / "manifest.json").exists()
     assert (ROOT / "apps" / "mcp" / "graph-ui" / "package.json").exists()
+
+
+def test_graph_ui_bundle_contains_expected_static_assets() -> None:
+    graph_static_dir = ROOT / "src" / "waggle" / "static" / "graph"
+
+    expected_files = ["index.html", "app.css", "app.js"]
+    missing = [name for name in expected_files if not (graph_static_dir / name).is_file()]
+
+    assert not missing, (
+        "Missing bundled Graph Studio assets: "
+        + ", ".join(missing)
+        + ". Rebuild or restore src/waggle/static/graph before packaging."
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -244,6 +244,7 @@ def test_doctor_flags_mixed_embedding_model_ids(
 ) -> None:
     db_path = tmp_path / "server-memory.db"
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     write_waggle_codex_config(tmp_path, db_path)
     graph = MemoryGraph(db_path, FakeEmbeddingModel())
     graph.observe_conversation(
@@ -296,6 +297,7 @@ def test_doctor_fix_reembeds_mixed_embedding_model_ids(
 ) -> None:
     db_path = tmp_path / "server-memory.db"
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     write_waggle_codex_config(tmp_path, db_path)
     graph = MemoryGraph(db_path, FakeEmbeddingModel())
     graph.observe_conversation(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -83,6 +83,24 @@ def make_app(tmp_path: Path) -> WaggleServer:
     return WaggleServer(graph=graph, config=config)
 
 
+def write_waggle_codex_config(home: Path, db_path: Path) -> None:
+    codex_dir = home / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "config.toml").write_text(
+        "\n".join(
+            [
+                "[mcp_servers.waggle]",
+                'command = "waggle-mcp"',
+                "",
+                "[mcp_servers.waggle.env]",
+                f'WAGGLE_DB_PATH = "{db_path}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_store_node_and_stats_tool(tmp_path: Path) -> None:
     app = make_app(tmp_path)
 
@@ -221,8 +239,12 @@ def test_parser_accepts_graph_editor_commands() -> None:
     assert share_args.file_ref == "file123"
 
 
-def test_doctor_flags_mixed_embedding_model_ids(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_doctor_flags_mixed_embedding_model_ids(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     db_path = tmp_path / "server-memory.db"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    write_waggle_codex_config(tmp_path, db_path)
     graph = MemoryGraph(db_path, FakeEmbeddingModel())
     graph.observe_conversation(
         user_message="Use FastAPI.",
@@ -269,8 +291,12 @@ def test_doctor_flags_mixed_embedding_model_ids(tmp_path: Path, capsys: pytest.C
     assert "Mixed embedding model IDs detected" in stdout
 
 
-def test_doctor_fix_reembeds_mixed_embedding_model_ids(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_doctor_fix_reembeds_mixed_embedding_model_ids(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     db_path = tmp_path / "server-memory.db"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    write_waggle_codex_config(tmp_path, db_path)
     graph = MemoryGraph(db_path, FakeEmbeddingModel())
     graph.observe_conversation(
         user_message="Use FastAPI.",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -86,6 +86,7 @@ def make_app(tmp_path: Path) -> WaggleServer:
 def write_waggle_codex_config(home: Path, db_path: Path) -> None:
     codex_dir = home / ".codex"
     codex_dir.mkdir(parents=True)
+    normalized_db_path = db_path.as_posix()
     (codex_dir / "config.toml").write_text(
         "\n".join(
             [
@@ -93,7 +94,7 @@ def write_waggle_codex_config(home: Path, db_path: Path) -> None:
                 'command = "waggle-mcp"',
                 "",
                 "[mcp_servers.waggle.env]",
-                f'WAGGLE_DB_PATH = "{db_path}"',
+                f'WAGGLE_DB_PATH = "{normalized_db_path}"',
                 "",
             ]
         ),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1461,6 +1461,7 @@ def test_default_graph_uses_home_scoped_sqlite_path(monkeypatch: pytest.MonkeyPa
     monkeypatch.delenv("WAGGLE_BACKEND", raising=False)
     monkeypatch.delenv("WAGGLE_DB_PATH", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     graph = _default_graph()
 
@@ -1508,6 +1509,7 @@ def test_default_graph_requires_neo4j_connection_settings(monkeypatch: pytest.Mo
 
 def test_write_other_config_no_longer_uses_pythonpath(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_other(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()
@@ -1520,6 +1522,7 @@ def test_write_other_config_no_longer_uses_pythonpath(monkeypatch: pytest.Monkey
 
 def test_write_codex_config_no_longer_uses_pythonpath(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_codex(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()
@@ -1547,6 +1550,7 @@ def test_setup_client_arg_normalization() -> None:
 
 def test_write_gemini_config_preserves_existing_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     settings_file = tmp_path / ".gemini" / "settings.json"
     settings_file.parent.mkdir(parents=True)
     settings_file.write_text(json.dumps({"theme": "dark", "mcpServers": {"other": {"command": "x"}}}))
@@ -1563,6 +1567,7 @@ def test_write_gemini_config_preserves_existing_settings(monkeypatch: pytest.Mon
 
 def test_write_antigravity_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_antigravity(str(tmp_path / "memory.db"), "/tmp/fake-python")
     payload = json.loads(config_path.read_text())
@@ -1574,6 +1579,7 @@ def test_write_antigravity_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
 
 def test_run_setup_writes_codex_config_and_agents(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
     result = _run_setup(
@@ -1599,6 +1605,7 @@ def test_write_codex_config_updates_existing_file_without_duplicates(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     config_file = tmp_path / ".codex" / "config.toml"
     config_file.parent.mkdir(parents=True)
     config_file.write_text(


### PR DESCRIPTION
## Summary

- add a packaging regression test for the bundled graph UI assets
- fail fast if `index.html`, `app.css`, or `app.js` disappears from `src/waggle/static/graph`

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

## Checklist

- [x] I linked an issue or explained why one is not needed.
- [ ] I updated docs if user-facing behavior changed.
- [x] I kept the PR focused on one logical change.
- [x] I did not commit secrets, local exports, or generated noise.

Fixes #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a packaging test that verifies the Graph UI bundle contains required static assets (HTML, CSS, JS) and fails with guidance if missing.
  * Updated server tests to create/normalize local Codex config and ensure HOME and USERPROFILE are set for consistent path and DB resolution in tests.
  * Adjusted CLI/config tests to set USERPROFILE as well for cross-platform path consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->