### PR TITLE
fix: validate empty transcript search

### DIFF
--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -676,6 +676,11 @@ export function App() {
   };
 
   const runTranscriptSearch = async () => {
+    if (transcriptSearch.trim() === "") {
+      setTranscriptHits([]);
+      setStatus("Please enter a search query.");
+      return;
+    }
     if (boot.sampleMode) {
       const queryText = transcriptSearch.trim().toLowerCase();
       setTranscriptHits(

--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -678,7 +678,7 @@ export function App() {
   const runTranscriptSearch = async () => {
     if (transcriptSearch.trim() === "") {
       setTranscriptHits([]);
-      setStatus("Please enter a search query.");
+      setToast("Please enter a search query.");
       return;
     }
     if (boot.sampleMode) {


### PR DESCRIPTION
## Summary
i have added validation to prevent empty transcript. search queries from making API calls

- added empty string check in runTranscriptSearch
- clears transcript hits on empty search
- it shows status messages to users 

## Testing

- [ ] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

## Checklist

- [ ] I linked an issue or explained why one is not needed.
- [ ] I updated docs if user-facing behavior changed.
- [ ] I kept the PR focused on one logical change.
- [ ] I did not commit secrets, local exports, or generated noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now validates that queries are non-empty before processing. Users attempting to search with an empty query will receive a status message, and previous results will be cleared.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->