### PR TITLE
fix(graph): log cosine similarity failures

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import hashlib
 import heapq
 import json

--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import hashlib
 import heapq
 import json
@@ -1811,8 +1810,14 @@ class MemoryGraph:
             vec_a = self.embedding_model.from_bytes(emb_a)
             vec_b = self.embedding_model.from_bytes(emb_b)
             return self.embedding_model.cosine_similarity(vec_a, vec_b)
-        except Exception:
-            return None
+        except Exception as exc:
+            LOGGER.warning(
+                "Failed to compute cosine similarity between nodes %s and %s: %s",
+                a.id,
+                b.id,
+                exc,
+            )
+            raise
 
     def _backfill_transcript_storage(self, connection: sqlite3.Connection, *, batch_size: int = 100) -> None:
         pending_user_pairs: dict[str, str] = {}

--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -1818,7 +1818,7 @@ class MemoryGraph:
                 b.id,
                 exc,
             )
-            raise
+            return None
 
     def _backfill_transcript_storage(self, connection: sqlite3.Connection, *, batch_size: int = 100) -> None:
         pending_user_pairs: dict[str, str] = {}

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -381,7 +381,7 @@ def test_node_cosine_similarity_logs_and_reraises_errors(tmp_path, caplog):
     caplog.at_level(logging.WARNING),
     pytest.raises(RuntimeError, match="embedding decode failed"),
 ):
-    graph._node_cosine_similarity(node_a, node_b)
+        graph._node_cosine_similarity(node_a, node_b)
 
     assert any(
         "Failed to compute cosine similarity" in record.message

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import hashlib
 import json
 import sqlite3

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -350,6 +350,7 @@ def test_semantic_duplicate_nodes_reuse_existing_entry(tmp_path: Path) -> None:
     assert second.node.id == first.node.id
     assert second.dedup_reason == "same_label_high_similarity"
 
+
 def test_node_cosine_similarity_logs_and_reraises_errors(tmp_path, caplog):
     import logging
 
@@ -378,15 +379,12 @@ def test_node_cosine_similarity_logs_and_reraises_errors(tmp_path, caplog):
     graph.embedding_model.from_bytes = broken_from_bytes
 
     with (
-    caplog.at_level(logging.WARNING),
-    pytest.raises(RuntimeError, match="embedding decode failed"),
-):
+        caplog.at_level(logging.WARNING),
+        pytest.raises(RuntimeError, match="embedding decode failed"),
+    ):
         graph._node_cosine_similarity(node_a, node_b)
 
-    assert any(
-        "Failed to compute cosine similarity" in record.message
-        for record in caplog.records
-    )
+    assert any("Failed to compute cosine similarity" in record.message for record in caplog.records)
 
     graph.embedding_model.from_bytes = original
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -371,18 +371,14 @@ def test_node_cosine_similarity_logs_and_reraises_errors(tmp_path, caplog):
         node_type=NodeType.ENTITY,
     ).node
 
-
-
     def broken_from_bytes(*args, **kwargs):
         raise RuntimeError("embedding decode failed")
+
     graph.embedding_model.from_bytes = broken_from_bytes
     with caplog.at_level(logging.WARNING):
         result = graph._node_cosine_similarity(node_a, node_b)
         assert result is None
-        assert any(
-            "Failed to compute cosine similarity" in record.message
-            for record in caplog.records
-            )
+        assert any("Failed to compute cosine similarity" in record.message for record in caplog.records)
 
 
 def test_entity_resolution_reuses_acronym_matches(tmp_path: Path) -> None:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -377,9 +377,11 @@ def test_node_cosine_similarity_logs_and_reraises_errors(tmp_path, caplog):
 
     graph.embedding_model.from_bytes = broken_from_bytes
 
