### PR TITLE
feat: add preview and audit trail support for clear-scope operations 

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -4139,49 +4139,52 @@ class MemoryGraph:
             )
             return node
 
-    def clear_session(self, *, session_id: str) -> ClearScopeResult:
+    def clear_session(self, *, session_id: str, dry_run: bool = False) -> ClearScopeResult:
         normalized_session = session_id.strip()
         if not normalized_session:
             raise ValueError("session_id is required.")
         with self._lock, self._connect() as connection:
-            result = self._clear_scope_rows(connection, scope="session", session_id=normalized_session)
-            self.emit_audit_event(
-                event_type="graph.scope_cleared",
-                resource_type="session",
-                resource_id=normalized_session,
-                action="delete",
-                metadata=result.model_dump(mode="json"),
-                connection=connection,
-            )
+            result = self._clear_scope_rows(connection, scope="session", session_id=normalized_session, dry_run=dry_run)
+            if not dry_run:
+                self.emit_audit_event(
+                    event_type="graph.scope_cleared",
+                    resource_type="session",
+                    resource_id=normalized_session,
+                    action="delete",
+                    metadata=result.model_dump(mode="json"),
+                    connection=connection,
+                )
             return result
 
-    def clear_project(self, *, project: str) -> ClearScopeResult:
+    def clear_project(self, *, project: str, dry_run: bool = False) -> ClearScopeResult:
         normalized_project = project.strip()
         if not normalized_project:
             raise ValueError("project is required.")
         with self._lock, self._connect() as connection:
-            result = self._clear_scope_rows(connection, scope="project", project=normalized_project)
-            self.emit_audit_event(
-                event_type="graph.scope_cleared",
-                resource_type="project",
-                resource_id=normalized_project,
-                action="delete",
-                metadata=result.model_dump(mode="json"),
-                connection=connection,
-            )
+            result = self._clear_scope_rows(connection, scope="project", project=normalized_project, dry_run=dry_run)
+            if not dry_run:
+                self.emit_audit_event(
+                    event_type="graph.scope_cleared",
+                    resource_type="project",
+                    resource_id=normalized_project,
+                    action="delete",
+                    metadata=result.model_dump(mode="json"),
+                    connection=connection,
+                )
             return result
 
-    def clear_all(self) -> ClearScopeResult:
+    def clear_all(self, *, dry_run: bool = False) -> ClearScopeResult:
         with self._lock, self._connect() as connection:
-            result = self._clear_scope_rows(connection, scope="all")
-            self.emit_audit_event(
-                event_type="graph.scope_cleared",
-                resource_type="tenant",
-                resource_id=self.tenant_id,
-                action="delete",
-                metadata=result.model_dump(mode="json"),
-                connection=connection,
-            )
+            result = self._clear_scope_rows(connection, scope="all", dry_run=dry_run)
+            if not dry_run:
+                self.emit_audit_event(
+                    event_type="graph.scope_cleared",
+                    resource_type="tenant",
+                    resource_id=self.tenant_id,
+                    action="delete",
+                    metadata=result.model_dump(mode="json"),
+                    connection=connection,
+                )
             return result
 
     def _clear_scope_rows(
@@ -4191,16 +4194,15 @@ class MemoryGraph:
         scope: str,
         project: str = "",
         session_id: str = "",
+        dry_run: bool = False,
     ) -> ClearScopeResult:
-        result = ClearScopeResult(scope=scope, project=project, session_id=session_id)
+        result = ClearScopeResult(scope=scope, project=project, session_id=session_id, dry_run=dry_run)
         if scope == "all":
-            node_ids = [
-                str(row["id"])
-                for row in connection.execute(
-                    "SELECT id FROM nodes WHERE tenant_id = ?",
-                    (self.tenant_id,),
-                ).fetchall()
-            ]
+            node_rows = connection.execute(
+                "SELECT id, node_type FROM nodes WHERE tenant_id = ?",
+                (self.tenant_id,),
+            ).fetchall()
+            node_ids = [str(row["id"]) for row in node_rows]
             window_ids = [
                 str(row["id"])
                 for row in connection.execute(
@@ -4216,13 +4218,23 @@ class MemoryGraph:
                 ).fetchall()
             ]
             result.deleted_graph_ui_rows = connection.execute(
-                "DELETE FROM graph_ui_state WHERE tenant_id = ?",
+                "SELECT COUNT(*) FROM graph_ui_state WHERE tenant_id = ?",
                 (self.tenant_id,),
-            ).rowcount
+            ).fetchone()[0]
             result.deleted_transcripts = connection.execute(
-                "DELETE FROM transcript_records WHERE tenant_id = ?",
+                "SELECT COUNT(*) FROM transcript_records WHERE tenant_id = ?",
                 (self.tenant_id,),
-            ).rowcount
+            ).fetchone()[0]
+
+            if not dry_run:
+                connection.execute(
+                    "DELETE FROM graph_ui_state WHERE tenant_id = ?",
+                    (self.tenant_id,),
+                )
+                connection.execute(
+                    "DELETE FROM transcript_records WHERE tenant_id = ?",
+                    (self.tenant_id,),
+                )
         elif scope == "project":
             repo_ids = [
                 str(row["id"])
@@ -4243,21 +4255,29 @@ class MemoryGraph:
                     (self.tenant_id, project),
                 ).fetchall()
             ]
-            node_ids = [
-                str(row["id"])
-                for row in connection.execute(
-                    "SELECT id FROM nodes WHERE tenant_id = ? AND project = ?",
-                    (self.tenant_id, project),
-                ).fetchall()
-            ]
+            node_rows = connection.execute(
+                "SELECT id, node_type FROM nodes WHERE tenant_id = ? AND project = ?",
+                (self.tenant_id, project),
+            ).fetchall()
+            node_ids = [str(row["id"]) for row in node_rows]
             result.deleted_graph_ui_rows = connection.execute(
-                "DELETE FROM graph_ui_state WHERE tenant_id = ? AND project = ?",
+                "SELECT COUNT(*) FROM graph_ui_state WHERE tenant_id = ? AND project = ?",
                 (self.tenant_id, project),
-            ).rowcount
+            ).fetchone()[0]
             result.deleted_transcripts = connection.execute(
-                "DELETE FROM transcript_records WHERE tenant_id = ? AND project = ?",
+                "SELECT COUNT(*) FROM transcript_records WHERE tenant_id = ? AND project = ?",
                 (self.tenant_id, project),
-            ).rowcount
+            ).fetchone()[0]
+
+            if not dry_run:
+                connection.execute(
+                    "DELETE FROM graph_ui_state WHERE tenant_id = ? AND project = ?",
+                    (self.tenant_id, project),
+                )
+                connection.execute(
+                    "DELETE FROM transcript_records WHERE tenant_id = ? AND project = ?",
+                    (self.tenant_id, project),
+                )
         elif scope == "session":
             repo_ids = []
             window_ids = [
@@ -4267,58 +4287,102 @@ class MemoryGraph:
                     (self.tenant_id, session_id),
                 ).fetchall()
             ]
