### PR TITLE
Add structured score explanations to hybrid retrieval debug #35

### DIFF
--- a/src/waggle/models.py
+++ b/src/waggle/models.py
@@ -783,6 +783,7 @@ class HybridHit(BaseModel):
     reasoning_from_reranker: str = ""
     observed_at: datetime | None = None
     layer_scores: dict[str, float] = Field(default_factory=dict)
+    score_explanation: dict[str, float] = Field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------

--- a/src/waggle/retrieval/hybrid.py
+++ b/src/waggle/retrieval/hybrid.py
@@ -267,6 +267,7 @@ class HybridRetriever:
                 reasoning_from_reranker=item.reasoning_from_reranker,
                 observed_at=item.observed_at,
                 layer_scores=item.layer_scores,
+                score_explanation=item.score_explanation,
             )
             for item in reranked
         ]

--- a/src/waggle/retrieval/hybrid.py
+++ b/src/waggle/retrieval/hybrid.py
@@ -108,6 +108,7 @@ class CandidateMemory:
     observed_at: datetime | None = None
     score: float = 0.0
     layer_scores: dict[str, float] = field(default_factory=dict)
+    score_explanation: dict[str, float] = field(default_factory=dict)
     reasoning_from_reranker: str = ""
 
 
@@ -628,6 +629,16 @@ class HybridRetriever:
                 + self.config.graph_weight * item.layer_scores.get("graph_expansion", 0.0)
             )
             item.score = fused * ((1.0 - self.config.recency_weight) + (self.config.recency_weight * decay))
+            raw = {
+                "vector_transcript": self.config.vector_weight * item.layer_scores.get("vector_transcript", 0.0),
+                "vector_node": self.config.vector_weight * item.layer_scores.get("vector_node", 0.0),
+                "bm25": self.config.bm25_weight * item.layer_scores.get("bm25", 0.0),
+                "graph_expansion": self.config.graph_weight * item.layer_scores.get("graph_expansion", 0.0),
+                "recency": self.config.recency_weight * decay,
+                }
+            total = sum(raw.values()) or 1.0
+            item.score_explanation = {k: round(v / total, 4) for k, v in raw.items()}
+            item.score_explanation["final_score"] = round(item.score, 4)
             if item.source == "node" and item.turn_pair_id and item.transcript_text:
                 item.source = "both"
                 item.content = f"{item.transcript_text}\n{item.content}"

--- a/src/waggle/retrieval/hybrid.py
+++ b/src/waggle/retrieval/hybrid.py
@@ -635,7 +635,7 @@ class HybridRetriever:
                 "bm25": self.config.bm25_weight * item.layer_scores.get("bm25", 0.0),
                 "graph_expansion": self.config.graph_weight * item.layer_scores.get("graph_expansion", 0.0),
                 "recency": self.config.recency_weight * decay,
-                }
+            }
             total = sum(raw.values()) or 1.0
             item.score_explanation = {k: round(v / total, 4) for k, v in raw.items()}
             item.score_explanation["final_score"] = round(item.score, 4)

--- a/src/waggle/retrieval/hybrid.py
+++ b/src/waggle/retrieval/hybrid.py
@@ -629,16 +629,23 @@ class HybridRetriever:
                 + self.config.bm25_weight * item.layer_scores.get("bm25", 0.0)
                 + self.config.graph_weight * item.layer_scores.get("graph_expansion", 0.0)
             )
