### PR TITLE
docs: document Waggle environment variables

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,69 @@
+# Environment variables
+
+Waggle reads the following `WAGGLE_*` environment variables in `src/waggle/config.py`. Values are parsed when `AppConfig.from_env()` starts the server or CLI command.
+
+Boolean values are enabled only when set to the lowercase string `true`. Integer and float values must parse as their listed type.
+
+## Core runtime
+
+| Variable | Default | Type | Applies when | Example |
+|----------|---------|------|--------------|---------|
+| `WAGGLE_BACKEND` | `sqlite` | string enum: `sqlite`, `neo4j` | Always. Selects the storage backend. | `neo4j` |
+| `WAGGLE_TRANSPORT` | `stdio` | string enum: `stdio`, `http` | Always. HTTP transport requires `WAGGLE_BACKEND=neo4j`. | `http` |
+| `WAGGLE_MODEL` | `all-MiniLM-L6-v2` | string | Always. Names the sentence-transformers embedding model. | `BAAI/bge-small-en-v1.5` |
+| `WAGGLE_DEFAULT_TENANT_ID` | `local-default` | string | Always. Used when a request does not provide a tenant. Must not be empty. | `workspace-default` |
+| `WAGGLE_LOG_LEVEL` | `INFO` | string | Always. Configures application logging verbosity. | `DEBUG` |
+| `WAGGLE_STARTUP_MODE` | `normal` | string enum: `fast`, `normal`, `strict` | Always. Controls startup/warmup behavior. | `strict` |
+
+## SQLite storage
+
+| Variable | Default | Type | Applies when | Example |
+|----------|---------|------|--------------|---------|
+| `WAGGLE_DB_PATH` | `~/.waggle/waggle.db` (or the Codex Waggle DB path discovered from `~/.codex/config.toml`) | path string | `WAGGLE_BACKEND=sqlite`. Expanded with `~` support. | `/var/lib/waggle/waggle.db` |
+
+## HTTP service
+
+| Variable | Default | Type | Applies when | Example |
+|----------|---------|------|--------------|---------|
+| `WAGGLE_HTTP_HOST` | `0.0.0.0` | string | HTTP server binding. | `127.0.0.1` |
+| `WAGGLE_HTTP_PORT` | `8080` (falls back to `PORT` before `8080`) | integer | HTTP server binding. | `8080` |
+| `WAGGLE_RATE_LIMIT_RPM` | `120` | integer | HTTP request rate limiting. | `240` |
+| `WAGGLE_WRITE_RATE_LIMIT_RPM` | `60` | integer | HTTP write-tool rate limiting. | `120` |
+| `WAGGLE_MAX_CONCURRENT_REQUESTS` | `8` | integer | HTTP request concurrency limiting. | `16` |
+| `WAGGLE_MAX_PAYLOAD_BYTES` | `1048576` | integer | HTTP request body size limit. | `2097152` |
+| `WAGGLE_REQUEST_TIMEOUT_SECONDS` | `30` | integer | Per-request timeout handling. | `60` |
+
+## Neo4j storage
+
+| Variable | Default | Type | Applies when | Example |
+|----------|---------|------|--------------|---------|
+| `WAGGLE_NEO4J_URI` | empty string | string | Required when `WAGGLE_BACKEND=neo4j`. | `bolt://localhost:7687` |
+| `WAGGLE_NEO4J_USERNAME` | empty string | string | Required when `WAGGLE_BACKEND=neo4j`. | `neo4j` |
+| `WAGGLE_NEO4J_PASSWORD` | empty string | string | Required when `WAGGLE_BACKEND=neo4j`. | `change-me` |
+| `WAGGLE_NEO4J_DATABASE` | empty string | string | Optional with `WAGGLE_BACKEND=neo4j`; uses the driver's default database when empty. | `neo4j` |
+
+## Retrieval and ranking
+
+| Variable | Default | Type | Applies when | Example |
+|----------|---------|------|--------------|---------|
+| `WAGGLE_RECENCY_HALF_LIFE_DAYS` | `30.0` | float | Hybrid retrieval recency scoring. Must be greater than `0`. | `14.0` |
+| `WAGGLE_HYBRID_VECTOR_WEIGHT` | `1.0` | float | Hybrid retrieval vector score weighting. | `1.2` |
+| `WAGGLE_HYBRID_BM25_WEIGHT` | `1.0` | float | Hybrid retrieval BM25 score weighting. | `0.8` |
+| `WAGGLE_HYBRID_GRAPH_WEIGHT` | `1.0` | float | Hybrid retrieval graph score weighting. | `1.5` |
+| `WAGGLE_HYBRID_RECENCY_WEIGHT` | `1.0` | float | Hybrid retrieval recency score weighting. | `0.5` |
+| `WAGGLE_HYBRID_RERANK_ENABLED` | `false` | boolean string | Hybrid retrieval reranking. Set to `true` to enable. | `true` |
+| `WAGGLE_HYBRID_RERANK_MODEL` | `claude-3-5-sonnet-latest` | string | Used when hybrid reranking is enabled. | `claude-3-5-haiku-latest` |
+| `WAGGLE_HYBRID_RERANK_TOP_K_IN` | `20` | integer | Candidate count passed into reranking. Must be at least `1`. | `30` |
+| `WAGGLE_HYBRID_RERANK_TOP_K_OUT` | `5` | integer | Candidate count returned after reranking. Must be at least `1`. | `8` |
+| `WAGGLE_TIERED_RETRIEVAL` | `false` | boolean string | Enables tiered retrieval when set to `true`. | `true` |
+| `WAGGLE_TIERED_TOP_K_WINDOWS` | `3` | integer | Tiered retrieval window count. Must be at least `1`. | `5` |
+| `WAGGLE_DEDUP_THRESHOLD` | `0.88` | float | Write-time canonicalization dedup threshold. Must be at least `0.85`. | `0.90` |
+
+## Exports and retention
+
+| Variable | Default | Type | Applies when | Example |
+|----------|---------|------|--------------|---------|
+| `WAGGLE_EXPORT_DIR` | unset | path string | Export commands and generated artifacts when an export directory is needed. | `/var/lib/waggle/exports` |
+| `WAGGLE_RETENTION_ENABLED` | `false` | boolean string | Retention pruning. Set to `true` to enable. | `true` |
+| `WAGGLE_RETENTION_DAYS` | `90` | integer | Retention pruning age. Must be at least `1`. | `180` |
+| `WAGGLE_RETENTION_PRUNE_INTERVAL_HOURS` | `24` | integer | Background retention prune interval. Must be at least `1`. | `12` |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -309,43 +309,7 @@ A reusable copy also lives in [automatic-memory-rules.md](./automatic-memory-rul
 
 ## Environment variables
 
-### Core
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `WAGGLE_BACKEND` | `sqlite` | `sqlite` or `neo4j` |
-| `WAGGLE_TRANSPORT` | `stdio` | `stdio` or `http` |
-| `WAGGLE_MODEL` | `all-MiniLM-L6-v2` | sentence-transformers model |
-| `WAGGLE_DEFAULT_TENANT_ID` | `local-default` | default tenant |
-| `WAGGLE_EXPORT_DIR` | — | optional export directory |
-
-### SQLite
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `WAGGLE_DB_PATH` | `~/.waggle/waggle.db` | path to the SQLite file |
-
-### HTTP service
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `WAGGLE_HTTP_HOST` | `0.0.0.0` | bind host |
-| `WAGGLE_HTTP_PORT` | `8080` | bind port |
-| `WAGGLE_LOG_LEVEL` | `INFO` | log level |
-| `WAGGLE_RATE_LIMIT_RPM` | `120` | global rate limit |
-| `WAGGLE_WRITE_RATE_LIMIT_RPM` | `60` | write-tool rate limit |
-| `WAGGLE_MAX_CONCURRENT_REQUESTS` | `8` | concurrency cap |
-| `WAGGLE_MAX_PAYLOAD_BYTES` | `1048576` | max request size |
-| `WAGGLE_REQUEST_TIMEOUT_SECONDS` | `30` | per-request timeout |
-
-### Neo4j
-
-| Variable | Description |
-|----------|-------------|
-| `WAGGLE_NEO4J_URI` | Bolt URI, e.g. `bolt://localhost:7687` |
-| `WAGGLE_NEO4J_USERNAME` | Neo4j username |
-| `WAGGLE_NEO4J_PASSWORD` | Neo4j password |
-| `WAGGLE_NEO4J_DATABASE` | Neo4j database name |
+See [Environment variables](./environment-variables.md) for the complete `WAGGLE_*` configuration reference, including defaults, value types, when each variable applies, and example values.
 
 ### Extraction
 


### PR DESCRIPTION
## Summary

- Added a dedicated environment-variable reference page covering every `WAGGLE_*` variable read by `src/waggle/config.py`.
- Linked the new page from `docs/reference.md` so future config additions have an obvious docs home.

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q` (`HOME` pointed at a temp directory with a minimal Waggle MCP config for the environment-sensitive doctor test)
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

## Checklist

- [x] I linked an issue or explained why one is not needed. Fixes #60
- [x] I updated docs if user-facing behavior changed.
- [x] I kept the PR focused on one logical change.
- [x] I did not commit secrets, local exports, or generated noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive environment variables documentation detailing all available configuration options for Waggle server and CLI behavior, including parsing rules and categorized settings for runtime, storage, HTTP services, retrieval/ranking, feature toggles, and retention controls.
  * Updated reference guide to consolidate and cross-reference the new dedicated configuration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->