### PR TITLE
fix: require graph:write scope for graph_delete_edge (closes #46)

### DIFF
--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3505,7 +3505,7 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
 
     async def graph_delete_edge(request: Request) -> Response:
         edge_id = request.path_params["edge_id"]
-        graph, _ = _require_http_scope(request, "graph:read")
+        graph, _ = _require_http_scope(request, "graph:write")
         edge = graph.delete_edge(edge_id=edge_id)
         return JSONResponse(edge.model_dump(mode="json"))
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -393,6 +393,21 @@ def test_mcp_write_requires_graph_write_scope(tmp_path: Path) -> None:
         assert denied.status_code == 403
 
 
+def test_http_graph_delete_edge_requires_graph_write_scope(tmp_path: Path) -> None:
+    """Regression test for #46: graph_delete_edge mutates the graph and must require graph:write."""
+    graph = make_graph(tmp_path)
+    app_server = WaggleServer(graph=graph, config=make_http_config(tmp_path))
+    read_only_key = graph.create_api_key("tenant-http", "reader", scopes=["graph:read"])
+    app = create_http_application(app_server, app_server.config)
+
+    with TestClient(app) as client:
+        denied = client.delete(
+            "/api/graph/edges/any-edge-id",
+            headers={"X-API-Key": read_only_key.raw_api_key},
+        )
+        assert denied.status_code == 403
+
+
 def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
     graph = make_graph(tmp_path)
     insert_transcript_record(


### PR DESCRIPTION
Closes #46.

## Problem

`graph_delete_edge` is a mutation endpoint but authorises requests with `graph:read`:

```python
async def graph_delete_edge(request: Request) -> Response:
    edge_id = request.path_params["edge_id"]
    graph, _ = _require_http_scope(request, "graph:read")   # ← wrong scope
    edge = graph.delete_edge(edge_id=edge_id)
    return JSONResponse(edge.model_dump(mode="json"))
```

This means a client holding a read-only key can permanently delete graph edges — an authorisation scope mismatch with the rest of the mutation surface:

| Endpoint | Scope (before) | Scope (after) |
|---|---|---|
| `graph_create_edge` | `graph:write` | `graph:write` |
| `graph_update_edge` | `graph:write` | `graph:write` |
| `graph_delete_node` | `graph:write` | `graph:write` |
| **`graph_delete_edge`** | **`graph:read`** ❌ | **`graph:write`** ✅ |

Reported by @Srishti-Gupta74 in #46.

## Fix

One-line change in `src/waggle/server.py`: `graph:read` → `graph:write` on the `graph_delete_edge` handler.

## Test

Added `test_http_graph_delete_edge_requires_graph_write_scope` in `tests/test_platform.py`. It issues `DELETE /api/graph/edges/<id>` with a read-only API key and asserts the response is `403`. Patterned after the existing `test_mcp_write_requires_graph_write_scope`.

## Scope sweep

While here, I grepped every `_require_http_scope(request, "graph:read")` call in `server.py` to confirm no other mutation endpoint had the same mistake. All other read-scoped endpoints are genuine reads (`graph_snapshot`, `graph_query`, `graph_diff_feed`, `graph_abhi_preview`, `graph_import_preview`, `graph_abhi_diff`) — `graph_delete_edge` was the lone outlier.

## Files changed

```
src/waggle/server.py    (+1 / -1)
tests/test_platform.py  (+15 / -0)
```

## What this doesn't change

- No public API contract change — clients that previously had `graph:write` keep working unchanged.
- Clients relying on read-only keys to delete edges will now correctly receive `403`. Given the bug, that's the intended behaviour.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [ ] CI runs the new `test_http_graph_delete_edge_requires_graph_write_scope` test (the `mcp` module isn't installed locally so the test couldn't be executed on my machine — same pre-existing condition noted in #12)
- [ ] CI test matrix (3.11/3.12/3.13) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edge deletion now requires write authorization; read-only keys are rejected.

* **Tests**
  * Added a regression test ensuring delete authorization is enforced.
  * Hardened multiple tests for cross-platform configuration discovery by aligning environment variables and isolating platform-specific config during test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->