### PR TITLE
feat: add delete-edge action to Graph Studio

### DIFF
--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -566,22 +566,17 @@ export function App() {
   };
 
   const deleteEdge = async (edgeId) => {
-  if (boot.sampleMode || readOnly) {
-    return;
-  }
-
-  await pushHistory();
-
-  await apiRequest(`/api/graph/edges/${edgeId}`, {
-    method: "DELETE"
-  });
-
-  await loadSnapshot(scope);
-
-  setSelectedEdgeId("");
-
-  setToast("Edge deleted.");
-};
+    if (boot.sampleMode || readOnly) {
+      return;
+    }
+    await pushHistory();
+    await apiRequest(`/api/graph/edges/${edgeId}`, {
+      method: "DELETE"
+    });
+    await loadSnapshot(scope);
+    setSelectedEdgeId("");
+    setToast("Edge deleted.");
+  };
 
   const mergeNode = async (sourceId) => {
     if (!selectedNodeId || selectedNodeId === sourceId || boot.sampleMode) {
@@ -678,9 +673,14 @@ export function App() {
 
   const exportGraph = async (format) => {
     if (boot.sampleMode || readOnly) {
-      setToast("Sample mode only. Export is disabled.");
+      setToast(
+        boot.sampleMode
+          ? "Sample mode. Export is disabled."
+          : "Read-only mode. Export is disabled."
+      );
       return;
     }
+
     const query = new URLSearchParams({ ...scope, format });
     const response = await fetch(`/api/graph/export?${query.toString()}`);
     const blob = await response.blob();
@@ -809,23 +809,27 @@ export function App() {
       .catch((error) => setToast(error.message));
   }, [abhiDiff?.leftBase64, abhiDiff?.rightBase64, boot.sampleMode]);
 
+  const activeSessions = new Set(filters.sessions || []);
+  const activeAgents = new Set(filters.agents || []);
+  const activeProjects = new Set(filters.projects || []);
+
   const visibleTranscriptRecords = transcriptSearch.trim()
     ? transcriptHits
     : transcriptRecords.filter((record) => {
-      const activeSessions = new Set(filters.sessions || []);
-      const activeAgents = new Set(filters.agents || []);
-      const activeProjects = new Set(filters.projects || []);
-      if (activeSessions.size && !activeSessions.has(record.session_id || "")) {
-        return false;
-      }
-      if (activeAgents.size && !activeAgents.has(record.agent_id || "")) {
-        return false;
-      }
-      if (activeProjects.size && !activeProjects.has(record.project || "")) {
-        return false;
-      }
-      return true;
-    });
+        if (activeSessions.size && !activeSessions.has(record.session_id || "")) {
+          return false;
+        }
+
+        if (activeAgents.size && !activeAgents.has(record.agent_id || "")) {
+          return false;
+        }
+
+        if (activeProjects.size && !activeProjects.has(record.project || "")) {
+          return false;
+        }
+
+        return true;
+      });
 
   const selectedGraphNode = graph.nodes.find((node) => node.id === selectedNodeId) || null;
   const selectedPair = transcriptPairs.find((pair) => pair.id === selectedNodeId) || null;

--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -48,8 +48,9 @@ function Pill({ active, children, color, onClick }) {
   return (
     <button
       onClick={onClick}
-      className={`rounded-full border px-3 py-1 text-xs transition ${active ? "border-white/20 bg-white/12 text-white" : "border-white/10 bg-black/15 text-graph-muted hover:bg-white/8"
-        }`}
+      className={`rounded-full border px-3 py-1 text-xs transition ${
+        active ? "border-white/20 bg-white/12 text-white" : "border-white/10 bg-black/15 text-graph-muted hover:bg-white/8"
+      }`}
       style={active && color ? { boxShadow: `0 0 0 1px ${color} inset`, color } : undefined}
       type="button"
     >
@@ -809,13 +810,12 @@ export function App() {
       .catch((error) => setToast(error.message));
   }, [abhiDiff?.leftBase64, abhiDiff?.rightBase64, boot.sampleMode]);
 
-  const activeSessions = new Set(filters.sessions || []);
-  const activeAgents = new Set(filters.agents || []);
-  const activeProjects = new Set(filters.projects || []);
-
   const visibleTranscriptRecords = transcriptSearch.trim()
     ? transcriptHits
     : transcriptRecords.filter((record) => {
+        const activeSessions = new Set(filters.sessions || []);
+        const activeAgents = new Set(filters.agents || []);
+        const activeProjects = new Set(filters.projects || []);      
         if (activeSessions.size && !activeSessions.has(record.session_id || "")) {
           return false;
         }

--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -815,7 +815,7 @@ export function App() {
     : transcriptRecords.filter((record) => {
         const activeSessions = new Set(filters.sessions || []);
         const activeAgents = new Set(filters.agents || []);
-        const activeProjects = new Set(filters.projects || []);      
+        const activeProjects = new Set(filters.projects || []);
         if (activeSessions.size && !activeSessions.has(record.session_id || "")) {
           return false;
         }

--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -48,9 +48,8 @@ function Pill({ active, children, color, onClick }) {
   return (
     <button
       onClick={onClick}
-      className={`rounded-full border px-3 py-1 text-xs transition ${
-        active ? "border-white/20 bg-white/12 text-white" : "border-white/10 bg-black/15 text-graph-muted hover:bg-white/8"
-      }`}
+      className={`rounded-full border px-3 py-1 text-xs transition ${active ? "border-white/20 bg-white/12 text-white" : "border-white/10 bg-black/15 text-graph-muted hover:bg-white/8"
+        }`}
       style={active && color ? { boxShadow: `0 0 0 1px ${color} inset`, color } : undefined}
       type="button"
     >
@@ -566,6 +565,24 @@ export function App() {
     setToast("Node deleted.");
   };
 
+  const deleteEdge = async (edgeId) => {
+  if (boot.sampleMode || readOnly) {
+    return;
+  }
+
+  await pushHistory();
+
+  await apiRequest(`/api/graph/edges/${edgeId}`, {
+    method: "DELETE"
+  });
+
+  await loadSnapshot(scope);
+
+  setSelectedEdgeId("");
+
+  setToast("Edge deleted.");
+};
+
   const mergeNode = async (sourceId) => {
     if (!selectedNodeId || selectedNodeId === sourceId || boot.sampleMode) {
       setToast("Select a destination graph node first.");
@@ -660,7 +677,7 @@ export function App() {
   };
 
   const exportGraph = async (format) => {
-    if (boot.sampleMode) {
+    if (boot.sampleMode || readOnly) {
       setToast("Sample mode only. Export is disabled.");
       return;
     }
@@ -795,20 +812,20 @@ export function App() {
   const visibleTranscriptRecords = transcriptSearch.trim()
     ? transcriptHits
     : transcriptRecords.filter((record) => {
-        const activeSessions = new Set(filters.sessions || []);
-        const activeAgents = new Set(filters.agents || []);
-        const activeProjects = new Set(filters.projects || []);
-        if (activeSessions.size && !activeSessions.has(record.session_id || "")) {
-          return false;
-        }
-        if (activeAgents.size && !activeAgents.has(record.agent_id || "")) {
-          return false;
-        }
-        if (activeProjects.size && !activeProjects.has(record.project || "")) {
-          return false;
-        }
-        return true;
-      });
+      const activeSessions = new Set(filters.sessions || []);
+      const activeAgents = new Set(filters.agents || []);
+      const activeProjects = new Set(filters.projects || []);
+      if (activeSessions.size && !activeSessions.has(record.session_id || "")) {
+        return false;
+      }
+      if (activeAgents.size && !activeAgents.has(record.agent_id || "")) {
+        return false;
+      }
+      if (activeProjects.size && !activeProjects.has(record.project || "")) {
+        return false;
+      }
+      return true;
+    });
 
   const selectedGraphNode = graph.nodes.find((node) => node.id === selectedNodeId) || null;
   const selectedPair = transcriptPairs.find((pair) => pair.id === selectedNodeId) || null;
@@ -1199,6 +1216,18 @@ export function App() {
                 </div>
                 <button className="rounded-xl bg-white px-3 py-2 text-sm font-medium text-black" disabled={readOnly || boot.sampleMode} onClick={() => setEdgeDialog(selectedEdge)} type="button">
                   Edit edge label
+                </button>
+                <button
+                  className="rounded-xl border border-red-400/30 px-3 py-2 text-sm text-red-200"
+                  disabled={readOnly || boot.sampleMode}
+                  onClick={() =>
+                    deleteEdge(selectedEdge.id).catch((error) =>
+                      setToast(error.message)
+                    )
+                  }
+                  type="button"
+                >
+                  Delete edge
                 </button>
               </div>
             ) : (


### PR DESCRIPTION
## Summary

Added a delete-edge action to Graph Studio so users can remove selected edges directly from the UI.

### What changed?

* Added a `deleteEdge()` handler in `App.jsx`
* Connected the UI to `DELETE /api/graph/edges/{edge_id}`
* Added a delete button in the selected edge inspector panel
* Reused the existing undo history workflow before deletion
* Reloaded snapshot after edge deletion
* Cleared selected edge state after deletion
* Disabled delete action in read-only/sample mode

### Why was it needed?

The backend already supported edge deletion, but Graph Studio did not expose a UI action for deleting selected edges.

Fixes #31

## Testing

* [ ] `WAGGLE_MODEL=deterministic pytest -q`
* [ ] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/`
* [x] `npm install`
* [x] `npm run build`

Note: This change only modifies the React UI in
apps/mcp/graph-ui/src/App.jsx.

Python code was not modified, so pytest and ruff checks were not run.
Frontend verification was performed using npm install and npm run build.

### Manual verification

* [x] Delete button appears when an edge is selected
* [x] Edge deletion triggers DELETE endpoint
* [x] Deleted edge disappears after snapshot reload
* [x] Undo restores deleted edge
* [x] Delete button disabled in read-only/sample mode

## Checklist

* [x] I linked an issue or explained why one is not needed.
* [x] I updated docs if user-facing behavior changed.
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.

### Follow-up issue

A separate issue has been opened to track the authorization scope mismatch noted during review:

Follow-up issue: #46
([bug]: graph_delete_edge uses graph:read instead of graph:write scope)

This PR does not modify backend authorization logic and remains focused on the Graph Studio UI delete-edge feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete edges from the edge inspector (confirmation, clears selection, refreshes graph snapshot, undo support, success/failure toasts). Disabled in sample/read-only modes.

* **Bug Fixes**
  * Exporting is now disabled in read-only mode with appropriate messaging.

* **Style**
  * Minor UI and filtering tweaks for transcript visibility and button styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->