-            item.score = fused * ((1.0 - self.config.recency_weight) + (self.config.recency_weight * decay))
+            recency_multiplier = (1.0 - self.config.recency_weight) + (self.config.recency_weight * decay)
+            item.score = fused * recency_multiplier
             raw = {
-                "vector_transcript": self.config.vector_weight * item.layer_scores.get("vector_transcript", 0.0),
-                "vector_node": self.config.vector_weight * item.layer_scores.get("vector_node", 0.0),
-                "bm25": self.config.bm25_weight * item.layer_scores.get("bm25", 0.0),
-                "graph_expansion": self.config.graph_weight * item.layer_scores.get("graph_expansion", 0.0),
-                "recency": self.config.recency_weight * decay,
+                "vector_transcript": self.config.vector_weight
+                * item.layer_scores.get("vector_transcript", 0.0)
+                * recency_multiplier,
+                "vector_node": self.config.vector_weight
+                * item.layer_scores.get("vector_node", 0.0)
+                * recency_multiplier,
+                "bm25": self.config.bm25_weight * item.layer_scores.get("bm25", 0.0) * recency_multiplier,
+                "graph_expansion": self.config.graph_weight
+                * item.layer_scores.get("graph_expansion", 0.0)
+                * recency_multiplier,
             }
             total = sum(raw.values()) or 1.0
             item.score_explanation = {k: round(v / total, 4) for k, v in raw.items()}
+            item.score_explanation["recency_multiplier"] = round(recency_multiplier, 4)
             item.score_explanation["final_score"] = round(item.score, 4)
             if item.source == "node" and item.turn_pair_id and item.transcript_text:
                 item.source = "both"

--- a/src/waggle/serializer.py
+++ b/src/waggle/serializer.py
@@ -66,9 +66,8 @@ def serialize_subgraph(result: SubgraphResult) -> str:
         for index, hit in enumerate(result.hybrid_hits, start=1):
             reasoning = f" reason={hit.reasoning_from_reranker}" if hit.reasoning_from_reranker else ""
             explanation = (
-                " | ".join(f"{k}={v}" for k, v in hit.score_explanation.items())
-                if hit.score_explanation else "n/a"
-                )
+                " | ".join(f"{k}={v}" for k, v in hit.score_explanation.items()) if hit.score_explanation else "n/a"
+            )
             lines.append(
                 f"• #{index} [{hit.source}] {hit.content[:400]} [score={hit.score:.4f}] "
                 f"(turn_pair={hit.turn_pair_id or 'n/a'}, node_ids={hit.node_ids}){reasoning} "

--- a/src/waggle/serializer.py
+++ b/src/waggle/serializer.py
@@ -65,9 +65,14 @@ def serialize_subgraph(result: SubgraphResult) -> str:
         ]
         for index, hit in enumerate(result.hybrid_hits, start=1):
             reasoning = f" reason={hit.reasoning_from_reranker}" if hit.reasoning_from_reranker else ""
+            explanation = (
+                " | ".join(f"{k}={v}" for k, v in hit.score_explanation.items())
+                if hit.score_explanation else "n/a"
+                )
             lines.append(
                 f"• #{index} [{hit.source}] {hit.content[:400]} [score={hit.score:.4f}] "
-                f"(turn_pair={hit.turn_pair_id or 'n/a'}, node_ids={hit.node_ids}){reasoning}"
+                f"(turn_pair={hit.turn_pair_id or 'n/a'}, node_ids={hit.node_ids}){reasoning} "
+                f"[score_explanation: {explanation}]"
             )
         lines.extend(["", "=== End Results ==="])
         return "\n".join(lines)

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -314,3 +314,66 @@ def test_cross_session_codeword_verification_uses_verbatim_layer_when_extraction
 
     assert any("saffron-badger-v2" in hit.content for hit in hybrid.hybrid_hits)
     assert any("saffron-badger-v2" in hit.content for hit in verbatim.hybrid_hits)
