### PR TITLE
feat: add offset pagination to transcript browsing (#29)

### DIFF
--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -191,6 +191,8 @@ export function App() {
   const [transcriptRecords, setTranscriptRecords] = useState(boot.sampleMode ? SAMPLE_TRANSCRIPTS : []);
   const [filters, setFilters] = useState({ search: "", tags: [], sessions: [], sources: [], agents: [], projects: [], dateRange: "all" });
   const [transcriptSearch, setTranscriptSearch] = useState("");
+  const [transcriptOffset, setTranscriptOffset] = useState(0);
+  const [transcriptTotalCount, setTranscriptTotalCount] = useState(0);
   const [transcriptHits, setTranscriptHits] = useState([]);
   const [retrievalQuery, setRetrievalQuery] = useState("how do transcript provenance and derived nodes interact?");
   const [retrievalResult, setRetrievalResult] = useState(boot.sampleMode ? SAMPLE_RETRIEVAL : null);
@@ -246,6 +248,8 @@ export function App() {
     ]);
     setSnapshot(graphData);
     setTranscriptRecords(transcriptData.records || []);
+    setTranscriptOffset(transcriptData.pagination?.offset ?? 0);
+    setTranscriptTotalCount(transcriptData.pagination?.total_count ?? 0);
     setSelectedNodeId("");
     setSelectedEdgeId("");
     setHoverNodeId("");
@@ -719,6 +723,21 @@ export function App() {
     setTranscriptHits(payload.hits || []);
   };
 
+  const loadMoreTranscripts = async () => {
+    const nextOffset = transcriptRecords.length;
+    const query = new URLSearchParams({
+      ...scope,
+      limit: "200",
+      offset: String(nextOffset),
+    });
+    const payload = await apiRequest(`/api/graph/transcripts?${query.toString()}`);
+    if (payload.records?.length) {
+      setTranscriptRecords((prev) => [...prev, ...payload.records]);
+      setTranscriptOffset(nextOffset);
+      setTranscriptTotalCount(payload.pagination?.total_count ?? 0);
+    }
+  };
+
   const runRetrievalDebug = async () => {
     if (boot.sampleMode) {
       setRetrievalResult(SAMPLE_RETRIEVAL);
@@ -1051,6 +1070,17 @@ export function App() {
                     );
                   })}
                 </div>
+                {!transcriptSearch.trim() && transcriptTotalCount > transcriptRecords.length ? (
+                  <div className="flex justify-center pt-2 pb-4">
+                    <button
+                      className="rounded-xl border border-white/10 px-4 py-2 text-sm text-graph-muted hover:text-white"
+                      onClick={() => loadMoreTranscripts().catch((error) => setToast(error.message))}
+                      type="button"
+                    >
+                      Load more ({transcriptRecords.length} of {transcriptTotalCount})
+                    </button>
+                  </div>
+                ) : null}
               </div>
             </div>
           ) : null}

--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -7370,6 +7370,7 @@ class MemoryGraph:
         project: str = "",
         session_id: str = "",
         limit: int = 200,
+        offset: int = 0,
     ) -> list[TranscriptRecord]:
         filters = ["tenant_id = ?"]
         params: list[Any] = [self.tenant_id]
@@ -7390,11 +7391,40 @@ class MemoryGraph:
                 FROM transcript_records
                 WHERE {" AND ".join(filters)}
                 ORDER BY observed_at ASC, turn_index ASC
