### PR TITLE
chore: bump ruff in .pre-commit-config to v0.15.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.15.12
     hooks:
       # Lint first, then format (order matters)
       - id: ruff


### PR DESCRIPTION
Bumps the ruff-pre-commit rev from `v0.11.10` to `v0.15.12` (current stable). Hook order, formatter pinning, and the `pre-commit-hooks` companion block from `main` are preserved verbatim.

## Single-line diff

```diff
-    rev: v0.11.10
+    rev: v0.15.12
```

## Why a new PR

This replaces [PR #8](https://github.com/Abhigyan-Shekhar/Waggle-mcp/pull/8), which was opened from `ard12/Waggle-mcp` (not a registered fork of this repo). When I rebased the old PR onto latest `main` to resolve a merge conflict and force-pushed, GitHub auto-closed it — non-registered-fork PRs cannot survive a head-ref rewrite.

Opening this from `ard12/Waggle-mcp-1` (the registered fork) so the PR survives future rebases.

## Rebase summary

The original PR pre-dated the richer `.pre-commit-config.yaml` that landed on `main` (added the `pre-commit-hooks` block — `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-toml`, `check-added-large-files --maxkb=500`, `check-merge-conflict`, `debug-statements`). The rebase keeps all of that and only bumps the ruff `rev`.