### PR TITLE
feat: warn when live environment uses default tenant

### DIFF
--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -1554,10 +1554,7 @@ class WaggleServer:
         graph = self.current_graph()
         started = time.perf_counter()
         graph.ensure_tenant(graph.tenant_id)
-        if (
-            self.config.api_key_environment == "live"
-            and self.config.default_tenant_id == "local-default"
-        ):
+        if self.config.api_key_environment == "live" and self.config.default_tenant_id == "local-default":
             LOGGER.warning(
                 "WAGGLE_API_KEY_ENVIRONMENT is set to 'live' but "
                 "WAGGLE_DEFAULT_TENANT_ID is still 'local-default'. "

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -1554,6 +1554,15 @@ class WaggleServer:
         graph = self.current_graph()
         started = time.perf_counter()
         graph.ensure_tenant(graph.tenant_id)
+        if (
+            self.config.api_key_environment == "live"
+            and self.config.default_tenant_id == "local-default"
+        ):
+            LOGGER.warning(
+                "WAGGLE_API_KEY_ENVIRONMENT is set to 'live' but "
+                "WAGGLE_DEFAULT_TENANT_ID is still 'local-default'. "
+                "Production deployments should use a unique tenant ID."
+            )
         em = graph.embedding_model
         if self.config.is_fast_mode:
             # Fast mode: zero ML overhead. Schema inspection is the goal.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1849,6 +1849,47 @@ def test_write_codex_config_updates_existing_file_without_duplicates(
     assert "/old/python" not in contents
     assert "/old/memory.db" not in contents
 
+def test_validate_startup_warns_for_live_default_tenant(tmp_path, caplog):
+    app = make_app(tmp_path)
+
+    app.config.api_key_environment = "live"
+    app.config.default_tenant_id = "local-default"
+
+    with caplog.at_level("WARNING"):
+        app.validate_startup()
+
+    assert (
+        "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'"
+        in caplog.text
+    )
+
+def test_validate_startup_does_not_warn_for_custom_tenant(tmp_path, caplog):
+    app = make_app(tmp_path)
+
+    app.config.api_key_environment = "live"
+    app.config.default_tenant_id = "workspace-prod"
+
+    with caplog.at_level("WARNING"):
+        app.validate_startup()
+
+    assert (
+        "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'"
+        not in caplog.text
+    )
+
+def test_validate_startup_does_not_warn_for_test_environment(tmp_path, caplog):
+    app = make_app(tmp_path)
+
+    app.config.api_key_environment = "test"
+    app.config.default_tenant_id = "local-default"
+
+    with caplog.at_level("WARNING"):
+        app.validate_startup()
+
+    assert (
+        "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'"
+        not in caplog.text
+    )
 
 def test_write_codex_agents_creates_managed_block(tmp_path: Path) -> None:
     agents_path = _write_codex_agents(tmp_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1864,6 +1864,7 @@ def test_write_codex_config_updates_existing_file_without_duplicates(
     assert "/old/python" not in contents
     assert "/old/memory.db" not in contents
 
+
 def test_validate_startup_warns_for_live_default_tenant(tmp_path, caplog):
     app = make_app(tmp_path)
 
@@ -1873,10 +1874,8 @@ def test_validate_startup_warns_for_live_default_tenant(tmp_path, caplog):
     with caplog.at_level("WARNING"):
         app.validate_startup()
 
-    assert (
-        "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'"
-        in caplog.text
-    )
+    assert "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'" in caplog.text
+
 
 def test_validate_startup_does_not_warn_for_custom_tenant(tmp_path, caplog):
     app = make_app(tmp_path)
@@ -1887,10 +1886,8 @@ def test_validate_startup_does_not_warn_for_custom_tenant(tmp_path, caplog):
     with caplog.at_level("WARNING"):
         app.validate_startup()
 
-    assert (
-        "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'"
-        not in caplog.text
-    )
+    assert "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'" not in caplog.text
+
 
 def test_validate_startup_does_not_warn_for_test_environment(tmp_path, caplog):
     app = make_app(tmp_path)
@@ -1901,10 +1898,8 @@ def test_validate_startup_does_not_warn_for_test_environment(tmp_path, caplog):
     with caplog.at_level("WARNING"):
         app.validate_startup()
 
-    assert (
-        "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'"
-        not in caplog.text
-    )
+    assert "WAGGLE_API_KEY_ENVIRONMENT is set to 'live'" not in caplog.text
+
 
 def test_write_codex_agents_creates_managed_block(tmp_path: Path) -> None:
     agents_path = _write_codex_agents(tmp_path)


### PR DESCRIPTION
## Summary
Adds a startup warning when `WAGGLE_API_KEY_ENVIRONMENT` is set to `live` while `WAGGLE_DEFAULT_TENANT_ID` remains `local-default`.

## What Changed
A configuration validation warning was added inside `WaggleServer.validate_startup()`.
When:
* `config.api_key_environment == "live"`
* `config.default_tenant_id == "local-default"`

the server now emits:
`LOGGER.warning("WAGGLE_API_KEY_ENVIRONMENT is set to 'live' but WAGGLE_DEFAULT_TENANT_ID is still 'local-default'. Production deployments should use a unique tenant ID.")`

Startup behavior is unchanged and the server continues running normally.

## Files Modified
**src/waggle/server.py**
* Added startup validation warning in `validate_startup()`.

**tests/test_server.py**

Added tests for:
* Warning emitted for `live + local-default`
* No warning for `live + workspace-prod`
* No warning for `test + local-default`

## Verification
```bash
pytest tests/test_server.py -q
70 passed in 68.05s

pytest tests/test_server.py -q -k warning
1 passed, 69 deselected
```

## Lines Touched
* `src/waggle/server.py`
* `tests/test_server.py`

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emits a startup warning when the API key environment is set to "live" while the tenant configuration remains the non-production default, helping surface likely production misconfiguration.

* **Tests**
  * Added automated tests that verify the warning appears only for the live-with-local-tenant case and not for valid production or non-live environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->