-                LIMIT ?
+                LIMIT ? OFFSET ?
                 """,
-                (*params, max(1, int(limit))),
+                (*params, max(1, int(limit)), max(0, int(offset))),
             ).fetchall()
         return [self._row_to_transcript_record(row) for row in rows]
+
+    def count_transcript_records(
+        self,
+        *,
+        agent_id: str = "",
+        project: str = "",
+        session_id: str = "",
+    ) -> int:
+        filters = ["tenant_id = ?"]
+        params: list[Any] = [self.tenant_id]
+        if project.strip():
+            filters.append("project = ?")
+            params.append(project.strip())
+        if session_id.strip():
+            filters.append("session_id = ?")
+            params.append(session_id.strip())
+        elif agent_id.strip():
+            filters.append("agent_id = ?")
+            params.append(agent_id.strip())
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                f"""
+                SELECT COUNT(*) AS cnt
+                FROM transcript_records
+                WHERE {" AND ".join(filters)}
+                """,
+                tuple(params),
+            ).fetchone()
+        return int(row["cnt"] or 0)
 
     def search_transcript_records(
         self,

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3114,6 +3114,7 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
     async def graph_transcripts(request: Request) -> Response:
         scope = _scope_from_request(request)
         limit = int(request.query_params.get("limit", "200") or "200")
+        offset = int(request.query_params.get("offset", "0") or "0")
         query_text = request.query_params.get("query", "").strip()
         graph, _ = _require_http_scope(request, "graph:read")
         if query_text and hasattr(graph, "search_transcript_records"):
@@ -3134,18 +3135,24 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
             )
         if not hasattr(graph, "list_transcript_records"):
             raise ValidationFailure("Transcript listing is not available in this backend.")
-        records = graph.list_transcript_records(limit=limit, **scope)
+        records = graph.list_transcript_records(limit=limit, offset=offset, **scope)
+        total_count = graph.count_transcript_records(**scope)
         _emit_http_audit(
             request,
             event_type="record.read",
             resource_type="transcript_records",
             action="read",
-            metadata={"mode": "chronological", "limit": limit},
+            metadata={"mode": "chronological", "limit": limit, "offset": offset},
         )
         return JSONResponse(
             {
                 "mode": "chronological",
                 "records": [record.model_dump(mode="json") for record in records],
+                "pagination": {
+                    "offset": offset,
+                    "limit": limit,
+                    "total_count": total_count,
+                },
             }
         )
 

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -365,6 +365,44 @@ def test_layer_scores_backward_compatible():
     assert "bm25" in candidate.layer_scores
 
 
+def test_list_transcript_records_pagination(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path, rerank_enabled=False)
+    with graph._lock, graph._connect() as connection:
+        observed_at = datetime(2026, 1, 1, tzinfo=UTC)
+        for index in range(5):
+            graph._store_transcript_record(
+                connection,
+                agent_id="codex",
+                project="alpha",
+                session_id="sess-page",
+                observed_at=observed_at,
+                turn_index=index,
+                role="user",
+                transcript_text=f"record {index}",
+                turn_pair_id="tp-page",
+            )
+
+    all_records = graph.list_transcript_records(project="alpha")
+    assert len(all_records) == 5
+    assert all_records[0].transcript_text == "record 0"
+    assert all_records[4].transcript_text == "record 4"
+
+    first_page = graph.list_transcript_records(project="alpha", limit=2, offset=0)
+    assert len(first_page) == 2
+    assert [r.transcript_text for r in first_page] == ["record 0", "record 1"]
+
+    second_page = graph.list_transcript_records(project="alpha", limit=2, offset=2)
+    assert len(second_page) == 2
+    assert [r.transcript_text for r in second_page] == ["record 2", "record 3"]
+
+    third_page = graph.list_transcript_records(project="alpha", limit=2, offset=4)
+    assert len(third_page) == 1
+    assert [r.transcript_text for r in third_page] == ["record 4"]
+
+    total = graph.count_transcript_records(project="alpha")
+    assert total == 5
+
+
 def test_score_explanation_includes_recency_contribution():
     candidate = CandidateMemory(
         candidate_id="test-4",


### PR DESCRIPTION
Changes:
- src/waggle/graph.py: Added offset param to list_transcript_records with SQL OFFSET. Added count_transcript_records method returning total matching count.
- src/waggle/server.py: graph_transcripts handler now accepts offset query param, calls count_transcript_records, and returns pagination: {offset, limit, total_count} in the response. Backward compatible — offset defaults to 0.
- apps/mcp/graph-ui/src/App.jsx: Added transcriptOffset/transcriptTotalCount state. New loadMoreTranscripts function fetches the next page and appends to existing records. "Load more (N of M)" button appears below the transcript list when more records are available. Search mode is unchanged (still bounded hits).
- tests/test_hybrid_retrieval.py: Added test_list_transcript_records_pagination verifying deterministic ordering across pages with offset/limit.
Closes #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcript pagination with incremental loading: a "Load more (X of Y)" button lets users fetch additional transcript records on demand when not searching.
  * Response now shows accurate progress and totals so users know how many transcripts remain.
  * Improves performance and usability when browsing large transcript collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->