### PR TITLE
Fix/edge weight validation

### DIFF
--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3465,6 +3465,13 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
     async def graph_create_edge(request: Request) -> Response:
         payload = await request.json()
         graph, _ = _require_http_scope(request, "graph:write")
+        raw_weight = payload.get("weight", 1.0)
+        try:
+            weight_value = float(raw_weight)
+        except (TypeError, ValueError):
+            raise ValidationFailure("Edge weight must be a numeric value between 0 and 1.")
+        if not (0 <= weight_value <= 1):
+            raise ValidationFailure("Edge weight must be a numeric value between 0 and 1.")
         snapshot = graph.get_graph_snapshot()
         snapshot["edges"] = [*snapshot.get("edges", []), _edge_snapshot_payload(snapshot=snapshot, payload=payload)]
         _validate_live_snapshot(snapshot)
@@ -3494,6 +3501,13 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
             for item in snapshot.get("edges", [])
         ]
         _validate_live_snapshot(snapshot)
+        if "weight" in payload and payload.get("weight") is not None:
+            try:
+                weight_value = float(payload["weight"])
+            except (TypeError, ValueError):
+                raise ValidationFailure("Edge weight must be a numeric value between 0 and 1.")
+            if not (0 <= weight_value <= 1):
+                raise ValidationFailure("Edge weight must be a numeric value between 0 and 1.")
         edge = graph.update_edge(
             edge_id=edge_id,
             source_id=str(payload.get("source_id", "")).strip() or None,

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3488,6 +3488,13 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
         edge_id = request.path_params["edge_id"]
         payload = await request.json()
         graph, _ = _require_http_scope(request, "graph:write")
+        if "weight" in payload and payload.get("weight") is not None:
+            try:
+                weight_value = float(payload["weight"])
+            except (TypeError, ValueError):
+                raise ValidationFailure("Edge weight must be a numeric value between 0 and 1.")
+            if not (0 <= weight_value <= 1):
+                raise ValidationFailure("Edge weight must be a numeric value between 0 and 1.")
         snapshot = graph.get_graph_snapshot()
         existing = next(
             (item for item in snapshot.get("edges", []) if str(item.get("id", "")).strip() == edge_id), None
@@ -3501,13 +3508,7 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
             for item in snapshot.get("edges", [])
         ]
         _validate_live_snapshot(snapshot)
-        if "weight" in payload and payload.get("weight") is not None:
-            try:
-                weight_value = float(payload["weight"])
-            except (TypeError, ValueError):
-                raise ValidationFailure("Edge weight must be a numeric value between 0 and 1.")
-            if not (0 <= weight_value <= 1):
-                raise ValidationFailure("Edge weight must be a numeric value between 0 and 1.")
+
         edge = graph.update_edge(
             edge_id=edge_id,
             source_id=str(payload.get("source_id", "")).strip() or None,

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -620,3 +620,120 @@ def test_http_admin_retention_and_audit_endpoints(tmp_path: Path) -> None:
         )
         assert audit.status_code == 200
         assert audit.json()[0]["event_type"] == "retention.policy.updated"
+
+def test_graph_create_edge_rejects_invalid_weight(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path)
+    app_server = WaggleServer(graph=graph, config=make_http_config(tmp_path))
+    created = graph.create_api_key("tenant-http", "http-test")
+    app = create_http_application(app_server, app_server.config)
+
+    source = graph.for_tenant("tenant-http").add_node(
+        label="Source",
+        content="source node",
+        node_type="fact",
+    )
+    target = graph.for_tenant("tenant-http").add_node(
+        label="Target",
+        content="target node",
+        node_type="fact",
+    )
+
+    with TestClient(app) as client:
+        headers = {"X-API-Key": created.raw_api_key}
+
+        resp = client.post(
+            "/api/graph/edges",
+            json={
+                "source_id": source.node.id,
+                "target_id": target.node.id,
+                "relationship": "relates_to",
+                "weight": 1.5,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+        resp = client.post(
+            "/api/graph/edges",
+            json={
+                "source_id": source.node.id,
+                "target_id": target.node.id,
+                "relationship": "relates_to",
+                "weight": -0.5,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+        resp = client.post(
+            "/api/graph/edges",
+            json={
+                "source_id": source.node.id,
+                "target_id": target.node.id,
+                "relationship": "relates_to",
+                "weight": "bad",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+        resp = client.post(
+            "/api/graph/edges",
+            json={
+                "source_id": source.node.id,
+                "target_id": target.node.id,
+                "relationship": "relates_to",
+                "weight": 0.5,
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200
+
+
+def test_graph_update_edge_rejects_invalid_weight(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path)
+    app_server = WaggleServer(graph=graph, config=make_http_config(tmp_path))
+    created = graph.create_api_key("tenant-http", "http-test")
+    app = create_http_application(app_server, app_server.config)
+
+    source = graph.for_tenant("tenant-http").add_node(
+        label="Source",
+        content="source node",
+        node_type="fact",
+    )
+    target = graph.for_tenant("tenant-http").add_node(
+        label="Target",
+        content="target node",
+        node_type="fact",
+    )
+
+    edge = graph.for_tenant("tenant-http").add_edge(
+        source_id=source.node.id,
+        target_id=target.node.id,
+        relationship="relates_to",
+        weight=0.5,
+    )
+
+    with TestClient(app) as client:
+        headers = {"X-API-Key": created.raw_api_key}
+
+        resp = client.patch(
+            f"/api/graph/edges/{edge.id}",
+            json={"weight": 1.5},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+        resp = client.patch(
+            f"/api/graph/edges/{edge.id}",
+            json={"weight": -0.1},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+        resp = client.patch(
+            f"/api/graph/edges/{edge.id}",
+            json={"weight": 0.8},
+            headers=headers,
+        )
+        assert resp.status_code == 200

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -621,6 +621,7 @@ def test_http_admin_retention_and_audit_endpoints(tmp_path: Path) -> None:
         assert audit.status_code == 200
         assert audit.json()[0]["event_type"] == "retention.policy.updated"
 
+
 def test_graph_create_edge_rejects_invalid_weight(tmp_path: Path) -> None:
     graph = make_graph(tmp_path)
     app_server = WaggleServer(graph=graph, config=make_http_config(tmp_path))

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -653,6 +653,7 @@ def test_graph_create_edge_rejects_invalid_weight(tmp_path: Path) -> None:
             headers=headers,
         )
         assert resp.status_code == 400
+        assert "numeric" in resp.json()["message"].lower()
 
         resp = client.post(
             "/api/graph/edges",
@@ -665,6 +666,7 @@ def test_graph_create_edge_rejects_invalid_weight(tmp_path: Path) -> None:
             headers=headers,
         )
         assert resp.status_code == 400
+        assert "numeric" in resp.json()["message"].lower()
 
         resp = client.post(
             "/api/graph/edges",
@@ -677,6 +679,7 @@ def test_graph_create_edge_rejects_invalid_weight(tmp_path: Path) -> None:
             headers=headers,
         )
         assert resp.status_code == 400
+        assert "numeric" in resp.json()["message"].lower()
 
         resp = client.post(
             "/api/graph/edges",
@@ -724,6 +727,7 @@ def test_graph_update_edge_rejects_invalid_weight(tmp_path: Path) -> None:
             headers=headers,
         )
         assert resp.status_code == 400
+        assert "numeric" in resp.json()["message"].lower()
 
         resp = client.patch(
             f"/api/graph/edges/{edge.id}",
@@ -731,6 +735,15 @@ def test_graph_update_edge_rejects_invalid_weight(tmp_path: Path) -> None:
             headers=headers,
         )
         assert resp.status_code == 400
+        assert "numeric" in resp.json()["message"].lower()
+
+        resp = client.patch(
+            f"/api/graph/edges/{edge.id}",
+            json={"weight": "bad"},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "numeric" in resp.json()["message"].lower()
 
         resp = client.patch(
             f"/api/graph/edges/{edge.id}",


### PR DESCRIPTION
## Summary

- What changed? Added weight validation for `/api/graph/edges` (POST) and `/api/graph/edges/{edge_id}` (PATCH) endpoints
- Why was it needed? Edge writes were accepting invalid weights (negative, greater than 1, or non-numeric) before reaching storage. Now returns a clear `400` response for invalid values.

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

## Checklist

- [x] I linked an issue or explained why one is not needed. (Closes #32)
- [x] I updated docs if user-facing behavior changed.
- [x] I kept the PR focused on one logical change.
- [x] I did not commit secrets, local exports, or generated noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graph edge weight validation tightened: create and update endpoints now require numeric weight values within the inclusive 0–1 range. Invalid, out-of-range, or non-numeric weights are rejected with clear error responses to prevent invalid graph edges.

* **Tests**
  * Added integration tests confirming weight validation for edge creation and updates, asserting invalid inputs return HTTP 400 and valid numeric weights succeed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->