### PR TITLE
docs: add Windows-specific setup and troubleshooting notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,6 +61,22 @@ body:
       label: Environment
       description: OS, Python version, client, and any relevant env vars.
       placeholder: macOS 14, Python 3.11, Codex desktop, WAGGLE_MODEL=deterministic
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - other
+  - type: textarea
+    id: windows_details
+    attributes:
+      label: Windows-specific details (fill only if on Windows)
+      description: PowerShell version, execution policy, terminal type (CMD/PowerShell/WSL)
+      placeholder: |
+        PowerShell 7.4, execution policy RemoteSigned, Windows Terminal
   - type: textarea
     id: logs
     attributes:

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -17,6 +17,7 @@ No cloud account. No API key. Local by default.
 - [Antigravity](./antigravity.md)
 - [Generic MCP clients](./generic-mcp.md)
 - [Troubleshooting](./troubleshooting.md)
+- [Windows setup & troubleshooting](./troubleshooting.md#windows-specific-troubleshooting)
 
 ## One-line install
 

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -69,3 +69,48 @@ waggle-mcp serve --transport stdio
 ## Security and privacy
 
 Waggle stores memory locally by default. If troubleshooting requires sharing logs, inspect them first so you do not leak transcript content or secrets.
+
+---
+
+## Windows-specific troubleshooting
+
+### `waggle-mcp: command not found` on Windows
+
+After installing with pipx, update your PATH:
+
+```powershell
+pipx ensurepath
+```
+
+Then **close and reopen** your terminal. If it still fails, add manually:
+
+```powershell
+$env:PATH += ";$env:USERPROFILE\.local\bin"
+```
+
+### PowerShell execution policy error
+
+If you see `running scripts is disabled on this system`, run:
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+### UTF-8 stdout errors on Windows
+
+```powershell
+$env:PYTHONUTF8 = "1"
+```
+
+### Database path on Windows
+
+```powershell
+$env:WAGGLE_DB_PATH = "$env:APPDATA\waggle\waggle.db"
+```
+
+### Enable verbose logs on Windows
+
+```powershell
+$env:WAGGLE_LOG_LEVEL = "DEBUG"
+waggle-mcp serve --transport stdio
+```


### PR DESCRIPTION
Closes #25

## Summary
- Added a dedicated Windows troubleshooting section to `docs/install/troubleshooting.md` covering common issues like command not found, PowerShell execution policy errors, UTF-8 stdout errors, database path setup, and verbose logging.
- Added Windows-specific fields (OS dropdown and Windows details textarea) to `.github/ISSUE_TEMPLATE/bug_report.yml` to help maintainers diagnose Windows bugs faster.
- Added a link to the new Windows section in `docs/install/README.md`.

This was needed because the existing docs only showed POSIX/bash syntax, making it harder for Windows contributors to set up and debug the project.

## Testing
- [ ] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

## Checklist
- [x] I linked an issue or explained why one is not needed.
- [x] I updated docs if user-facing behavior changed.
- [x] I kept the PR focused on one logical change.
- [x] I did not commit secrets, local exports, or generated noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows troubleshooting guide covering PATH configuration, PowerShell execution policy, UTF-8 encoding, database setup, and logging solutions.
  * Enhanced bug report template with Operating System dropdown and Windows-specific details field.
  * Updated install guide with link to Windows setup resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->