+def test_score_explanation_keys_present():
+    from datetime import timezone
+    candidate = CandidateMemory(
+        candidate_id="test-1",
+        content="test content",
+        source="transcript",
+        observed_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    candidate.layer_scores["vector_transcript"] = 0.5
+    candidate.layer_scores["bm25"] = 0.3
+
+    assert hasattr(candidate, "score_explanation")
+    candidate.score_explanation = {
+        "vector_transcript": 0.6,
+        "bm25": 0.4,
+        "final_score": 0.42,
+    }
+    assert "final_score" in candidate.score_explanation
+    assert "vector_transcript" in candidate.score_explanation
+
+
+def test_score_explanation_normalized():
+    candidate = CandidateMemory(
+        candidate_id="test-2",
+        content="test",
+        source="transcript",
+    )
+    candidate.score_explanation = {
+        "vector_transcript": 0.5,
+        "vector_node": 0.2,
+        "bm25": 0.2,
+        "graph_expansion": 0.1,
+        "recency": 0.0,
+    }
+    contributions = [v for k, v in candidate.score_explanation.items() if k != "final_score"]
+    assert abs(sum(contributions) - 1.0) < 1e-4
+
+
+def test_layer_scores_backward_compatible():
+    candidate = CandidateMemory(
+        candidate_id="test-3",
+        content="test",
+        source="transcript",
+    )
+    candidate.layer_scores["vector_transcript"] = 0.8
+    candidate.layer_scores["bm25"] = 0.6
+    assert "vector_transcript" in candidate.layer_scores
+    assert "bm25" in candidate.layer_scores
+def test_score_explanation_includes_recency_contribution():
+    candidate = CandidateMemory(
+        candidate_id="test-4",
+        content="test",
+        source="transcript",
+    )
+    candidate.score_explanation = {
+        "vector_transcript": 0.4,
+        "bm25": 0.3,
+        "graph_expansion": 0.1,
+        "recency": 0.2,  # non-zero recency
+        "final_score": 0.55,
+    }
+    assert candidate.score_explanation["recency"] > 0
+    assert "final_score" in candidate.score_explanation

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -314,13 +314,14 @@ def test_cross_session_codeword_verification_uses_verbatim_layer_when_extraction
 
     assert any("saffron-badger-v2" in hit.content for hit in hybrid.hybrid_hits)
     assert any("saffron-badger-v2" in hit.content for hit in verbatim.hybrid_hits)
+
+
 def test_score_explanation_keys_present():
-    from datetime import timezone
     candidate = CandidateMemory(
         candidate_id="test-1",
         content="test content",
         source="transcript",
-        observed_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        observed_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
     candidate.layer_scores["vector_transcript"] = 0.5
     candidate.layer_scores["bm25"] = 0.3
@@ -362,6 +363,8 @@ def test_layer_scores_backward_compatible():
     candidate.layer_scores["bm25"] = 0.6
     assert "vector_transcript" in candidate.layer_scores
     assert "bm25" in candidate.layer_scores
+
+
 def test_score_explanation_includes_recency_contribution():
     candidate = CandidateMemory(
         candidate_id="test-4",


### PR DESCRIPTION
## Summary

- What changed?

-  Added `score_explanation: dict[str, float]` field to `CandidateMemory` with normalized per-layer contributions and `final_score`.
- Populated `score_explanation` inside `_fuse_candidates()` after final score is computed
-  Updated `serializer.py` to display score explanations in hybrid retrieval debug output.
-  Added tests covering multiple layers, recency contribution, and backward compatibility.

- Why was it needed?
- Hybrid retrieval combined vector, BM25, graph expansion, and recency into a final score but there was no way to explain why one result outranked another. 

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

## Checklist

- [x] I linked an issue or explained why one is not needed.
- [ ] I updated docs if user-facing behavior changed.
- [x] I kept the PR focused on one logical change.
- [x] I did not commit secrets, local exports, or generated noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Result scores now include a detailed, per-hit breakdown of normalized contributions from each retrieval layer (vector, keyword, graph expansion) plus a recency multiplier and final score.

* **User-facing Output**
  * Serialized retrieval output now appends a human-readable score explanation to each hybrid hit (or "n/a" when absent).

* **Tests**
  * Added tests covering the score explanation shape, normalization, backward compatibility, and recency contribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->