-            node_ids = [
-                str(row["id"])
-                for row in connection.execute(
-                    "SELECT id FROM nodes WHERE tenant_id = ? AND session_id = ?",
-                    (self.tenant_id, session_id),
-                ).fetchall()
-            ]
+            node_rows = connection.execute(
+                "SELECT id, node_type FROM nodes WHERE tenant_id = ? AND session_id = ?",
+                (self.tenant_id, session_id),
+            ).fetchall()
+            node_ids = [str(row["id"]) for row in node_rows]
             result.deleted_graph_ui_rows = connection.execute(
-                "DELETE FROM graph_ui_state WHERE tenant_id = ? AND session_id = ?",
+                "SELECT COUNT(*) FROM graph_ui_state WHERE tenant_id = ? AND session_id = ?",
                 (self.tenant_id, session_id),
-            ).rowcount
+            ).fetchone()[0]
             result.deleted_transcripts = connection.execute(
-                "DELETE FROM transcript_records WHERE tenant_id = ? AND session_id = ?",
+                "SELECT COUNT(*) FROM transcript_records WHERE tenant_id = ? AND session_id = ?",
                 (self.tenant_id, session_id),
-            ).rowcount
+            ).fetchone()[0]
+
+            if not dry_run:
+                connection.execute(
+                    "DELETE FROM graph_ui_state WHERE tenant_id = ? AND session_id = ?",
+                    (self.tenant_id, session_id),
+                )
+                connection.execute(
+                    "DELETE FROM transcript_records WHERE tenant_id = ? AND session_id = ?",
+                    (self.tenant_id, session_id),
+                )
         else:
             raise ValueError(f"Unsupported clear scope: {scope}")
+
+        # Compute counts by node type
+        counts_by_node_type: dict[str, int] = {}
+        for row in node_rows:
+            nt = str(row["node_type"])
+            counts_by_node_type[nt] = counts_by_node_type.get(nt, 0) + 1
+        result.counts_by_node_type = counts_by_node_type
 
         if node_ids:
             placeholders = ", ".join("?" for _ in node_ids)
             result.deleted_edges = connection.execute(
                 f"""
-                DELETE FROM edges
+                SELECT COUNT(*) FROM edges
                 WHERE tenant_id = ? AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))
                 """,
                 (self.tenant_id, *node_ids, *node_ids),
-            ).rowcount
-            result.deleted_nodes = connection.execute(
-                f"DELETE FROM nodes WHERE tenant_id = ? AND id IN ({placeholders})",
-                (self.tenant_id, *node_ids),
-            ).rowcount
+            ).fetchone()[0]
+            result.deleted_nodes = len(node_ids)
+
+            if not dry_run:
+                connection.execute(
+                    f"""
+                    DELETE FROM edges
+                    WHERE tenant_id = ? AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))
+                    """,
+                    (self.tenant_id, *node_ids, *node_ids),
+                )
+                connection.execute(
+                    f"DELETE FROM nodes WHERE tenant_id = ? AND id IN ({placeholders})",
+                    (self.tenant_id, *node_ids),
+                )
 
         if window_ids:
             placeholders = ", ".join("?" for _ in window_ids)
             result.deleted_context_window_edges = connection.execute(
                 f"""
-                DELETE FROM context_window_edges
+                SELECT COUNT(*) FROM context_window_edges
                 WHERE tenant_id = ? AND (source_window_id IN ({placeholders}) OR target_window_id IN ({placeholders}))
                 """,
                 (self.tenant_id, *window_ids, *window_ids),
-            ).rowcount
+            ).fetchone()[0]
             result.deleted_context_windows = connection.execute(
-                f"DELETE FROM context_windows WHERE tenant_id = ? AND id IN ({placeholders})",
+                f"SELECT COUNT(*) FROM context_windows WHERE tenant_id = ? AND id IN ({placeholders})",
                 (self.tenant_id, *window_ids),
-            ).rowcount
+            ).fetchone()[0]
+
+            if not dry_run:
+                connection.execute(
+                    f"""
+                    DELETE FROM context_window_edges
+                    WHERE tenant_id = ? AND (source_window_id IN ({placeholders}) OR target_window_id IN ({placeholders}))
+                    """,
+                    (self.tenant_id, *window_ids, *window_ids),
+                )
+                connection.execute(
+                    f"DELETE FROM context_windows WHERE tenant_id = ? AND id IN ({placeholders})",
+                    (self.tenant_id, *window_ids),
+                )
 
         if repo_ids:
             placeholders = ", ".join("?" for _ in repo_ids)
             result.deleted_repos = connection.execute(
-                f"DELETE FROM repos WHERE tenant_id = ? AND id IN ({placeholders})",
+                f"SELECT COUNT(*) FROM repos WHERE tenant_id = ? AND id IN ({placeholders})",
                 (self.tenant_id, *repo_ids),
-            ).rowcount
+            ).fetchone()[0]
+
+            if not dry_run:
+                connection.execute(
+                    f"DELETE FROM repos WHERE tenant_id = ? AND id IN ({placeholders})",
+                    (self.tenant_id, *repo_ids),
+                )
         elif scope == "all":
             result.deleted_repos = len(repo_ids)
 

--- a/src/waggle/models.py
+++ b/src/waggle/models.py
@@ -884,6 +884,9 @@ class ClearScopeResult(BaseModel):
     deleted_context_window_edges: int = 0
     deleted_repos: int = 0
     deleted_graph_ui_rows: int = 0
+    dry_run: bool = False
+    counts_by_node_type: dict[str, int] = Field(default_factory=dict)
+
 
 
 # ---------------------------------------------------------------------------

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -4475,6 +4475,9 @@ def _build_parser() -> argparse.ArgumentParser:
     doctor.add_argument(
         "--fix", action="store_true", help="Re-embed stale transcript/node rows to the current model ID."
     )
