### PR TITLE
Refactor logger percent formatting

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -910,10 +910,14 @@ class MemoryGraph:
             try:
                 journal_mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
                 if journal_mode.upper() != "WAL":
-                    LOGGER.info(f"Migrating database {self.db_path} from {journal_mode} to WAL mode")
+                    LOGGER.info(
+                        "Migrating database %s from %s to WAL mode",
+                        self.db_path,
+                        journal_mode,
+                        )
                     connection.execute("PRAGMA journal_mode=WAL")
             except Exception as e:
-                LOGGER.warning(f"Could not verify journal mode: {e}")
+                LOGGER.warning("Could not verify journal mode: %s", e)
 
             # Initialize schema
             connection.executescript(SCHEMA_SQL)
@@ -5852,9 +5856,12 @@ class MemoryGraph:
                 except Exception as verbatim_err:
                     # Verbatim persistence is mandatory. If it fails, the entire call fails.
                     connection.rollback()
-                    logger.exception(f"Failed to persist verbatim turn {turn_pair_id}: {verbatim_err}")
+                    logger.exception(
+                        "Failed to persist verbatim turn %s: %s",
+                        turn_pair_id,
+                        verbatim_err,
+                        )
                     raise
-
                 # ===== STEP 2: RUN EXTRACTION IN TRY/EXCEPT (NON-BLOCKING) =====
                 extraction_candidates = []
                 try:
@@ -5863,10 +5870,14 @@ class MemoryGraph:
                         assistant_response=assistant_response,
                     )
                 except Exception as extraction_err:
-                    logger.exception(f"Extraction failed for turn {turn_pair_id}: {extraction_err}")
+                    logger.exception(
+                        "Extraction failed for turn %s: %s",
+                        turn_pair_id,
+                        extraction_err,
+                        )
                     result.extraction_errors.append(
                         f"Extraction exception: {type(extraction_err).__name__}: {extraction_err!s}"
-                    )
+                        )
                     # Continue: verbatim is stored, extraction is optional enrichment
 
                 # ===== STEP 3: APPLY EXTRACTED CANDIDATES (IF ANY) =====
@@ -5898,10 +5909,14 @@ class MemoryGraph:
                             candidates_result.conflicts
                         )  # conflicts are one type of inferred relation
                     except Exception as candidate_err:
-                        logger.exception(f"Candidate application failed for turn {turn_pair_id}: {candidate_err}")
+                        logger.exception(
+                            "Candidate application failed for turn %s: %s",
+                            turn_pair_id,
+                            candidate_err,
+                            )
                         result.extraction_errors.append(
                             f"Candidate storage exception: {type(candidate_err).__name__}: {candidate_err!s}"
-                        )
+                            )
                         # Continue: verbatim persists regardless
 
                 # ===== STEP 4: WINDOW CONTEXT AND EDGES (SAME AS BEFORE) =====
@@ -5912,17 +5927,23 @@ class MemoryGraph:
                     self._update_window_node_count(connection, window_id)
                     self._mark_window_embedding_stale(connection, window_id)
                 except Exception as window_err:
-                    logger.warning(f"Window context update failed for turn {turn_pair_id}: {window_err}")
+                    logger.warning("Window context update failed for turn %s: %s",
+                                   turn_pair_id,
+                                   window_err,
+                                   )
                     result.extraction_errors.append(f"Window context error: {window_err!s}")
                     window_id = ""
                     repo_id = ""
-
             # Derive edges outside the transaction lock
             if window_id and repo_id:
                 try:
                     self.derive_context_window_edges(window_id, repo_id)
                 except Exception as edge_err:
-                    logger.warning(f"Context window edge derivation failed for turn {turn_pair_id}: {edge_err}")
+                    logger.warning(
+                        "Context window edge derivation failed for turn %s: %s",
+                        turn_pair_id,
+                        edge_err,
+                        )
                     result.extraction_errors.append(f"Edge derivation error: {edge_err!s}")
 
         return result

--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -914,7 +914,7 @@ class MemoryGraph:
                         "Migrating database %s from %s to WAL mode",
                         self.db_path,
                         journal_mode,
-                        )
+                    )
                     connection.execute("PRAGMA journal_mode=WAL")
             except Exception as e:
                 LOGGER.warning("Could not verify journal mode: %s", e)
@@ -5860,7 +5860,7 @@ class MemoryGraph:
                         "Failed to persist verbatim turn %s: %s",
                         turn_pair_id,
                         verbatim_err,
-                        )
+                    )
                     raise
                 # ===== STEP 2: RUN EXTRACTION IN TRY/EXCEPT (NON-BLOCKING) =====
                 extraction_candidates = []
@@ -5874,10 +5874,10 @@ class MemoryGraph:
                         "Extraction failed for turn %s: %s",
                         turn_pair_id,
                         extraction_err,
-                        )
+                    )
                     result.extraction_errors.append(
                         f"Extraction exception: {type(extraction_err).__name__}: {extraction_err!s}"
-                        )
+                    )
                     # Continue: verbatim is stored, extraction is optional enrichment
 
                 # ===== STEP 3: APPLY EXTRACTED CANDIDATES (IF ANY) =====
@@ -5913,10 +5913,10 @@ class MemoryGraph:
                             "Candidate application failed for turn %s: %s",
                             turn_pair_id,
                             candidate_err,
-                            )
+                        )
                         result.extraction_errors.append(
                             f"Candidate storage exception: {type(candidate_err).__name__}: {candidate_err!s}"
-                            )
+                        )
                         # Continue: verbatim persists regardless
 
                 # ===== STEP 4: WINDOW CONTEXT AND EDGES (SAME AS BEFORE) =====
@@ -5927,10 +5927,11 @@ class MemoryGraph:
                     self._update_window_node_count(connection, window_id)
                     self._mark_window_embedding_stale(connection, window_id)
                 except Exception as window_err:
-                    logger.warning("Window context update failed for turn %s: %s",
-                                   turn_pair_id,
-                                   window_err,
-                                   )
+                    logger.warning(
+                        "Window context update failed for turn %s: %s",
+                        turn_pair_id,
+                        window_err,
+                    )
                     result.extraction_errors.append(f"Window context error: {window_err!s}")
                     window_id = ""
                     repo_id = ""
@@ -5943,7 +5944,7 @@ class MemoryGraph:
                         "Context window edge derivation failed for turn %s: %s",
                         turn_pair_id,
                         edge_err,
-                        )
+                    )
                     result.extraction_errors.append(f"Edge derivation error: {edge_err!s}")
 
         return result


### PR DESCRIPTION
## Summary

* Replaced f-string interpolation in logging calls with %-style logging arguments in `src/waggle/graph.py`.
* This change was needed to enable lazy log formatting, reduce unnecessary formatting overhead, and improve compatibility with structured logging systems that group events by message template.

## Testing

* [x] `pytest`
* [x] `WAGGLE_MODEL=deterministic pytest -q` (not run locally)
* [x] `ruff check src/ tests/` (not run locally)
* [x] `ruff format --check src/ tests/` (not run locally)

## Checklist

* [x] I linked an issue or explained why one is not needed.
* [x]  Documentation updates were not required because this change does not affect user-facing behavior.
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.

Closes #63


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal logging format and structured exception/warning reporting for persistence and extraction steps.
  * Enhanced error handling clarity while preserving existing rollback and non-fatal extraction behaviors.
  * No functional or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->