### PR TITLE
docs: add migration guide for API key prefix change

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -155,6 +155,21 @@ Today, remote access relies on Waggle API keys and tenant isolation.
 
 Set `WAGGLE_API_KEY_ENVIRONMENT=live` before issuing production keys so generated keys use the `sk_live_` prefix. Local and default installs use the non-production `sk_test_` prefix unless this variable is explicitly set to `live`.
 
+## Migration
+
+Starting with the release that merged PR #88, the default API key prefix changed from `sk_live_` to `sk_test_`.
+
+Existing API keys are unaffected by this change. Authentication uses the stored key hash rather than the key prefix, so previously generated `sk_live_` keys continue to work after upgrading.
+
+To continue generating `sk_live_` keys in production, set:
+
+`WAGGLE_API_KEY_ENVIRONMENT=live`
+
+The provided production deployment configurations (`docker-compose.prod.yml`, `kubernetes/configmap.yaml`, and `render.yaml`) already set this value.
+
+No action is required for local or development environments. The default `sk_test_` prefix is intentional for test and local deployments.
+
+
 Recommended operational flow:
 
 1. Create a tenant:

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -165,7 +165,7 @@ To continue generating `sk_live_` keys in production, set:
 
 `WAGGLE_API_KEY_ENVIRONMENT=live`
 
-The provided production deployment configurations (`docker-compose.prod.yml`, `kubernetes/configmap.yaml`, and `render.yaml`) already set this value.
+The provided production deployment configurations (`docker-compose.prod.yml`, `deploy/kubernetes/configmap.yaml`, and `render.yaml`) already set this value.
 
 No action is required for local or development environments. The default `sk_test_` prefix is intentional for test and local deployments.
 


### PR DESCRIPTION
## Summary

* Added a Migration section to `docs/deployment/production.md`.
* Documented the API key prefix change introduced in PR #88.
* Clarified that existing `sk_live_` keys continue to work because authentication is based on the key hash rather than the prefix.
* Added guidance for using `WAGGLE_API_KEY_ENVIRONMENT=live` in production deployments.

## Testing

* Documentation-only change.
* No code changes were made.
* No tests were required.

## Checklist

* [x] I linked an issue or explained why one is not needed.
* [x] I updated docs if user-facing behavior changed.
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.

Closes #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Migration" note under API keys explaining the default API key prefix change and confirming existing keys continue to work (authentication uses stored key hashes). Provides guidance for production operators who need legacy-style key generation to set the environment to "live" and notes development defaults to the test prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->