### PR TITLE
test: rename vague transcript handoff tests

### DIFF
--- a/tests/test_ingest_transcript_handoff.py
+++ b/tests/test_ingest_transcript_handoff.py
@@ -147,7 +147,7 @@ def make_transcript_payload(
 
 
 class TestBuildExtractiveBlocks:
-    def test_simple_user_assistant(self) -> None:
+    def test_build_extractive_blocks_preserves_user_assistant_order(self) -> None:
         msgs = [
             TranscriptMessage(role="user", content="hello"),
             TranscriptMessage(role="assistant", content="world"),
@@ -254,7 +254,7 @@ class TestIngestTranscriptHandoffBackend:
         assert result.export_skipped is True
         assert result.export_skipped_reason == "no_messages"
 
-    def test_simple_user_assistant_turn(self, tmp_path: Path) -> None:
+    def test_ingest_transcript_handoff_processes_single_user_assistant_turn(self, tmp_path: Path) -> None:
         graph = make_graph(tmp_path)
         payload = TranscriptIngestionInput(
             session_id="s1",


### PR DESCRIPTION
## Summary

- What changed? Renamed the two vague `test_simple_*` tests in `tests/test_ingest_transcript_handoff.py` to describe the behavior they assert.
- Why was it needed? This makes pytest output and IDE outlines clearer when transcript handoff behavior regresses.

Fixes #59

## Testing

- [x] `uv run --extra dev pytest tests/test_ingest_transcript_handoff.py -q`
- [x] `uv run ruff check tests/test_ingest_transcript_handoff.py`
- [x] `uv run ruff format --check tests/test_ingest_transcript_handoff.py`

## Checklist

- [x] I linked an issue or explained why one is not needed.
- [x] I updated docs if user-facing behavior changed. N/A — test-only rename.
- [x] I kept the PR focused on one logical change.
- [x] I did not commit secrets, local exports, or generated noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test method names for improved clarity and documentation purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->