### PR TITLE
test(locks): add tests for ProcessLock acquire, release, reentrant gu…

### DIFF
--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,0 +1,100 @@
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from waggle.locks import ProcessLock
+
+
+def test_context_manager(tmp_path: Path):
+    """Verify ProcessLock works as a context manager."""
+    lock_path = tmp_path / "test.lock"
+    lock = ProcessLock(lock_path)
+
+    with lock:
+        assert lock._fd is not None
+        assert lock_path.exists()
+
+    assert lock._fd is None
+    assert lock_path.exists()
+
+
+def test_reentrant_guard(tmp_path: Path):
+    """Verify acquiring the same lock twice raises RuntimeError."""
+    lock_path = tmp_path / "test.lock"
+    lock = ProcessLock(lock_path)
+    lock.acquire()
+    try:
+        with pytest.raises(RuntimeError):
+            lock.acquire()
+    finally:
+        lock.release()
+
+
+def test_double_release(tmp_path: Path):
+    """Verify release() is idempotent."""
+    lock_path = tmp_path / "test.lock"
+    lock = ProcessLock(lock_path)
+    lock.acquire()
+    lock.release()
+    # Should not raise an error
+    lock.release()
+
+
+def test_lock_file_creation(tmp_path: Path):
+    """Verify ProcessLock creates the lock file and its parent directory."""
+    lock_dir = tmp_path / "non_existent_dir"
+    lock_path = lock_dir / "test.lock"
+
+    assert not lock_dir.exists()
+
+    with ProcessLock(lock_path):
+        assert lock_dir.exists()
+        assert lock_path.exists()
+
+
+def test_cross_thread_exclusion(tmp_path: Path):
+    """Verify the lock prevents concurrent access from different threads."""
+    lock_path = tmp_path / "test.lock"
+    lock1 = ProcessLock(lock_path)
+    lock2 = ProcessLock(lock_path)
+    event = threading.Event()
+    second_thread_acquired = False
+
+    def thread_one_task():
+        with lock1:
+            event.set()  # Signal that thread 1 has the lock
+            time.sleep(0.2)
+
+    def thread_two_task():
+        nonlocal second_thread_acquired
+        # This should block until thread_one_task releases the lock
+        with lock2:
+            second_thread_acquired = True
+
+    t1 = threading.Thread(target=thread_one_task)
+    t1.start()
+
+    # Wait for thread 1 to acquire the lock
+    event.wait(timeout=1)
+    assert event.is_set()
+
+    t2 = threading.Thread(target=thread_two_task)
+    t2.start()
+
+    # Give thread 2 a moment to try to acquire the lock
+    t2.join(timeout=0.1)
+
+    # Thread 2 should be blocked, so it shouldn't have acquired the lock yet
+    assert not second_thread_acquired
+    assert t2.is_alive()
+
+    # Wait for both threads to complete
+    t1.join(timeout=2)
+    t2.join(timeout=2)
+
+    # After t1 finishes, t2 should have been able to acquire the lock
+    assert second_thread_acquired
+    assert not t1.is_alive()
+    assert not t2.is_alive()


### PR DESCRIPTION
## Summary
- What changed? Created tests/test_locks.py with 5 tests covering context manager, reentrant guard, double release, lock file creation, and cross-thread exclusion.
- Why was it needed? ProcessLock had no tests despite being used extensively in graph.py for SQLite transaction protection. Fixes #134.

## Testing
- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

**OS tested on:** Windows 11

**pytest output:**
tests/test_locks.py::test_context_manager PASSED
tests/test_locks.py::test_reentrant_guard PASSED
tests/test_locks.py::test_double_release PASSED
tests/test_locks.py::test_lock_file_creation PASSED
tests/test_locks.py::test_cross_thread_exclusion PASSED
5 passed in 1.16s

**Cross-thread exclusion:** Yes — two threads acquire the same ProcessLock, first thread holds it briefly then releases, second thread blocks until released. Used threading.join(timeout=2) to prevent hangs.

## Checklist
- [x] I linked an issue or explained why one is not needed.
- [ ] I updated docs if user-facing behavior changed.
- [x] I kept the PR focused on one logical change.
- [x] I did not commit secrets, local exports, or generated noise.

<img width="1018" height="392" alt="Screenshot 2026-05-30 192042" src="https://github.com/user-attachments/assets/6c54e872-4002-4ce2-8606-b256ba4d6d9f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the process locking mechanism. Validates context manager functionality including proper initialization and cleanup, prevents reentrancy violations through guard checks, ensures idempotent release operations remain safe when called multiple times, handles lock file creation with automatic parent directory setup, and verifies thread-safe mutual exclusion preventing concurrent access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->