### PR TITLE
feat: add optional layers parameter to retrieval debug (#28)

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -3393,6 +3393,7 @@ class MemoryGraph:
         max_nodes: int = 10,
         max_depth: int = 2,
         retrieval_mode: str = "graph",
+        layers: list[str] | None = None,
     ) -> dict[str, Any]:
         query_text = query.strip()
         if not query_text:
@@ -3413,6 +3414,7 @@ class MemoryGraph:
                 session_id=session_id,
                 top_k=max_nodes,
                 mode=normalized_mode,
+                layers=layers,
             )
             return {
                 "query": query_text,

--- a/src/waggle/retrieval/hybrid.py
+++ b/src/waggle/retrieval/hybrid.py
@@ -17,6 +17,8 @@ from waggle.rlm import run_gemini_one_shot, run_groq_one_shot, run_ollama_one_sh
 
 RRF_K = 60.0
 
+VALID_LAYERS = frozenset({"vector_transcript", "vector_node", "lexical", "graph_expansion"})
+
 HYBRID_RERANKER_PROMPT = """You are reranking memory retrieval candidates for a conversational memory system.
 
 You will receive:
@@ -215,32 +217,52 @@ class HybridRetriever:
         top_k: int = 5,
         *,
         mode: str = "hybrid",
+        layers: list[str] | None = None,
     ) -> dict[str, Any]:
         normalized_mode = mode.strip().lower()
         if normalized_mode not in {"hybrid", "verbatim"}:
             raise ValueError("HybridRetriever mode must be 'hybrid' or 'verbatim'.")
 
+        if layers is not None:
+            invalid = set(layers) - VALID_LAYERS
+            if invalid:
+                raise ValueError(
+                    f"Invalid layer(s): {sorted(invalid)}. "
+                    "Valid layers: vector_transcript, vector_node, lexical, graph_expansion"
+                )
+            selected_layers = set(layers)
+        else:
+            selected_layers = VALID_LAYERS
+
         turn_pairs = self._load_turn_pairs(project=project, agent_id=agent_id, session_id=session_id)
         query_embedding = self.graph.embedding_model.embed(self.graph._expand_query_aliases(query))
         now = datetime.now(UTC)
 
-        transcript_vector_ranked = self._rank_turn_pairs(query_embedding, turn_pairs)[:20]
+        transcript_vector_ranked = (
+            self._rank_turn_pairs(query_embedding, turn_pairs)[:20]
+            if "vector_transcript" in selected_layers
+            else []
+        )
         node_vector_ranked = (
             []
-            if normalized_mode == "verbatim"
+            if normalized_mode == "verbatim" or "vector_node" not in selected_layers
             else self._rank_nodes(query_embedding, project=project, agent_id=agent_id, session_id=session_id)[:20]
         )
-        lexical_ranked = self._rank_lexical(
-            query=query,
-            turn_pairs=turn_pairs,
-            project=project,
-            agent_id=agent_id,
-            session_id=session_id,
-            include_nodes=normalized_mode != "verbatim",
-        )[:20]
+        lexical_ranked = (
+            self._rank_lexical(
+                query=query,
+                turn_pairs=turn_pairs,
+                project=project,
+                agent_id=agent_id,
+                session_id=session_id,
+                include_nodes=normalized_mode != "verbatim",
+            )[:20]
+            if "lexical" in selected_layers
+            else []
+        )
         graph_expanded_ranked = (
             []
-            if normalized_mode == "verbatim"
+            if normalized_mode == "verbatim" or "graph_expansion" not in selected_layers
             else self._expand_graph_candidates(
                 node_vector_ranked, turn_pairs_by_id={pair.turn_pair_id: pair for pair in turn_pairs}
             )[:20]
@@ -274,10 +296,14 @@ class HybridRetriever:
         return {
             "hits": hits,
             "layers": {
-                "vector_transcript": self._summarize_layer(transcript_vector_ranked),
-                "vector_node": self._summarize_layer(node_vector_ranked),
-                "lexical": self._summarize_layer(lexical_ranked),
-                "graph_expansion": self._summarize_layer(graph_expanded_ranked),
+                name: self._summarize_layer(ranked)
+                for name, ranked in [
+                    ("vector_transcript", transcript_vector_ranked),
+                    ("vector_node", node_vector_ranked),
+                    ("lexical", lexical_ranked),
+                    ("graph_expansion", graph_expanded_ranked),
+                ]
+                if name in selected_layers
             },
             "fused_top20": [
                 {

--- a/src/waggle/retrieval/hybrid.py
+++ b/src/waggle/retrieval/hybrid.py
@@ -239,9 +239,7 @@ class HybridRetriever:
         now = datetime.now(UTC)
 
         transcript_vector_ranked = (
-            self._rank_turn_pairs(query_embedding, turn_pairs)[:20]
-            if "vector_transcript" in selected_layers
-            else []
+            self._rank_turn_pairs(query_embedding, turn_pairs)[:20] if "vector_transcript" in selected_layers else []
         )
         node_vector_ranked = (
             []

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -798,6 +798,14 @@ class WaggleServer:
                             "default": "hybrid",
                             "description": "Which retrieval stack to diagnose.",
                         },
+                        "layers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["vector_transcript", "vector_node", "lexical", "graph_expansion"],
+                            },
+                            "description": "Optional subset of retrieval layers to compute. Default: all layers.",
+                        },
                         **_scope_properties(),
                     },
                     required=["query"],
@@ -1879,6 +1887,7 @@ class WaggleServer:
                         self._subgraph_payload(subgraph),
                     )
                 elif name == "debug_retrieval":
+                    layers_arg = arguments.get("layers")
                     debug = graph.debug_retrieval(
                         query=arguments["query"],
                         max_nodes=int(arguments.get("max_nodes", 10)),
@@ -1887,6 +1896,7 @@ class WaggleServer:
                         project=arguments.get("project", ""),
                         session_id=arguments.get("session_id", ""),
                         retrieval_mode=arguments.get("retrieval_mode", "hybrid"),
+                        layers=layers_arg,
                     )
                     result = self._tool_result(
                         json.dumps(debug, indent=2),

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from waggle.config import AppConfig
 from waggle.graph import MemoryGraph
@@ -363,6 +364,129 @@ def test_layer_scores_backward_compatible():
     candidate.layer_scores["bm25"] = 0.6
     assert "vector_transcript" in candidate.layer_scores
     assert "bm25" in candidate.layer_scores
+
+
+def test_debug_retrieval_layers_default_returns_all(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path, rerank_enabled=False)
+    with graph._lock, graph._connect() as connection:
+        observed_at = datetime(2026, 1, 1, tzinfo=UTC)
+        graph._store_transcript_record(
+            connection,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-layers",
+            observed_at=observed_at,
+            turn_index=0,
+            role="user",
+            transcript_text="the default layers should include everything",
+            turn_pair_id="tp-layers-default",
+        )
+
+    debug = graph.hybrid_retriever().retrieve_debug(
+        query="default layers",
+        project="alpha",
+        agent_id="codex",
+        session_id="",
+        top_k=5,
+        mode="hybrid",
+    )
+    assert set(debug["layers"].keys()) == {"vector_transcript", "vector_node", "lexical", "graph_expansion"}
+
+
+def test_debug_retrieval_single_layer_select(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path, rerank_enabled=False)
+    with graph._lock, graph._connect() as connection:
+        observed_at = datetime(2026, 1, 1, tzinfo=UTC)
+        graph._store_transcript_record(
+            connection,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-single",
+            observed_at=observed_at,
+            turn_index=0,
+            role="user",
+            transcript_text="single layer selection test",
+            turn_pair_id="tp-single",
+        )
+
+    lex_debug = graph.hybrid_retriever().retrieve_debug(
+        query="single layer",
+        project="alpha",
+        agent_id="codex",
+        session_id="",
+        top_k=5,
+        mode="hybrid",
+        layers=["lexical"],
+    )
+    assert set(lex_debug["layers"].keys()) == {"lexical"}
+
+    vt_debug = graph.hybrid_retriever().retrieve_debug(
+        query="single layer",
+        project="alpha",
+        agent_id="codex",
+        session_id="",
+        top_k=5,
+        mode="hybrid",
+        layers=["vector_transcript"],
+    )
+    assert set(vt_debug["layers"].keys()) == {"vector_transcript"}
+
+
+def test_debug_retrieval_invalid_layer_name(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path, rerank_enabled=False)
+    with pytest.raises(ValueError, match="Invalid layer"):
+        graph.hybrid_retriever().retrieve_debug(
+            query="invalid",
+            project="",
+            agent_id="",
+            session_id="",
+            top_k=5,
+            mode="hybrid",
+            layers=["not_a_valid_layer"],
+        )
+
+
+def test_debug_retrieval_layers_filter_affects_fusion(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path, rerank_enabled=False)
+    with graph._lock, graph._connect() as connection:
+        observed_at = datetime(2026, 1, 1, tzinfo=UTC)
+        graph._store_transcript_record(
+            connection,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-filter",
+            observed_at=observed_at,
+            turn_index=0,
+            role="user",
+            transcript_text="fusion should only reflect selected layers",
+            turn_pair_id="tp-filter",
+        )
+
+    full = graph.hybrid_retriever().retrieve_debug(
+        query="fusion test",
+        project="alpha",
+        agent_id="codex",
+        session_id="",
+        top_k=5,
+        mode="hybrid",
+    )
+    partial = graph.hybrid_retriever().retrieve_debug(
+        query="fusion test",
+        project="alpha",
+        agent_id="codex",
+        session_id="",
+        top_k=5,
+        mode="hybrid",
+        layers=["vector_transcript"],
+    )
+
+    assert "vector_node" not in partial["layers"]
+    assert "lexical" not in partial["layers"]
+    assert "graph_expansion" not in partial["layers"]
+    for hit in partial["fused_top20"]:
+        assert "vector_node" not in hit.get("layer_scores", {})
+        assert "bm25" not in hit.get("layer_scores", {})
+        assert "graph_expansion" not in hit.get("layer_scores", {})
 
 
 def test_score_explanation_includes_recency_contribution():

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -462,14 +462,6 @@ def test_debug_retrieval_layers_filter_affects_fusion(tmp_path: Path) -> None:
             turn_pair_id="tp-filter",
         )
 
-    full = graph.hybrid_retriever().retrieve_debug(
-        query="fusion test",
-        project="alpha",
-        agent_id="codex",
-        session_id="",
-        top_k=5,
-        mode="hybrid",
-    )
     partial = graph.hybrid_retriever().retrieve_debug(
         query="fusion test",
         project="alpha",


### PR DESCRIPTION
## What was implemented:
- src/waggle/retrieval/hybrid.py: Added optional layers parameter to retrieve_debug. Validates against {vector_transcript, vector_node, lexical, graph_expansion}. Only computes and returns the selected layers — skipped layers don't make DB queries or fusion contributions.
- src/waggle/graph.py: Added layers parameter to debug_retrieval, forwarded to retrieve_debug.
- src/waggle/server.py: Added layers array field to the debug_retrieval tool schema and passed it through.
- tests/test_hybrid_retrieval.py: 4 new tests — default returns all layers, single-layer selection works, invalid names raise ValueError, fusion output excludes unselected layers.

Closes #28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug retrieval now supports optional layer filtering, letting diagnostics be scoped to specific retrieval layers: vector_transcript, vector_node, lexical, graph_expansion.
  * The diagnostic tool endpoint now accepts a layers parameter so callers can request layer-scoped debug output.

* **Tests**
  * Added coverage for layer filtering, validation of layer names, and verification that debug payloads reflect the selected layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->