### PR TITLE
test: unblock CI by dropping over-specified exit-code assertion in doctor fix test

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -310,10 +310,17 @@ def test_doctor_fix_reembeds_mixed_embedding_model_ids(tmp_path: Path, capsys: p
         neo4j_database="",
     )
 
-    exit_code = _run_doctor(config, fix=True)
+    _run_doctor(config, fix=True)
     stdout = capsys.readouterr().out
 
-    assert exit_code == 0
+    # NOTE: we intentionally don't assert on _run_doctor's exit code here.
+    # The doctor reports many orthogonal environment checks (MCP client config
+    # files, embedding model cache, Windows stdout encoding, ...) and exits 1 if
+    # ANY of them surface an issue. On a clean CI runner section [1] always
+    # appends "No MCP client config file contains a 'waggle' server entry",
+    # so the exit code is always 1 regardless of whether the fix path worked.
+    # The assertions below cover what this test actually means to verify:
+    # that fix=True re-embedded the stale rows and the store is now consistent.
     assert "Re-embedded stale rows" in stdout
     repaired = graph.get_embedding_store_health()
     assert repaired["mixed_models"] is False


### PR DESCRIPTION
## Why this matters

`tests/test_server.py::test_doctor_fix_reembeds_mixed_embedding_model_ids` fails on every CI run on a clean GitHub Actions runner. Because the workflow uses \`pytest -q --tb=short -x\` (stop on first failure), this single broken assertion **blocks every test that comes after it alphabetically** from running across Python 3.11 / 3.12 / 3.13.

It's been masking CI signal on multiple PRs (e.g. #12, #47).

## Root cause

The test expected:

\`\`\`python
exit_code = _run_doctor(config, fix=True)
...
assert exit_code == 0
\`\`\`

But \`_run_doctor\` reports many environment checks and returns 1 if **any** of them surface an issue. Specifically, section [1] (lines 5001–5040 of \`server.py\`) iterates \`_KNOWN_CONFIG_PATHS\` looking for an MCP client config (Claude Desktop, Cursor, Antigravity, Codex, ...) with a \`waggle\` entry. On a clean GitHub Actions runner none of these exist, so:

\`\`\`
issues.append(
    \"No MCP client config file contains a 'waggle' server entry. ...\"
)
\`\`\`

…which means \`return 1\` at line 5155 fires every single time, regardless of whether the \`fix=True\` repair path worked.

The CI failure trail (always identical):

\`\`\`
tests/test_server.py:316: in test_doctor_fix_reembeds_mixed_embedding_model_ids
    assert exit_code == 0
E   assert 1 == 0
\`\`\`

## Fix

Drop the over-specified \`assert exit_code == 0\`. Keep the three assertions that actually verify what \`fix=True\` is supposed to do:

\`\`\`python
assert \"Re-embedded stale rows\" in stdout
repaired = graph.get_embedding_store_health()
assert repaired[\"mixed_models\"] is False
assert repaired[\"transcript_stale_rows\"] == 0
\`\`\`

Added an inline comment explaining why we don't assert on exit code, so this doesn't get re-added in a future cleanup pass.

## Why not fix the doctor instead?

The doctor's behaviour is correct — it's surfacing a real issue ('no MCP client config has a waggle entry'). The test was wrong to assume \`fix=True\` would clear *every* possible doctor finding. It only clears stale embedding rows.

## Sister test is unaffected

\`test_doctor_diagnoses_mixed_embedding_model_ids\` (line 240, no \`fix=True\`) keeps its \`assert exit_code == 1\` — it's robust because both \"mixed models\" and \"no MCP config\" issues independently force exit 1.

## Files changed

\`\`\`
tests/test_server.py  (+9 / -2)
\`\`\`

## Test plan

- [x] \`ruff check\` passes
- [x] \`ruff format --check\` passes
- [ ] CI test matrix (3.11/3.12/3.13) green — and now actually runs the tests that come after \`test_doctor_fix_reembeds_mixed_embedding_model_ids\` (e.g. the new scope test from #47)