-    with caplog.at_level(logging.WARNING):
-        with pytest.raises(RuntimeError, match="embedding decode failed"):
-            graph._node_cosine_similarity(node_a, node_b)
+    with (
+    caplog.at_level(logging.WARNING),
+    pytest.raises(RuntimeError, match="embedding decode failed"),
+):
+    graph._node_cosine_similarity(node_a, node_b)
 
     assert any(
         "Failed to compute cosine similarity" in record.message

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -378,15 +378,14 @@ def test_node_cosine_similarity_logs_and_reraises_errors(tmp_path, caplog):
 
     graph.embedding_model.from_bytes = broken_from_bytes
 
-    with (
-        caplog.at_level(logging.WARNING),
-        pytest.raises(RuntimeError, match="embedding decode failed"),
-    ):
-        graph._node_cosine_similarity(node_a, node_b)
-
-    assert any("Failed to compute cosine similarity" in record.message for record in caplog.records)
-
-    graph.embedding_model.from_bytes = original
+    with caplog.at_level(logging.WARNING):
+        result = graph._node_cosine_similarity(node_a, node_b)
+        assert result is None
+        
+        assert any(
+            "Failed to compute cosine similarity" in record.message
+            for record in caplog.records
+            )
 
 
 def test_entity_resolution_reuses_acronym_matches(tmp_path: Path) -> None:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import hashlib
 import json
 import sqlite3
@@ -349,6 +350,44 @@ def test_semantic_duplicate_nodes_reuse_existing_entry(tmp_path: Path) -> None:
     assert second.created is False
     assert second.node.id == first.node.id
     assert second.dedup_reason == "same_label_high_similarity"
+
+def test_node_cosine_similarity_logs_and_reraises_errors(tmp_path, caplog):
+    import logging
+
+    graph = MemoryGraph(
+        tmp_path / "cosine.db",
+        FakeEmbeddingModel(),
+    )
+
+    node_a = graph.add_node(
+        label="A",
+        content="hello",
+        node_type=NodeType.ENTITY,
+    ).node
+
+    node_b = graph.add_node(
+        label="B",
+        content="world",
+        node_type=NodeType.ENTITY,
+    ).node
+
+    original = graph.embedding_model.from_bytes
+
+    def broken_from_bytes(*args, **kwargs):
+        raise RuntimeError("embedding decode failed")
+
+    graph.embedding_model.from_bytes = broken_from_bytes
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError, match="embedding decode failed"):
+            graph._node_cosine_similarity(node_a, node_b)
+
+    assert any(
+        "Failed to compute cosine similarity" in record.message
+        for record in caplog.records
+    )
+
+    graph.embedding_model.from_bytes = original
 
 
 def test_entity_resolution_reuses_acronym_matches(tmp_path: Path) -> None:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -371,17 +371,14 @@ def test_node_cosine_similarity_logs_and_reraises_errors(tmp_path, caplog):
         node_type=NodeType.ENTITY,
     ).node
 
-    original = graph.embedding_model.from_bytes
+
 
     def broken_from_bytes(*args, **kwargs):
         raise RuntimeError("embedding decode failed")
-
     graph.embedding_model.from_bytes = broken_from_bytes
-
     with caplog.at_level(logging.WARNING):
         result = graph._node_cosine_similarity(node_a, node_b)
         assert result is None
-        
         assert any(
             "Failed to compute cosine similarity" in record.message
             for record in caplog.records


### PR DESCRIPTION
## Summary

* Updated `_node_cosine_similarity()` to stop silently swallowing exceptions.
* Added warning-level logging when cosine similarity computation fails.
* Preserved existing non-fatal behavior by returning `None` after logging failures.
* Added a regression test covering embedding decoding failures and verifying that a warning is logged.

## Why was it needed?

Previously, all exceptions inside `_node_cosine_similarity()` were converted to `None` with no visibility into the failure. This made issues such as corrupted embeddings, model errors, or database problems difficult to diagnose. The change preserves the existing behavior for callers while ensuring failures are recorded through warning-level logs.

## Testing

* [x] WAGGLE_MODEL=deterministic pytest -q
* [x] ruff check src/ tests/
* [x] ruff format --check src/ tests/

## Checklist

* [x] I linked an issue or explained why one is not needed.
* [x] I updated docs if user-facing behavior changed.
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.

Closes #61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cosine similarity computation failures now emit warning logs and return None instead of failing silently.
* **Tests**
  * Added a test to verify that failed cosine similarity calculations log a warning and return None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->