### PR TITLE
refactor(server): consolidate doctor command invocation

### DIFF
--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -4533,6 +4533,8 @@ def _run_admin_command(config: AppConfig, args: argparse.Namespace) -> int:
     }
     if args.command in _CLI_COMMAND_ALIASES:
         args.command = _CLI_COMMAND_ALIASES[args.command]
+    if args.command == "doctor":
+        return _run_doctor_command(config, args)
     backend = _build_backend(config)
     if args.command == "create-tenant":
         tenant = backend.ensure_tenant(args.tenant_id, args.name)
@@ -4971,18 +4973,21 @@ def _run_admin_command(config: AppConfig, args: argparse.Namespace) -> int:
     if args.command == "features":
         print(_FEATURES_GUIDE)
         return 0
-    if args.command == "doctor":
-        return _run_doctor(
-            config,
-            fix=bool(getattr(args, "fix", False)),
-            json_output=bool(getattr(args, "json_output", False)),
-        )
     raise ValidationFailure(f"Unknown command: {args.command}")
 
 
 # ---------------------------------------------------------------------------
 # doctor command
 # ---------------------------------------------------------------------------
+
+
+def _run_doctor_command(config: AppConfig, args: argparse.Namespace) -> int:
+    return _run_doctor(
+        config,
+        fix=bool(getattr(args, "fix", False)),
+        json_output=bool(getattr(args, "json_output", False)),
+    )
+
 
 _KNOWN_CONFIG_PATHS: list[tuple[str, str]] = [
     # (label, path_template)
@@ -6051,7 +6056,7 @@ def _run_setup(args: argparse.Namespace) -> int:
         doctor_config = AppConfig.from_env()
         doctor_config.db_path = db_path
         doctor_config.model_name = args.model
-        doctor_exit = _run_doctor(doctor_config)
+        doctor_exit = _run_doctor_command(doctor_config, args)
         if doctor_exit:
             print(_c(_CYAN, "Setup completed; doctor reported follow-up warnings above."))
         return 0
@@ -6173,13 +6178,7 @@ def main() -> None:
     if command == "doctor":
         # Doctor only needs the config — not a live backend connection.
         config = AppConfig.from_env()
-        sys.exit(
-            _run_doctor(
-                config,
-                fix=bool(getattr(args, "fix", False)),
-                json_output=bool(getattr(args, "json_output", False)),
-            )
-        )
+        sys.exit(_run_admin_command(config, args))
 
     config = AppConfig.from_env()
     if command == "serve" and getattr(args, "transport", None):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ast
+import inspect
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,6 +10,7 @@ import numpy as np
 import pytest
 
 import waggle
+import waggle.server as server_module
 from waggle.config import AppConfig
 from waggle.graph import MemoryGraph
 from waggle.models import NodeType, RelationType
@@ -254,6 +257,18 @@ def test_parser_accepts_graph_editor_commands() -> None:
     assert pull_args.file_ref == "file123"
     assert share_args.command == "share"
     assert share_args.file_ref == "file123"
+
+
+def test_run_doctor_has_single_invocation_site() -> None:
+    tree = ast.parse(inspect.getsource(server_module))
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_run_doctor"
+    ]
+
+    assert len(calls) == 1
 
 
 def test_doctor_flags_mixed_embedding_model_ids(


### PR DESCRIPTION
Closes #81

## Summary

This PR consolidates doctor command routing so `_run_doctor` is invoked from exactly one place in `server.py`.

## Changes

- Added `_run_doctor_command()` to centralize doctor CLI argument handling.
- Routed `main()` doctor handling through `_run_admin_command()`.
- Moved doctor handling before `_build_backend()` in `_run_admin_command()` to preserve its config-only behavior.
- Updated `setup --run-doctor` to use the shared helper.
- Added a regression test to prevent multiple `_run_doctor` invocation sites.

## Verification

- Targeted pytest checks passed.
- Ruff checks passed.
- Verified doctor CLI behavior for `doctor`, `doctor --json`, and `doctor --fix`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified admin command routing to process all commands through a single dispatcher instead of special-case handling.

* **Tests**
  * Added test to verify single invocation point for the doctor command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhigyan-Shekhar/Waggle-mcp/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->