+    doctor.add_argument(
+        "--json", dest="as_json", action="store_true", help="Output doctor results in structured JSON format."
+    )
 
     demo_cmd = subparsers.add_parser(
         "demo",
@@ -4949,7 +4952,7 @@ def _run_admin_command(config: AppConfig, args: argparse.Namespace) -> int:
         print(_FEATURES_GUIDE)
         return 0
     if args.command == "doctor":
-        return _run_doctor(config, fix=bool(getattr(args, "fix", False)))
+        return _run_doctor(config, fix=bool(getattr(args, "fix", False)), as_json=bool(getattr(args, "as_json", False)))
     raise ValidationFailure(f"Unknown command: {args.command}")
 
 
@@ -4989,22 +4992,28 @@ Known API gotchas (from the Waggle field error log):
 """
 
 
-def _run_doctor(config: AppConfig, *, fix: bool = False) -> int:
+def _run_doctor(config: AppConfig, *, fix: bool = False, as_json: bool = False) -> int:
     """waggle-mcp doctor — surface configuration and environment issues."""
     issues: list[str] = []
     ok_items: list[str] = []
 
-    print()
-    print(_c(_BOLD, "waggle-mcp doctor"))
-    print(_c(_CYAN, "─" * 50))
+    if not as_json:
+        print()
+        print(_c(_BOLD, "waggle-mcp doctor"))
+        print(_c(_CYAN, "─" * 50))
 
     # ── 1. Config file locations ─────────────────────────────────────────────
-    print(_c(_BOLD, "\n[1] MCP client config files"))
+    if not as_json:
+        print(_c(_BOLD, "\n[1] MCP client config files"))
     waggle_found_in: list[str] = []
+    config_files_data = []
     for label, template in _KNOWN_CONFIG_PATHS:
         raw = template.replace("%APPDATA%", os.environ.get("APPDATA", "")).replace("%USERPROFILE%", str(Path.home()))
         path = Path(raw).expanduser()
-        if path.exists():
+        exists = path.exists()
+        has_waggle = False
+        parsed = False
+        if exists:
             try:
                 raw_text = path.read_text(encoding="utf-8", errors="replace")
                 if path.suffix == ".toml":
@@ -5013,13 +5022,17 @@ def _run_doctor(config: AppConfig, *, fix: bool = False) -> int:
                     data = json.loads(raw_text)
                     servers = data.get("mcpServers", data.get("tools", {}) if isinstance(data, dict) else {})
                     has_waggle = isinstance(servers, dict) and "waggle" in servers
+                parsed = True
                 if has_waggle:
                     waggle_found_in.append(label)
-                    _ok(f"{label}\n     {path}  [waggle entry found]")
+                    if not as_json:
+                        _ok(f"{label}\n     {path}  [waggle entry found]")
                 else:
-                    print(f"  {_c(_CYAN, chr(0x2022))} {label}\n     {path}  [exists, no waggle entry]")
+                    if not as_json:
+                        print(f"  {_c(_CYAN, chr(0x2022))} {label}\n     {path}  [exists, no waggle entry]")
             except Exception:
-                print(f"  {_c(_CYAN, chr(0x2022))} {label}\n     {path}  [exists, could not parse]")
+                if not as_json:
+                    print(f"  {_c(_CYAN, chr(0x2022))} {label}\n     {path}  [exists, could not parse]")
         # only show missing paths that are plausible for this platform
         elif (
             (
@@ -5029,7 +5042,23 @@ def _run_doctor(config: AppConfig, *, fix: bool = False) -> int:
             or (sys.platform == "win32" and "Windows" in label)
             or (sys.platform.startswith("linux") and ("Linux" in label or "Cursor" in label))
         ):
-            print(f"  {_c(_CYAN, chr(0x2022))} {label}\n     {path}  [not found]")
+            if not as_json:
+                print(f"  {_c(_CYAN, chr(0x2022))} {label}\n     {path}  [not found]")
+
+        is_plausible = (
+            exists or
+            (sys.platform == "darwin" and ("macOS" in label or "Cursor" in label or "Antigravity" in label or "Codex" in label)) or
+            (sys.platform == "win32" and "Windows" in label) or
+            (sys.platform.startswith("linux") and ("Linux" in label or "Cursor" in label))
+        )
+        if exists or is_plausible:
+            config_files_data.append({
+                "label": label,
+                "path": str(path),
+                "exists": exists,
+                "has_waggle": has_waggle,
+                "parsed": parsed
+            })
 
     if not waggle_found_in:
         issues.append(
@@ -5040,21 +5069,28 @@ def _run_doctor(config: AppConfig, *, fix: bool = False) -> int:
         ok_items.append(f"Waggle found in: {', '.join(waggle_found_in)}")
 
     # ── 2. DB path ───────────────────────────────────────────────────────────
-    print(_c(_BOLD, "\n[2] Database path"))
+    if not as_json:
+        print(_c(_BOLD, "\n[2] Database path"))
     db_path = Path(config.db_path)
     db_dir = db_path.parent
-    if db_path.exists():
-        _ok(f"DB file exists: {db_path}")
+    db_exists = db_path.exists()
+    db_dir_exists = db_dir.exists()
+    if db_exists:
+        if not as_json:
+            _ok(f"DB file exists: {db_path}")
         ok_items.append("DB file found")
-    elif db_dir.exists():
-        _ok(f"DB directory exists (file will be created on first run): {db_path}")
+    elif db_dir_exists:
+        if not as_json:
+            _ok(f"DB directory exists (file will be created on first run): {db_path}")
         ok_items.append("DB directory writable")
     else:
         issues.append(f"DB directory does not exist: {db_dir}. Create it with: mkdir -p <dir>")
-        _fail(f"DB directory missing: {db_dir}")
+        if not as_json:
+            _fail(f"DB directory missing: {db_dir}")
 
     # ── 3. Embedding model ───────────────────────────────────────────────────
-    print(_c(_BOLD, "\n[3] Embedding model"))
+    if not as_json:
+        print(_c(_BOLD, "\n[3] Embedding model"))
     model_name = config.model_name
     hf_home = (
         os.environ.get("HF_HOME")
@@ -5063,8 +5099,11 @@ def _run_doctor(config: AppConfig, *, fix: bool = False) -> int:
     )
     st_cache = Path(os.environ.get("SENTENCE_TRANSFORMERS_HOME", Path(hf_home) / "hub"))
 
-    if model_name.strip().lower() in {"fake", "fake-model", "deterministic", "offline-demo"}:
-        _ok(f"Model: {model_name!r}  (deterministic — no download, always offline-safe)")
+    is_deterministic = model_name.strip().lower() in {"fake", "fake-model", "deterministic", "offline-demo"}
+    is_cached = False
+    if is_deterministic:
+        if not as_json:
+            _ok(f"Model: {model_name!r}  (deterministic — no download, always offline-safe)")
         ok_items.append("Deterministic model — no download needed")
     else:
         # Heuristic: look for a cached sentence-transformers directory
@@ -5074,88 +5113,160 @@ def _run_doctor(config: AppConfig, *, fix: bool = False) -> int:
             st_cache / safe_name,
             Path(hf_home) / "hub" / f"models--{safe_name.replace('_', '--', 1)}",
         ]
-        cached = any(p.exists() for p in possible_dirs)
-        if cached:
-            _ok(f"Model: {model_name!r}  (cached locally — fast startup)")
+        is_cached = any(p.exists() for p in possible_dirs)
+        if is_cached:
+            if not as_json:
+                _ok(f"Model: {model_name!r}  (cached locally — fast startup)")
             ok_items.append("Embedding model cached")
         else:
-            print(
-                f"  {_c(_CYAN, chr(0x2139))} Model: {model_name!r}  — NOT found in local cache.\n"
-                f"    First store_node/query_graph call will download ~420 MB from HuggingFace.\n"
-                f"    To avoid: set WAGGLE_MODEL=deterministic, or pre-download with:\n"
-                f"      python -c \"from sentence_transformers import SentenceTransformer; SentenceTransformer('{model_name}')\""
-            )
+            if not as_json:
+                print(
+                    f"  {_c(_CYAN, chr(0x2139))} Model: {model_name!r}  — NOT found in local cache.\n"
+                    f"    First store_node/query_graph call will download ~420 MB from HuggingFace.\n"
+                    f"    To avoid: set WAGGLE_MODEL=deterministic, or pre-download with:\n"
+                    f"      python -c \"from sentence_transformers import SentenceTransformer; SentenceTransformer('{model_name}')\""
+                )
             issues.append(
                 f"Embedding model '{model_name}' not found in cache. "
                 "First semantic call will block for a network download. "
                 "Set WAGGLE_MODEL=deterministic for offline-safe mode."
             )
 
+    embedding_model_data = {
+        "model_name": model_name,
+        "cached": is_cached,
+        "deterministic": is_deterministic
+    }
+
     # ── 4. WAGGLE_STARTUP_MODE ───────────────────────────────────────────────
-    print(_c(_BOLD, "\n[4] Embedding store"))
+    if not as_json:
+        print(_c(_BOLD, "\n[4] Embedding store"))
     graph = _default_graph(config)
+    embedding_store_data = None
     if isinstance(graph, MemoryGraph):
         store_health = graph.get_embedding_store_health()
         if fix and (store_health["transcript_stale_rows"] or store_health["node_stale_rows"]):
             repair = graph.reembed_stale_embeddings(batch_size=100)
-            _ok(
-                "Re-embedded stale rows: "
-                f"{repair['transcript_rows_updated']} transcript rows, {repair['node_rows_updated']} node rows."
-            )
+            if not as_json:
+                _ok(
+                    "Re-embedded stale rows: "
+                    f"{repair['transcript_rows_updated']} transcript rows, {repair['node_rows_updated']} node rows."
+                )
             store_health = graph.get_embedding_store_health()
         transcript_models = store_health["transcript_model_counts"]
         node_models = store_health["node_model_counts"]
-        print(f"  Current model id: {store_health['current_model_id']}")
-        print(f"  Transcript model ids: {transcript_models or '{}'}")
-        print(f"  Node model ids: {node_models or '{}'}")
-        print(f"  Stale transcript rows: {store_health['transcript_stale_rows']}")
-        print(f"  Stale node rows: {store_health['node_stale_rows']}")
+        if not as_json:
+            print(f"  Current model id: {store_health['current_model_id']}")
+            print(f"  Transcript model ids: {transcript_models or '{}'}")
+            print(f"  Node model ids: {node_models or '{}'}")
+            print(f"  Stale transcript rows: {store_health['transcript_stale_rows']}")
+            print(f"  Stale node rows: {store_health['node_stale_rows']}")
         if store_health["mixed_models"]:
             issues.append("Mixed embedding_model_id values detected in the store.")
-            _fail("Mixed embedding model IDs detected across transcript_records/nodes.")
+            if not as_json:
+                _fail("Mixed embedding model IDs detected across transcript_records/nodes.")
         else:
-            _ok("Store model IDs are consistent.")
+            if not as_json:
+                _ok("Store model IDs are consistent.")
+
+        embedding_store_data = {
+            "current_model_id": store_health["current_model_id"],
+            "transcript_model_counts": transcript_models,
+            "node_model_counts": node_models,
+            "transcript_stale_rows": store_health["transcript_stale_rows"],
+            "node_stale_rows": store_health["node_stale_rows"],
+            "mixed_models": store_health["mixed_models"]
+        }
 
     # ── 5. WAGGLE_STARTUP_MODE ───────────────────────────────────────────────
-    print(_c(_BOLD, "\n[5] Startup mode"))
-    print(f"  WAGGLE_STARTUP_MODE = {config.startup_mode!r}")
+    if not as_json:
+        print(_c(_BOLD, "\n[5] Startup mode"))
+        print(f"  WAGGLE_STARTUP_MODE = {config.startup_mode!r}")
     if config.is_fast_mode:
-        _ok("fast mode: zero ML overhead. Schema/tool listing only. Semantic tools return 'unavailable'.")
+        if not as_json:
+            _ok("fast mode: zero ML overhead. Schema/tool listing only. Semantic tools return 'unavailable'.")
     elif config.is_strict_mode:
-        _ok("strict mode: server blocks on startup until embedding model is ready.")
+        if not as_json:
+            _ok("strict mode: server blocks on startup until embedding model is ready.")
     else:
-        _ok("normal mode: embedding loads in background. First semantic call may wait up to ~30 s.")
+        if not as_json:
+            _ok("normal mode: embedding loads in background. First semantic call may wait up to ~30 s.")
 
     # ── 6. Windows stdout encoding ───────────────────────────────────────────
+    stdout_encoding_data = None
     if sys.platform == "win32":
-        print(_c(_BOLD, "\n[6] Windows stdout encoding"))
+        if not as_json:
+            print(_c(_BOLD, "\n[6] Windows stdout encoding"))
         enc = getattr(sys.stdout, "encoding", "unknown")
-        if enc.lower().replace("-", "") in ("utf8", "utf8"):
-            _ok(f"stdout encoding: {enc}")
+        is_utf8 = enc.lower().replace("-", "") in ("utf8", "utf8")
+        if is_utf8:
+            if not as_json:
+                _ok(f"stdout encoding: {enc}")
         else:
-            _fail(
-                f"stdout encoding is {enc!r} (not UTF-8). "
-                "Unicode characters (emoji, accented text) will cause UnicodeEncodeError.\n"
-                "    Fix: run with 'python -X utf8' or add at script top:\n"
-                "      import sys; sys.stdout.reconfigure(encoding='utf-8')"
-            )
+            if not as_json:
+                _fail(
+                    f"stdout encoding is {enc!r} (not UTF-8). "
+                    "Unicode characters (emoji, accented text) will cause UnicodeEncodeError.\n"
+                    "    Fix: run with 'python -X utf8' or add at script top:\n"
+                    "      import sys; sys.stdout.reconfigure(encoding='utf-8')"
+                )
             issues.append(f"Windows stdout encoding is {enc!r} — set PYTHONUTF8=1 or use python -X utf8.")
+        stdout_encoding_data = {
+            "encoding": enc,
+            "is_utf8": is_utf8
+        }
 
     # ── 7. Known gotchas ─────────────────────────────────────────────────────
-    print(_c(_BOLD, "\n[7] Known API gotchas"))
-    print(_DOCTOR_KNOWN_GOTCHAS)
+    if not as_json:
+        print(_c(_BOLD, "\n[7] Known API gotchas"))
+        print(_DOCTOR_KNOWN_GOTCHAS)
 
     # ── Summary ──────────────────────────────────────────────────────────────
-    print(_c(_BOLD, "─" * 50))
+    if not as_json:
+        print(_c(_BOLD, "─" * 50))
     if issues:
-        print(_c(_RED, f"Found {len(issues)} issue(s):"))
-        for i, issue in enumerate(issues, 1):
-            print(f"  {i}. {issue}")
-        print()
+        if not as_json:
+            print(_c(_RED, f"Found {len(issues)} issue(s):"))
+            for i, issue in enumerate(issues, 1):
+                print(f"  {i}. {issue}")
+            print()
+        else:
+            result = {
+                "ok": False,
+                "config_files": config_files_data,
+                "database": {
+                    "path": str(db_path),
+                    "exists": db_exists,
+                    "parent_exists": db_dir_exists
+                },
+                "embedding_model": embedding_model_data,
+                "embedding_store": embedding_store_data,
+                "startup_mode": config.startup_mode,
+                "stdout_encoding": stdout_encoding_data,
+                "issues": issues
+            }
+            print(json.dumps(result, indent=2))
         return 1
     else:
-        print(_c(_GREEN, f"All checks passed ({len(ok_items)} OK). Waggle looks healthy."))
-        print()
+        if not as_json:
+            print(_c(_GREEN, f"All checks passed ({len(ok_items)} OK). Waggle looks healthy."))
+            print()
+        else:
+            result = {
+                "ok": True,
+                "config_files": config_files_data,
+                "database": {
+                    "path": str(db_path),
+                    "exists": db_exists,
+                    "parent_exists": db_dir_exists
+                },
+                "embedding_model": embedding_model_data,
+                "embedding_store": embedding_store_data,
+                "startup_mode": config.startup_mode,
+                "stdout_encoding": stdout_encoding_data,
+                "issues": []
+            }
+            print(json.dumps(result, indent=2))
         return 0
 
 
@@ -6088,7 +6199,7 @@ def main() -> None:
     if command == "doctor":
         # Doctor only needs the config — not a live backend connection.
         config = AppConfig.from_env()
-        sys.exit(_run_doctor(config, fix=bool(getattr(args, "fix", False))))
+        sys.exit(_run_doctor(config, fix=bool(getattr(args, "fix", False)), as_json=bool(getattr(args, "as_json", False))))
 
     config = AppConfig.from_env()
     if command == "serve" and getattr(args, "transport", None):

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -1030,6 +1030,11 @@ class WaggleServer:
                             "default": False,
                             "description": "Must be true to perform the destructive clear operation.",
                         },
+                        "dry_run": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "Preview the clear operation without deleting data.",
+                        },
                     },
                     required=["session_id"],
                 ),
@@ -1048,6 +1053,11 @@ class WaggleServer:
                             "default": False,
                             "description": "Must be true to perform the destructive clear operation.",
                         },
+                        "dry_run": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "Preview the clear operation without deleting data.",
+                        },
                     },
                     required=["project"],
                 ),
@@ -1064,6 +1074,11 @@ class WaggleServer:
                             "type": "boolean",
                             "default": False,
                             "description": "Must be true to perform the destructive clear operation.",
+                        },
+                        "dry_run": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": "Preview the clear operation without deleting data.",
                         },
                     }
                 ),
@@ -1977,26 +1992,38 @@ class WaggleServer:
                         {"id": node.id, "label": node.label, "tenant_id": node.tenant_id},
                     )
                 elif name == "clear_session":
-                    self._require_clear_confirmation(arguments, "clear_session")
-                    cleared = graph.clear_session(session_id=arguments["session_id"])
+                    dry_run = bool(arguments.get("dry_run", False))
+                    if not dry_run:
+                        self._require_clear_confirmation(arguments, "clear_session")
+                    cleared = graph.clear_session(session_id=arguments["session_id"], dry_run=dry_run)
+                    prefix = "[Preview] Would clear" if dry_run else "Cleared"
+                    verb = "Would delete" if dry_run else "Deleted"
                     result = self._tool_result(
-                        f"Cleared session '{cleared.session_id}'. Deleted {cleared.deleted_nodes} node(s), "
+                        f"{prefix} session '{cleared.session_id}'. {verb} {cleared.deleted_nodes} node(s), "
                         f"{cleared.deleted_edges} edge(s), and {cleared.deleted_transcripts} transcript record(s).",
                         self._clear_scope_payload(cleared),
                     )
                 elif name == "clear_project":
-                    self._require_clear_confirmation(arguments, "clear_project")
-                    cleared = graph.clear_project(project=arguments["project"])
+                    dry_run = bool(arguments.get("dry_run", False))
+                    if not dry_run:
+                        self._require_clear_confirmation(arguments, "clear_project")
+                    cleared = graph.clear_project(project=arguments["project"], dry_run=dry_run)
+                    prefix = "[Preview] Would clear" if dry_run else "Cleared"
+                    verb = "Would delete" if dry_run else "Deleted"
                     result = self._tool_result(
-                        f"Cleared project '{cleared.project}'. Deleted {cleared.deleted_nodes} node(s), "
+                        f"{prefix} project '{cleared.project}'. {verb} {cleared.deleted_nodes} node(s), "
                         f"{cleared.deleted_edges} edge(s), and {cleared.deleted_transcripts} transcript record(s).",
                         self._clear_scope_payload(cleared),
                     )
                 elif name == "clear_all":
-                    self._require_clear_confirmation(arguments, "clear_all")
-                    cleared = graph.clear_all()
+                    dry_run = bool(arguments.get("dry_run", False))
+                    if not dry_run:
+                        self._require_clear_confirmation(arguments, "clear_all")
+                    cleared = graph.clear_all(dry_run=dry_run)
+                    prefix = "[Preview] Would clear" if dry_run else "Cleared"
+                    verb = "Would delete" if dry_run else "Deleted"
                     result = self._tool_result(
-                        f"Cleared all graph memory data for tenant '{graph.tenant_id}'. Deleted {cleared.deleted_nodes} node(s), "
+                        f"{prefix} all graph memory data for tenant '{graph.tenant_id}'. {verb} {cleared.deleted_nodes} node(s), "
                         f"{cleared.deleted_edges} edge(s), and {cleared.deleted_transcripts} transcript record(s).",
                         self._clear_scope_payload(cleared),
                     )
@@ -4154,6 +4181,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     clear_session.add_argument("--session-id", required=True)
     clear_session.add_argument("--yes", action="store_true", help="Confirm the destructive clear operation.")
+    clear_session.add_argument("--dry-run", action="store_true", help="Preview the clear operation without deleting data.")
 
     clear_project = subparsers.add_parser(
         "clear-project",
@@ -4161,12 +4189,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     clear_project.add_argument("--project", required=True)
     clear_project.add_argument("--yes", action="store_true", help="Confirm the destructive clear operation.")
+    clear_project.add_argument("--dry-run", action="store_true", help="Preview the clear operation without deleting data.")
 
     clear_all = subparsers.add_parser(
         "clear-all",
         help="Delete all graph memory data for the current tenant.",
     )
     clear_all.add_argument("--yes", action="store_true", help="Confirm the destructive clear operation.")
+    clear_all.add_argument("--dry-run", action="store_true", help="Preview the clear operation without deleting data.")
 
     import_abhi = subparsers.add_parser(
         "import",
@@ -4731,21 +4761,24 @@ def _run_admin_command(config: AppConfig, args: argparse.Namespace) -> int:
         print(json.dumps(payload, indent=2))
         return 0
     if args.command == "clear-session":
-        if not bool(getattr(args, "yes", False)):
+        dry_run = bool(getattr(args, "dry_run", False))
+        if not dry_run and not bool(getattr(args, "yes", False)):
             raise ValidationFailure("clear-session is destructive and requires --yes.")
-        cleared = backend.clear_session(session_id=args.session_id)
+        cleared = backend.clear_session(session_id=args.session_id, dry_run=dry_run)
         print(json.dumps(cleared.model_dump(mode="json"), indent=2))
         return 0
     if args.command == "clear-project":
-        if not bool(getattr(args, "yes", False)):
+        dry_run = bool(getattr(args, "dry_run", False))
+        if not dry_run and not bool(getattr(args, "yes", False)):
             raise ValidationFailure("clear-project is destructive and requires --yes.")
-        cleared = backend.clear_project(project=args.project)
+        cleared = backend.clear_project(project=args.project, dry_run=dry_run)
         print(json.dumps(cleared.model_dump(mode="json"), indent=2))
         return 0
     if args.command == "clear-all":
-        if not bool(getattr(args, "yes", False)):
+        dry_run = bool(getattr(args, "dry_run", False))
+        if not dry_run and not bool(getattr(args, "yes", False)):
             raise ValidationFailure("clear-all is destructive and requires --yes.")
-        cleared = backend.clear_all()
+        cleared = backend.clear_all(dry_run=dry_run)
         print(json.dumps(cleared.model_dump(mode="json"), indent=2))
         return 0
     if args.command == "import":
@@ -5590,7 +5623,7 @@ def _write_codex(db_path: str, python_exe: str) -> Path:
     pattern = re.compile(r"(?ms)^\[mcp_servers\.waggle\]\n.*?(?=^\[(?!mcp_servers\.waggle(?:\.env)?\])[^\n]+\]\n|\Z)")
     replacement = toml_block.rstrip() + "\n"
     if pattern.search(existing):
-        updated = pattern.sub(replacement, existing, count=1)
+        updated = pattern.sub(replacement.replace('\\', '\\\\'), existing, count=1)
     else:
         separator = "\n\n" if existing.strip() else ""
         updated = existing.rstrip() + separator + replacement

--- a/tests/test_distribution_cli.py
+++ b/tests/test_distribution_cli.py
@@ -35,6 +35,7 @@ def test_parser_exposes_graph_studio_aliases(command_name: str) -> None:
 
 def test_write_codex_config_uses_packaged_stdio_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_codex(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()
@@ -60,6 +61,7 @@ def test_json_client_writers_use_packaged_stdio_command(
     relative_path: str,
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setattr("waggle.server.sys.platform", "linux")
 
     config_path = writer(str(tmp_path / "memory.db"), "/tmp/fake-python")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2254,3 +2254,61 @@ def test_abhi_json_file_raises_validation_failure(tmp_path: Path) -> None:
     json_file.write_text('{"graph": {}}', encoding="utf-8")
     with pytest.raises(VF, match=r"not a valid \.abhi file"):
         load_abhi_document(json_file)
+
+
+def test_clear_scope_dry_run_and_audit_trail(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path)
+    
+    # 1. Add some initial scope-scoped data
+    graph.add_node(
+        label="Test Node",
+        content="Use Redis for caching.",
+        node_type=NodeType.DECISION,
+        project="test_proj",
+        session_id="test_sess",
+    )
+    graph.observe_conversation(
+        user_message="Use Redis for caching.",
+        assistant_response="Noted.",
+        project="test_proj",
+        session_id="test_sess",
+    )
+    
+    # Verify we have nodes
+    stats_before = graph.get_stats()
+    assert stats_before.total_nodes > 0
+    
+    # 2. Perform a dry-run clear on the session
+    result_dry = graph.clear_session(session_id="test_sess", dry_run=True)
+    assert result_dry.dry_run is True
+    assert result_dry.deleted_nodes > 0
+    assert result_dry.deleted_transcripts > 0
+    assert any(k in result_dry.counts_by_node_type for k in ("decision", "note", "entity", "fact"))
+    
+    # Verify data is STILL in the graph
+    stats_after_dry = graph.get_stats()
+    assert stats_after_dry.total_nodes == stats_before.total_nodes
+    
+    # Verify NO audit event was emitted for this dry-run
+    events_dry = graph.list_audit_events(event_type="graph.scope_cleared")
+    assert len(events_dry) == 0
+    
+    # 3. Perform a real clear on the session
+    result_real = graph.clear_session(session_id="test_sess", dry_run=False)
+    assert result_real.dry_run is False
+    assert result_real.deleted_nodes == result_dry.deleted_nodes
+    assert result_real.deleted_transcripts == result_dry.deleted_transcripts
+    
+    # Verify data is DELETED
+    stats_after_real = graph.get_stats()
+    assert stats_after_real.total_nodes < stats_before.total_nodes
+    
+    # Verify audit event WAS emitted for this real clear
+    events_real = graph.list_audit_events(event_type="graph.scope_cleared")
+    assert len(events_real) == 1
+    assert events_real[0].resource_type == "session"
+    assert events_real[0].resource_id == "test_sess"
+    # Verify structured counts are inside metadata
+    meta = events_real[0].metadata
+    assert meta["dry_run"] is False
+    assert meta["deleted_nodes"] == result_real.deleted_nodes

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -221,7 +221,13 @@ def test_parser_accepts_graph_editor_commands() -> None:
     assert share_args.file_ref == "file123"
 
 
-def test_doctor_flags_mixed_embedding_model_ids(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_doctor_flags_mixed_embedding_model_ids(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_config = tmp_path / "mock_config.json"
+    mock_config.write_text(json.dumps({"mcpServers": {"waggle": {}}}))
+    monkeypatch.setattr("waggle.server._KNOWN_CONFIG_PATHS", [("Mock Client", str(mock_config))])
+
     db_path = tmp_path / "server-memory.db"
     graph = MemoryGraph(db_path, FakeEmbeddingModel())
     graph.observe_conversation(
@@ -269,7 +275,13 @@ def test_doctor_flags_mixed_embedding_model_ids(tmp_path: Path, capsys: pytest.C
     assert "Mixed embedding model IDs detected" in stdout
 
 
-def test_doctor_fix_reembeds_mixed_embedding_model_ids(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_doctor_fix_reembeds_mixed_embedding_model_ids(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_config = tmp_path / "mock_config.json"
+    mock_config.write_text(json.dumps({"mcpServers": {"waggle": {}}}))
+    monkeypatch.setattr("waggle.server._KNOWN_CONFIG_PATHS", [("Mock Client", str(mock_config))])
+
     db_path = tmp_path / "server-memory.db"
     graph = MemoryGraph(db_path, FakeEmbeddingModel())
     graph.observe_conversation(
@@ -318,6 +330,51 @@ def test_doctor_fix_reembeds_mixed_embedding_model_ids(tmp_path: Path, capsys: p
     repaired = graph.get_embedding_store_health()
     assert repaired["mixed_models"] is False
     assert repaired["transcript_stale_rows"] == 0
+
+
+def test_doctor_json_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_config = tmp_path / "mock_config.json"
+    mock_config.write_text(json.dumps({"mcpServers": {"waggle": {}}}))
+    monkeypatch.setattr("waggle.server._KNOWN_CONFIG_PATHS", [("Mock Client", str(mock_config))])
+
+    db_path = tmp_path / "server-memory.db"
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="fake-model",
+        db_path=str(db_path),
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024 * 1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+
+    exit_code = _run_doctor(config, as_json=True)
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    data = json.loads(stdout)
+    assert data["ok"] is True
+    assert isinstance(data["config_files"], list)
+    assert data["database"]["path"] == str(db_path)
+    assert data["database"]["exists"] is False
+    assert data["database"]["parent_exists"] is True
+    assert data["embedding_model"]["model_name"] == "fake-model"
+    assert data["embedding_model"]["deterministic"] is True
+    assert data["startup_mode"] == "normal"
+    assert data["issues"] == []
 
 
 def test_create_and_list_api_keys_cli_redacts_hash(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,8 +167,11 @@ def test_parser_accepts_graph_editor_commands() -> None:
         ["checkpoint-context", "--project", "MCP", "--session-id", "thread-1", "--output", "handoff.abhi"]
     )
     clear_session_args = parser.parse_args(["clear-session", "--session-id", "thread-1", "--yes"])
+    clear_session_dry_run_args = parser.parse_args(["clear-session", "--session-id", "thread-1", "--dry-run"])
     clear_project_args = parser.parse_args(["clear-project", "--project", "MCP", "--yes"])
+    clear_project_dry_run_args = parser.parse_args(["clear-project", "--project", "MCP", "--dry-run"])
     clear_all_args = parser.parse_args(["clear-all", "--yes"])
+    clear_all_dry_run_args = parser.parse_args(["clear-all", "--dry-run"])
     push_args = parser.parse_args(["push", "--client-secret-path", "client.json", "--folder-id", "folder123"])
     pull_args = parser.parse_args(["pull", "file123", "--client-secret-path", "client.json"])
     share_args = parser.parse_args(["share", "file123", "--client-secret-path", "client.json"])
@@ -207,11 +210,14 @@ def test_parser_accepts_graph_editor_commands() -> None:
     assert clear_session_args.command == "clear-session"
     assert clear_session_args.session_id == "thread-1"
     assert clear_session_args.yes is True
+    assert clear_session_dry_run_args.dry_run is True
     assert clear_project_args.command == "clear-project"
     assert clear_project_args.project == "MCP"
     assert clear_project_args.yes is True
+    assert clear_project_dry_run_args.dry_run is True
     assert clear_all_args.command == "clear-all"
     assert clear_all_args.yes is True
+    assert clear_all_dry_run_args.dry_run is True
     assert push_args.command == "push"
     assert push_args.encrypt is True
     assert push_args.folder_id == "folder123"
@@ -1490,6 +1496,7 @@ def test_default_graph_uses_home_scoped_sqlite_path(monkeypatch: pytest.MonkeyPa
     monkeypatch.delenv("WAGGLE_BACKEND", raising=False)
     monkeypatch.delenv("WAGGLE_DB_PATH", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     graph = _default_graph()
 
@@ -1537,6 +1544,7 @@ def test_default_graph_requires_neo4j_connection_settings(monkeypatch: pytest.Mo
 
 def test_write_other_config_no_longer_uses_pythonpath(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_other(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()
@@ -1549,6 +1557,7 @@ def test_write_other_config_no_longer_uses_pythonpath(monkeypatch: pytest.Monkey
 
 def test_write_codex_config_no_longer_uses_pythonpath(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_codex(str(tmp_path / "memory.db"), "/tmp/fake-python")
     contents = config_path.read_text()
@@ -1576,6 +1585,7 @@ def test_setup_client_arg_normalization() -> None:
 
 def test_write_gemini_config_preserves_existing_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     settings_file = tmp_path / ".gemini" / "settings.json"
     settings_file.parent.mkdir(parents=True)
     settings_file.write_text(json.dumps({"theme": "dark", "mcpServers": {"other": {"command": "x"}}}))
@@ -1592,6 +1602,7 @@ def test_write_gemini_config_preserves_existing_settings(monkeypatch: pytest.Mon
 
 def test_write_antigravity_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     config_path = _write_antigravity(str(tmp_path / "memory.db"), "/tmp/fake-python")
     payload = json.loads(config_path.read_text())
@@ -1603,6 +1614,7 @@ def test_write_antigravity_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
 
 def test_run_setup_writes_codex_config_and_agents(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
     result = _run_setup(
@@ -1628,6 +1640,7 @@ def test_write_codex_config_updates_existing_file_without_duplicates(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     config_file = tmp_path / ".codex" / "config.toml"
     config_file.parent.mkdir(parents=True)
     config_file.write_text(
@@ -1686,3 +1699,114 @@ def test_write_codex_agents_updates_existing_block_without_duplication(tmp_path:
     assert "Keep this note." in contents
     assert AUTOMATIC_MEMORY_RULE_TEXT.strip() in contents
     assert "build_context before answers and on_assistant_turn after answers" in contents
+
+
+def test_clear_tools_dry_run_preview(tmp_path: Path) -> None:
+    app = make_app(tmp_path)
+    
+    app.graph.add_node(
+        label="Vault Decision",
+        content="Export this node to a markdown vault.",
+        node_type=NodeType.DECISION,
+        project="alpha",
+        session_id="sess-1",
+    )
+    app.graph.observe_conversation(
+        user_message="Use Redis for caching.",
+        assistant_response="Noted.",
+        project="alpha",
+        session_id="sess-1",
+    )
+    
+    # 1. Test clear_session with dry_run=True (without confirm!)
+    result = app.handle_tool_call("clear_session", {"session_id": "sess-1", "dry_run": True})
+    assert result.isError is False
+    assert result.structuredContent["dry_run"] is True
+    assert result.structuredContent["deleted_nodes"] > 0
+    assert result.structuredContent["deleted_transcripts"] > 0
+    # Should contain counts_by_node_type
+    assert any(k in result.structuredContent["counts_by_node_type"] for k in ("decision", "note", "entity", "fact"))
+    # Check text content prefix
+    assert "[Preview] Would clear" in result.content[0].text
+    
+    # Verify data still exists
+    assert app.graph.get_stats().total_nodes > 0
+    # Verify no audit event
+    assert len(app.graph.list_audit_events(event_type="graph.scope_cleared")) == 0
+    
+    # 2. Test clear_project with dry_run=True
+    result_proj = app.handle_tool_call("clear_project", {"project": "alpha", "dry_run": True})
+    assert result_proj.isError is False
+    assert result_proj.structuredContent["dry_run"] is True
+    assert result_proj.structuredContent["deleted_nodes"] > 0
+    assert "[Preview] Would clear" in result_proj.content[0].text
+    
+    # 3. Test clear_all with dry_run=True
+    result_all = app.handle_tool_call("clear_all", {"dry_run": True})
+    assert result_all.isError is False
+    assert result_all.structuredContent["dry_run"] is True
+    assert result_all.structuredContent["deleted_nodes"] > 0
+    assert "[Preview] Would clear" in result_all.content[0].text
+
+
+def test_clear_cli_commands_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    app = make_app(tmp_path)
+    
+    app.graph.add_node(
+        label="Test Node",
+        content="Use Redis for caching.",
+        node_type=NodeType.DECISION,
+        project="alpha",
+        session_id="sess-1",
+    )
+    app.graph.observe_conversation(
+        user_message="Use Redis for caching.",
+        assistant_response="Noted.",
+        project="alpha",
+        session_id="sess-1",
+    )
+    
+    # Run clear-session with dry-run
+    args = SimpleNamespace(
+        command="clear-session",
+        session_id="sess-1",
+        dry_run=True,
+        yes=False,
+    )
+    exit_code = _run_admin_command(app.config, args)
+    assert exit_code == 0
+    
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["deleted_nodes"] > 0
+    assert payload["deleted_transcripts"] > 0
+    
+    # Verify data is not deleted
+    assert app.graph.get_stats().total_nodes > 0
+    
+    # Run clear-project with dry-run
+    args = SimpleNamespace(
+        command="clear-project",
+        project="alpha",
+        dry_run=True,
+        yes=False,
+    )
+    exit_code = _run_admin_command(app.config, args)
+    assert exit_code == 0
+    
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["deleted_nodes"] > 0
+    
+    # Run clear-all with dry-run
+    args = SimpleNamespace(
+        command="clear-all",
+        dry_run=True,
+        yes=False,
+    )
+    exit_code = _run_admin_command(app.config, args)
+    assert exit_code == 0
+    
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["deleted_nodes"] > 0


### PR DESCRIPTION
## Summary

Implements preview/dry-run support and audit trail logging for clear-scope operations.

### Features Added

* Added `dry_run` support for clear-session, clear-project, and clear-all operations
* Added structured deletion counts and `counts_by_node_type`
* Added audit event emission for real clear operations
* Added MCP and CLI support for `--dry-run`
* Added automated tests for:

  * dry-run behavior
  * audit logging
  * CLI and MCP preview flows
  * backward compatibility
* Fixed Windows path handling issues in tests

## Verification

* `pytest`
* `ruff check`
* `ruff format`

Closes #36


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` flag to preview destructive operations (clear session, project, all) without making actual changes
  * Added `--json` flag to doctor command for structured JSON output
  * Clear operations now report detailed deletion counts by data type

* **Bug Fixes**
  * Fixed Windows path handling in configuration files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->