### PR TITLE
test(serializer): add dedicated tests for serialize_* functions

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from waggle.models import (
+    ConflictRecord,
+    ContextTimelineItem,
+    GraphStats,
+    Node,
+    NodeType,
+    ObservationResult,
+    TimelineResult,
+)
+from waggle.serializer import (
+    serialize_observation_result,
+    serialize_recent_nodes,
+    serialize_stats,
+    serialize_timeline,
+)
+
+
+# 1. serialize_stats
+def test_serialize_stats_counts():
+    stats = GraphStats(total_nodes=5, total_edges=3)
+    output = serialize_stats(stats)
+    assert "Total nodes: 5" in output
+    assert "Total edges: 3" in output
+
+
+def test_serialize_stats_empty():
+    stats = GraphStats()
+    output = serialize_stats(stats)
+    assert "No nodes stored yet." in output
+
+
+# 2. serialize_recent_nodes
+def test_serialize_recent_nodes_empty():
+    output = serialize_recent_nodes([])
+    assert "No nodes stored" in output
+
+
+def test_serialize_recent_nodes_nonempty():
+    node = Node(
+        label="My Decision",
+        content="we chose PostgreSQL",
+        node_type=NodeType.DECISION,
+    )
+    output = serialize_recent_nodes([node])
+    assert "My Decision" in output
+
+
+# 3. serialize_observation_result
+def test_serialize_observation_result():
+    node = Node(
+        label="Use PostgreSQL",
+        content="db choice",
+        node_type=NodeType.DECISION,
+    )
+    conflict = ConflictRecord(
+        other_node_id="abc123",
+        other_node_label="Use MySQL",
+        reason="contradicts earlier database choice",
+    )
+    result = ObservationResult(stored_nodes=[node], conflicts=[conflict])
+    output = serialize_observation_result(result)
+    assert "[STORED]" in output
+    assert "Use PostgreSQL" in output
+    assert "[CONFLICTS]" in output
+    assert "Use MySQL" in output
+
+
+# 4. serialize_timeline
+def test_serialize_timeline_empty():
+    result = TimelineResult(items=[])
+    output = serialize_timeline(result)
+    assert "No timeline items." in output
+
+
+def test_serialize_timeline_nonempty():
+    item = ContextTimelineItem(
+        kind="node_created",
+        timestamp=datetime(2024, 6, 15, tzinfo=UTC),
+        label="Decision stored",
+        summary="A node was saved",
+    )
+    result = TimelineResult(items=[item])
+    output = serialize_timeline(result)
+    assert "2024-06-15" in output
+    assert "Decision stored" in output


### PR DESCRIPTION
## Functions tested
- `serialize_stats` — integer counts and empty fallback messages
- `serialize_recent_nodes` — empty list returns "No nodes stored", 
  non-empty includes node label
- `serialize_observation_result` — real ObservationResult with Node and 
  ConflictRecord, both [STORED] and [CONFLICTS] sections asserted
- `serialize_timeline` — empty returns "No timeline items.", 
  non-empty includes formatted timestamp and label

## Test output
set WAGGLE_MODEL=deterministic && python -m pytest tests/test_serializer.py -v

tests/test_serializer.py::test_serialize_stats_counts PASSED        [ 14%]
tests/test_serializer.py::test_serialize_stats_empty PASSED         [ 28%]
tests/test_serializer.py::test_serialize_recent_nodes_empty PASSED  [ 42%]
tests/test_serializer.py::test_serialize_recent_nodes_nonempty PASSED [ 57%]
tests/test_serializer.py::test_serialize_observation_result PASSED  [ 71%]
tests/test_serializer.py::test_serialize_timeline_empty PASSED      [ 85%]
tests/test_serializer.py::test_serialize_timeline_nonempty PASSED   [100%]
7 passed in 0.61s

## Notes
- Tested 4 functions with 7 tests total (more than minimum 4)
- All inputs are real model objects — no mocks
- ruff check tests/test_serializer.py — All checks passed!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for core serializer functions to enhance output validation and reliability. Tests verify correct behavior across both empty and populated data scenarios, including proper formatting of data markers, empty state messages, node/edge counts, conflict sections, and timezone-aware date formatting in timeline serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->