### PR TITLE
fix: unbreak doctor and Windows tests in CI (test infra + one Codex writer bug)

### DIFF
--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -5479,7 +5479,9 @@ def _write_codex(db_path: str, python_exe: str) -> Path:
     pattern = re.compile(r"(?ms)^\[mcp_servers\.waggle\]\n.*?(?=^\[(?!mcp_servers\.waggle(?:\.env)?\])[^\n]+\]\n|\Z)")
     replacement = toml_block.rstrip() + "\n"
     if pattern.search(existing):
-        updated = pattern.sub(replacement, existing, count=1)
+        # Pass replacement via a lambda so re.sub does not interpret backslash
+        # sequences (\U, \1, \g<…>) inside Windows paths like C:\Users\....
+        updated = pattern.sub(lambda _m: replacement, existing, count=1)
     else:
         separator = "\n\n" if existing.strip() else ""
         updated = existing.rstrip() + separator + replacement

--- a/tests/test_distribution_cli.py
+++ b/tests/test_distribution_cli.py
@@ -35,6 +35,7 @@ def test_parser_exposes_graph_studio_aliases(command_name: str) -> None:
 
 def test_write_codex_config_uses_packaged_stdio_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_codex(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()
@@ -60,6 +61,7 @@ def test_json_client_writers_use_packaged_stdio_command(
     relative_path: str,
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setattr("waggle.server.sys.platform", "linux")
 
     config_path = writer(str(tmp_path / "memory.db"), "/tmp/fake-python")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -269,7 +269,22 @@ def test_doctor_flags_mixed_embedding_model_ids(tmp_path: Path, capsys: pytest.C
     assert "Mixed embedding model IDs detected" in stdout
 
 
-def test_doctor_fix_reembeds_mixed_embedding_model_ids(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_doctor_fix_reembeds_mixed_embedding_model_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Isolate Path.home() / %APPDATA% so doctor's MCP-config-discovery section sees
+    # only the stub config we plant below, not whatever exists on the CI runner.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    monkeypatch.setenv("APPDATA", str(fake_home / "AppData"))
+    claude_cfg = fake_home / ".config" / "claude" / "claude_desktop_config.json"
+    claude_cfg.parent.mkdir(parents=True)
+    claude_cfg.write_text(json.dumps({"mcpServers": {"waggle": {"command": "waggle-mcp"}}}))
+
     db_path = tmp_path / "server-memory.db"
     graph = MemoryGraph(db_path, FakeEmbeddingModel())
     graph.observe_conversation(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1448,6 +1448,7 @@ def test_default_graph_uses_home_scoped_sqlite_path(monkeypatch: pytest.MonkeyPa
     monkeypatch.delenv("WAGGLE_BACKEND", raising=False)
     monkeypatch.delenv("WAGGLE_DB_PATH", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     graph = _default_graph()
 
@@ -1495,6 +1496,7 @@ def test_default_graph_requires_neo4j_connection_settings(monkeypatch: pytest.Mo
 
 def test_write_other_config_no_longer_uses_pythonpath(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_other(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()
@@ -1507,6 +1509,7 @@ def test_write_other_config_no_longer_uses_pythonpath(monkeypatch: pytest.Monkey
 
 def test_write_codex_config_no_longer_uses_pythonpath(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_codex(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()
@@ -1534,6 +1537,7 @@ def test_setup_client_arg_normalization() -> None:
 
 def test_write_gemini_config_preserves_existing_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     settings_file = tmp_path / ".gemini" / "settings.json"
     settings_file.parent.mkdir(parents=True)
     settings_file.write_text(json.dumps({"theme": "dark", "mcpServers": {"other": {"command": "x"}}}))
@@ -1550,6 +1554,7 @@ def test_write_gemini_config_preserves_existing_settings(monkeypatch: pytest.Mon
 
 def test_write_antigravity_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_antigravity(str(tmp_path / "memory.db"), "/tmp/fake-python")
     payload = json.loads(config_path.read_text())
@@ -1561,6 +1566,7 @@ def test_write_antigravity_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
 
 def test_run_setup_writes_codex_config_and_agents(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
     result = _run_setup(
@@ -1586,6 +1592,7 @@ def test_write_codex_config_updates_existing_file_without_duplicates(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     config_file = tmp_path / ".codex" / "config.toml"
     config_file.parent.mkdir(parents=True)
     config_file.write_text(


### PR DESCRIPTION
## What

Three pre-existing failures on `main` block CI for every PR that rebases. Two are test-infrastructure issues, one is a real product bug surfaced by the test infra fix. All reproduce on `main` itself ([CI run 26561410693](https://github.com/Abhigyan-Shekhar/Waggle-mcp/actions/runs/26561410693)) — none are introduced by any in-flight branch.

## Fix 1 — test infra: doctor section [1] not isolated from runner env

`test_server.py::test_doctor_fix_reembeds_mixed_embedding_model_ids` (Linux 3.12 / 3.13)

`_run_doctor` walks `_KNOWN_CONFIG_PATHS` against the runner's real `Path.home()` and `%APPDATA%`. CI runners have no `waggle` entry in any client config, so section [1] appends an issue and the doctor returns `1` even when the mixed-models scenario under test was correctly repaired.

Redirect `HOME` / `USERPROFILE` / `APPDATA` to a tmp-rooted fake home and plant a stub `claude_desktop_config.json` with a `waggle` entry. Only the env-discovery section is isolated; the mixed-models logic still runs end-to-end.

## Fix 2 — test infra: HOME without USERPROFILE on Windows

Multiple tests in `test_server.py` and `test_distribution_cli.py` (Windows 3.11)

Tests set `monkeypatch.setenv("HOME", str(tmp_path))`, but `pathlib.Path.home()` resolves via `USERPROFILE` on Windows regardless of `HOME` — so writers wrote into the runner's real user profile, not the sandbox.

Add `monkeypatch.setenv("USERPROFILE", str(tmp_path))` alongside the existing `HOME` setting in all nine affected tests.

## Fix 3 — product: `_write_codex` re.sub interprets `\U` in Windows db_path

`test_server.py::test_write_codex_config_updates_existing_file_without_duplicates` (Windows 3.11, surfaced by Fix 2)

`_write_codex` builds a replacement TOML block containing the resolved db_path and passes it to `re.sub` as a string. On Windows the path starts with `C:\Users\...`; Python 3.12+ raises `re.error: bad escape \U at position 157` because `re.sub` interprets backslash sequences (`\1`, `\g<…>`, `\Unnnnnnnn`) inside the replacement.

Wrap the replacement in a lambda so `re.sub` treats it as opaque and skips backreference interpretation. This was masked by Fix 2 (tests were writing into the real user profile, where the path starts with `C:\Users\runneradmin\` but the test never actually hit the existing-file branch of `_write_codex`).

## Scope

- `src/waggle/server.py`: 3 lines (one `re.sub` call) for Fix 3
- `tests/test_server.py`, `tests/test_distribution_cli.py`: ~25 lines for Fix 1 + Fix 2

The product fix is small and targeted, but it is genuinely product code — surfacing this PR's title/scope accordingly.

These same commits are also included in [PR #12](https://github.com/Abhigyan-Shekhar/Waggle-mcp/pull/12) to unblock its CI; if this lands first, the PR #12 cherry-pick will drop on rebase.