### PR TITLE
feat: add deterministic retrieval regression fixtures (#21)

### DIFF
--- a/src/waggle/neo4j_graph.py
+++ b/src/waggle/neo4j_graph.py
@@ -1878,7 +1878,6 @@ def update_node(
     valid_to: datetime | None = None,
     evidence_records: list[EvidenceRecord] | None = None,
 ) -> Node:
-
     if (
         content is None
         and label is None

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -475,9 +475,7 @@ def test_regression_graph_neighborhood_includes_connected_nodes(tmp_path: Path) 
     )
     graph_expansion_layer = debug["layers"].get("graph_expansion", [])
     vector_node_ids = {
-        entry["node_ids"][0]
-        for entry in debug["layers"].get("vector_node", [])
-        if entry.get("node_ids")
+        entry["node_ids"][0] for entry in debug["layers"].get("vector_node", []) if entry.get("node_ids")
     }
     assert graph_expansion_layer, "Graph expansion layer should return results."
     assert node_a.id in vector_node_ids, (

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -380,3 +380,102 @@ def test_score_explanation_includes_recency_contribution():
     }
     assert candidate.score_explanation["recency"] > 0
     assert "final_score" in candidate.score_explanation
+
+
+def test_regression_lexical_match_ranks_expected_first(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path, rerank_enabled=False)
+    with graph._lock, graph._connect() as connection:
+        observed_at = datetime(2026, 1, 1, tzinfo=UTC)
+        graph._store_transcript_record(
+            connection,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-reg",
+            observed_at=observed_at,
+            turn_index=0,
+            role="user",
+            transcript_text="The deployment uses the jade-phoenix protocol for secure handoff.",
+            turn_pair_id="tp-reg",
+        )
+        graph._store_transcript_record(
+            connection,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-reg",
+            observed_at=observed_at,
+            turn_index=1,
+            role="assistant",
+            transcript_text="I have recorded the jade-phoenix protocol as the deployment standard.",
+            turn_pair_id="tp-reg",
+        )
+
+    debug = graph.hybrid_retriever().retrieve_debug(
+        query="jade-phoenix deployment protocol",
+        project="alpha",
+        agent_id="codex",
+        session_id="",
+        top_k=5,
+        mode="hybrid",
+    )
+    lexical_layer = debug["layers"].get("lexical", [])
+    assert lexical_layer, "Lexical layer should return results for jade-phoenix query."
+    top_lexical_id = lexical_layer[0]["candidate_id"]
+    assert "tp-reg" in top_lexical_id, f"Expected lexical top hit to reference tp-reg, got {top_lexical_id}"
+
+
+def test_regression_graph_neighborhood_includes_connected_nodes(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path, rerank_enabled=False)
+    with graph._lock, graph._connect() as connection:
+        observed_at = datetime(2026, 2, 1, tzinfo=UTC)
+        graph._store_transcript_record(
+            connection,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-graph-reg",
+            observed_at=observed_at,
+            turn_index=0,
+            role="user",
+            transcript_text="The root cause is a misconfigured load balancer.",
+            turn_pair_id="tp-graph-reg",
+        )
+        node_a = graph.add_node(
+            label="Load balancer config",
+            content="The load balancer forwards traffic to backend services.",
+            node_type=NodeType.FACT,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-graph-reg",
+            source_turn_pair_id="tp-graph-reg",
+            connection=connection,
+        ).node
+        node_b = graph.add_node(
+            label="Backend service health",
+            content="Backend service health checks are failing intermittently.",
+            node_type=NodeType.FACT,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-graph-reg",
+            source_turn_pair_id="tp-graph-reg",
+            connection=connection,
+        ).node
+        graph.add_edge(
+            source_id=node_a.id,
+            target_id=node_b.id,
+            relationship=RelationType.DERIVED_FROM,
+            connection=connection,
+        )
+
+    debug = graph.hybrid_retriever().retrieve_debug(
+        query="load balancer root cause",
+        project="alpha",
+        agent_id="codex",
+        session_id="",
+        top_k=5,
+        mode="hybrid",
+    )
+    graph_expansion_layer = debug["layers"].get("graph_expansion", [])
+    assert graph_expansion_layer, "Graph expansion layer should return results."
+    all_node_ids = set()
+    for entry in graph_expansion_layer:
+        all_node_ids.update(entry.get("node_ids", []))
+    assert node_b.id in all_node_ids, f"Expected node_b ({node_b.id}) to appear in graph expansion, got {all_node_ids}"

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import numpy as np
@@ -426,7 +426,7 @@ def test_regression_lexical_match_ranks_expected_first(tmp_path: Path) -> None:
 def test_regression_graph_neighborhood_includes_connected_nodes(tmp_path: Path) -> None:
     graph = make_graph(tmp_path, rerank_enabled=False)
     with graph._lock, graph._connect() as connection:
-        observed_at = datetime(2026, 2, 1, tzinfo=UTC)
+        observed_at = datetime.now(UTC) - timedelta(days=7)
         graph._store_transcript_record(
             connection,
             agent_id="codex",
@@ -474,7 +474,15 @@ def test_regression_graph_neighborhood_includes_connected_nodes(tmp_path: Path) 
         mode="hybrid",
     )
     graph_expansion_layer = debug["layers"].get("graph_expansion", [])
+    vector_node_ids = {
+        entry["node_ids"][0]
+        for entry in debug["layers"].get("vector_node", [])
+        if entry.get("node_ids")
+    }
     assert graph_expansion_layer, "Graph expansion layer should return results."
+    assert node_a.id in vector_node_ids, (
+        f"Expected node_a ({node_a.id}) to appear in vector_node seeds, got {vector_node_ids}"
+    )
     all_node_ids = set()
     for entry in graph_expansion_layer:
         all_node_ids.update(entry.get("node_ids", []))

--- a/tests/test_recency.py
+++ b/tests/test_recency.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import math
 import sqlite3
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 import numpy as np
 
 from waggle.graph import MemoryGraph, recency_weight, score_node
 from waggle.models import NodeType, RelationType
+from waggle.retrieval.hybrid import HybridRetrievalConfig, HybridRetriever
 
 
 class ConstantEmbeddingModel:
@@ -128,3 +130,51 @@ def test_superseded_nodes_rank_below_current_version(tmp_path: Path) -> None:
 
     assert ranked[old_node.id].metadata["superseded_by"] == new_node.id
     assert ranked[new_node.id].final_score > ranked[old_node.id].final_score
+
+
+def test_regression_recency_ranks_recent_transcript_higher(tmp_path: Path) -> None:
+    graph = make_graph(tmp_path)
+    recent_time = datetime(2026, 5, 15, tzinfo=UTC)
+    old_time = datetime(2025, 1, 1, tzinfo=UTC)
+    with graph._lock, graph._connect() as connection:
+        graph._store_transcript_record(
+            connection,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-recency",
+            observed_at=old_time,
+            turn_index=0,
+            role="user",
+            transcript_text="The deployment protocol is jade-phoenix.",
+            turn_pair_id="tp-recency-old",
+        )
+        graph._store_transcript_record(
+            connection,
+            agent_id="codex",
+            project="alpha",
+            session_id="sess-recency",
+            observed_at=recent_time,
+            turn_index=1,
+            role="user",
+            transcript_text="The deployment protocol is jade-phoenix.",
+            turn_pair_id="tp-recency-new",
+        )
+
+    retriever = HybridRetriever(
+        graph,
+        config=HybridRetrievalConfig(rerank_enabled=False, recency_half_life_days=30.0),
+    )
+    debug = retriever.retrieve_debug(
+        query="jade-phoenix deployment protocol",
+        project="alpha",
+        agent_id="codex",
+        session_id="",
+        top_k=5,
+        mode="hybrid",
+    )
+    hit_ids = [hit.turn_pair_id for hit in debug["hits"]]
+    new_pos = hit_ids.index("tp-recency-new") if "tp-recency-new" in hit_ids else len(hit_ids)
+    old_pos = hit_ids.index("tp-recency-old") if "tp-recency-old" in hit_ids else len(hit_ids)
+    assert new_pos < old_pos, (
+        f"Expected recent tp-recency-new before old tp-recency-old, got positions {new_pos} vs {old_pos}"
+    )

--- a/tests/test_recency.py
+++ b/tests/test_recency.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import sqlite3
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import numpy as np
@@ -134,8 +134,9 @@ def test_superseded_nodes_rank_below_current_version(tmp_path: Path) -> None:
 
 def test_regression_recency_ranks_recent_transcript_higher(tmp_path: Path) -> None:
     graph = make_graph(tmp_path)
-    recent_time = datetime(2026, 5, 15, tzinfo=UTC)
-    old_time = datetime(2025, 1, 1, tzinfo=UTC)
+    now = datetime.now(UTC)
+    recent_time = now - timedelta(days=1)
+    old_time = now - timedelta(days=90)
     with graph._lock, graph._connect() as connection:
         graph._store_transcript_record(
             connection,


### PR DESCRIPTION
# Add deterministic retrieval regression fixtures

## Problem

Hybrid retrieval combines embeddings, BM25, graph expansion, and recency. Small ranking changes can improve one case while silently regressing another. There are no regression guards to catch regressions before merge.

## Changes

Three new regression tests that fail if an expected top result disappears:

| Test | File | What it guards |
|---|---|---|
| `test_regression_lexical_match_ranks_expected_first` | `tests/test_hybrid_retrieval.py` | Seeds a record with a unique term ("jade-phoenix"), asserts BM25 lexical layer returns it as top hit |
| `test_regression_graph_neighborhood_includes_connected_nodes` | `tests/test_hybrid_retrieval.py` | Creates nodes linked by `DERIVED_FROM`, asserts graph expansion includes the connected neighbor |
| `test_regression_recency_ranks_recent_transcript_higher` | `tests/test_recency.py` | Seeds two identical transcripts at different timestamps (2025 vs 2026), asserts the recent one outranks the old one |

## Design

- **Deterministic**: All tests use `FakeEmbeddingModel` (16-dim character-modulo hash) or `ConstantEmbeddingModel` (constant output) — same input always produces the same embedding.
- **No network or model downloads**: Tests run offline with zero external dependencies.
- **Ordering assertions, not fragile scores**: Tests check position in ranked output (e.g., "expected record is at position 0") rather than exact float values.
- **Compact**: Each fixture seeds 1–2 records and a handful of nodes. No benchmark artifacts to read.

## Acceptance criteria

- [x] New tests fail if an expected top result disappears from retrieval output
- [x] The fixtures are small enough to understand without reading benchmark artifacts
- [x] The tests run without network access or model downloads
- [x] Existing retrieval tests still pass (all 18 pass)

Closes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests verifying lexical match ranking prioritizes expected results.
  * Added regression tests confirming graph neighborhood expansion includes connected nodes.
  * Added regression tests ensuring recent content ranks higher in retrieval results.

* **Chores**
  * Updated node update handling to accept optional evidence records during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->