### PR TITLE
ci: fix publish-vscode-extension workflow failing on every push

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: vscode-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish-vscode:
     runs-on: ubuntu-latest
@@ -43,10 +47,14 @@ jobs:
           path: apps/vscode-extension/*.vsix
 
       - name: Publish to Marketplace
-        if: ${{ secrets.VSCE_PAT != '' }}
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx @vscode/vsce publish
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "::notice::VSCE_PAT not set; skipping marketplace publish."
+            exit 0
+          fi
+          npx @vscode/vsce publish
 
       - name: Upload VSIX to GitHub release
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Closes #52. Supersedes the previously-closed #51 (same fix, fresh PR).

## Problem

Every push to `Abhigyan-Shekhar/Waggle-mcp` (and downstream forks) creates a failed run of `publish-vscode-extension.yml`, even though the trigger is restricted to `push.tags: v*`. Sample of affected runs on `main`:

| Time (UTC) | Branch | Conclusion |
|---|---|---|
| 10:42 | main | failure |
| 10:11 | codex/repo-layout-cli-mcp-vscode | failure |
| 09:45 | codex/repo-layout-cli-mcp-vscode | failure |

Each has `startup_failure: 1`, `jobs: []`, empty `billable`. No job ever runs.

## Root cause

```yaml
- name: Publish to Marketplace
  if: ${{ secrets.VSCE_PAT != '' }}
```

The `secrets` context is not allowed in `if:` expressions. GitHub blocks it as a security measure (using `if: secrets.X != ''` would let an attacker probe whether a secret exists through timing/skip patterns). The workflow fails YAML validation at parse-time. For invalid workflow files, GitHub creates a placeholder failed run on every push event, bypassing the trigger filter.

Docs: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability

## Fix

Drop the step-level `if:` and move the secret presence check into the `run:` script:

```yaml
- name: Publish to Marketplace
  env:
    VSCE_PAT: ${{ secrets.VSCE_PAT }}
  run: |
    if [ -z "$VSCE_PAT" ]; then
      echo "::notice::VSCE_PAT not set; skipping marketplace publish."
      exit 0
    fi
    npx @vscode/vsce publish
```

The step always runs but exits cleanly with a notice when no PAT is set (fork builds, PR runs).

## Bonus: concurrency control

Added a small `concurrency` block so two simultaneous `v1.2.3` re-tag pushes serialise the publish step instead of racing the marketplace upload:

```yaml
concurrency:
  group: vscode-publish-${{ github.ref }}
  cancel-in-progress: false
```

`cancel-in-progress: false` is deliberate. An in-flight publish should finish, not get killed mid-upload.

## Files changed

```
.github/workflows/publish-vscode-extension.yml  (+10 / -2)
```

## After this lands

Spurious failed-run accumulation stops on `main` immediately. Existing feature branches keep showing the failure until they're rebased onto post-fix `main`.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish-vscode-extension.yml'))"` parses cleanly
- [ ] Next branch push to `main` produces zero new runs of this workflow
- [ ] Next `v*` tag push runs the full publish pipeline end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved publishing workflow reliability by preventing cancellation of in-progress releases and enhancing credential validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->