### PR TITLE
perf(graph): batch-embed observation nodes in one forward pass

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -5637,7 +5637,21 @@ class MemoryGraph:
         """
         result = ObservationResult()
         stored_candidate_records: list[tuple[Node, list[str]]] = []
-        for candidate in candidates:
+        _candidate_texts = [str(c["content"]) for c in candidates]
+        _batch_embeddings: np.ndarray | None = None
+        if _candidate_texts:
+            try:
+                _batch_embeddings = self.embedding_model.embed_batch(_candidate_texts)
+                if _batch_embeddings is not None and len(_batch_embeddings) != len(_candidate_texts):
+                    raise ValueError(
+                        f"embed_batch returned {len(_batch_embeddings)} vectors, expected {len(_candidate_texts)}"
+                    )
+            except (AttributeError, NotImplementedError):
+                # embed_batch is not available on this model backend (e.g. a test
+                # stub).  Fall back gracefully: add_node will call embed() itself.
+                _batch_embeddings = None
+
+        for _idx, candidate in enumerate(candidates):
             candidate_tags = list(candidate.get("tags", []))
             speaker_tag = next((tag for tag in candidate_tags if str(tag).startswith("speaker:")), "")
             speaker = speaker_tag.split(":", 1)[1] if ":" in speaker_tag else "user"
@@ -5649,6 +5663,11 @@ class MemoryGraph:
                 turn_index=turn_index,
                 observed_at=observed_at,
                 session_id=session_id,
+            )
+            # Pass the pre-computed vector when available; otherwise let add_node
+            # fall back to its own embed() call (preserves backward-compatibility).
+            _precomputed: np.ndarray | None = (
+                _batch_embeddings[_idx] if _batch_embeddings is not None and _idx < len(_batch_embeddings) else None
             )
             store_result = self.add_node(
                 label=str(candidate["label"]),
@@ -5662,6 +5681,7 @@ class MemoryGraph:
                 session_id=session_id,
                 evidence_records=[evidence],
                 valid_from=observed_at,
+                embedding=_precomputed,
                 connection=connection,
             )
             result.stored_nodes.append(store_result.node)

--- a/tests/test_observe_conversation_refactor.py
+++ b/tests/test_observe_conversation_refactor.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import numpy as np
 
 from waggle.graph import MemoryGraph
+from waggle.models import NodeType
 
 
 class FakeEmbeddingModel:
@@ -25,6 +26,7 @@ class FakeEmbeddingModel:
     model_id = "fake-model:deterministic-v1"
 
     def embed(self, text: str) -> np.ndarray:
+        """Return a deterministic 8-dim unit vector for *text*."""
         vector = np.zeros(8, dtype=np.float32)
         for token in text.lower().split():
             index = sum(ord(character) for character in token) % len(vector)
@@ -34,13 +36,20 @@ class FakeEmbeddingModel:
             return vector
         return vector / norm
 
+    def embed_batch(self, texts: list[str]) -> np.ndarray:
+        """Batch embed: stacks individual embed() results into a 2-D array."""
+        return np.stack([self.embed(t) for t in texts], axis=0)
+
     def to_bytes(self, embedding: np.ndarray) -> bytes:
+        """Serialise *embedding* to a raw float32 byte string."""
         return embedding.astype(np.float32).tobytes()
 
     def from_bytes(self, data: bytes) -> np.ndarray:
+        """Deserialise a raw float32 byte string back to an ndarray."""
         return np.frombuffer(data, dtype=np.float32)
 
     def cosine_similarity(self, a: np.ndarray, b: np.ndarray) -> float:
+        """Return the cosine similarity between vectors *a* and *b*."""
         a_norm = np.linalg.norm(a)
         b_norm = np.linalg.norm(b)
         if a_norm == 0.0 or b_norm == 0.0:
@@ -301,3 +310,185 @@ class TestEdgeCases:
 
         # Should still mark as stored (no content to store, but no error)
         assert result.verbatim_stored is True or result.turn_id  # At minimum, turn_id should exist
+
+
+class TestBatchEmbeddingAdoption:
+    """Verify that _apply_observation_candidates uses embed_batch for multi-node observations."""
+
+    def test_embed_batch_called_once_for_multi_node_observation(self, tmp_path: Path) -> None:
+        """embed_batch should be called exactly once regardless of how many nodes are extracted."""
+        graph = make_graph(tmp_path)
+
+        with patch("waggle.graph.extract_conversation_candidates") as mock_extract:
+            mock_extract.return_value = [
+                {
+                    "label": "Python",
+                    "content": "User prefers Python.",
+                    "node_type": NodeType.PREFERENCE,
+                    "tags": [],
+                },
+                {
+                    "label": "FastAPI",
+                    "content": "FastAPI chosen for web layer.",
+                    "node_type": NodeType.DECISION,
+                    "tags": [],
+                },
+                {
+                    "label": "PostgreSQL",
+                    "content": "PostgreSQL for the database.",
+                    "node_type": NodeType.FACT,
+                    "tags": [],
+                },
+                {
+                    "label": "Docker",
+                    "content": "Docker for containerisation.",
+                    "node_type": NodeType.ENTITY,
+                    "tags": [],
+                },
+                {
+                    "label": "GitHub Actions",
+                    "content": "CI via GitHub Actions.",
+                    "node_type": NodeType.FACT,
+                    "tags": [],
+                },
+            ]
+
+            original_embed_batch = graph.embedding_model.embed_batch
+            embed_batch_calls: list[list[str]] = []
+
+            def spy_embed_batch(texts: list[str]) -> np.ndarray:
+                """Record the call then delegate to the real embed_batch."""
+                embed_batch_calls.append(list(texts))
+                return original_embed_batch(texts)
+
+            graph.embedding_model.embed_batch = spy_embed_batch  # type: ignore[method-assign]
+
+            result = graph.observe_conversation(
+                user_message="I like Python, FastAPI, Postgres, Docker and GitHub Actions.",
+                assistant_response="Great stack choices.",
+            )
+
+        # embed_batch must have been called exactly once
+        assert len(embed_batch_calls) == 1, (
+            f"Expected embed_batch to be called once; got {len(embed_batch_calls)} call(s)"
+        )
+        # The single call must include all 5 candidate texts
+        assert len(embed_batch_calls[0]) == 5
+        # All five nodes must have been stored
+        assert result.verbatim_stored is True
+        assert len(result.stored_nodes) == 5
+
+    def test_all_nodes_have_embeddings_after_batch_observe(self, tmp_path: Path) -> None:
+        """Every node stored via a multi-node observation must have a valid non-zero embedding."""
+        from waggle.models import NodeType
+
+        graph = make_graph(tmp_path)
+
+        with patch("waggle.graph.extract_conversation_candidates") as mock_extract:
+            mock_extract.return_value = [
+                {"label": "Node A", "content": "Alpha content.", "node_type": NodeType.FACT, "tags": []},
+                {"label": "Node B", "content": "Beta content.", "node_type": NodeType.FACT, "tags": []},
+                {"label": "Node C", "content": "Gamma content.", "node_type": NodeType.ENTITY, "tags": []},
+            ]
+
+            result = graph.observe_conversation(
+                user_message="Alpha, Beta, Gamma.",
+                assistant_response="Stored.",
+            )
+
+        assert len(result.stored_nodes) == 3
+        for node in result.stored_nodes:
+            # Fetch the raw embedding bytes back from the DB
+            fetched = graph.get_node(node.id)
+            # The node must exist and have a label (proxy for a complete write)
+            assert fetched.label
+            assert fetched.content
+            # Verify that embedding data was successfully generated and persisted
+            assert fetched.embedding_model_id
+            assert fetched.embedding_dim and fetched.embedding_dim > 0
+
+    def test_dedup_still_works_with_batch_embeddings(self, tmp_path: Path) -> None:
+        """Dedup must fire correctly when the embedding comes from the batch path."""
+        from waggle.models import NodeType
+
+        graph = make_graph(tmp_path)
+
+        # Lower the dedup threshold so near-duplicate texts merge
+        graph.dedup_similarity_threshold = 0.0  # merge everything
+
+        # First observation: store one node
+        with patch("waggle.graph.extract_conversation_candidates") as mock_extract:
+            mock_extract.return_value = [
+                {"label": "Database", "content": "We use PostgreSQL.", "node_type": NodeType.FACT, "tags": []},
+            ]
+            graph.observe_conversation(user_message="PostgreSQL.", assistant_response="OK.")
+
+        # Second observation: identical content — must trigger dedup merge, not create a new node
+        with patch("waggle.graph.extract_conversation_candidates") as mock_extract:
+            mock_extract.return_value = [
+                {"label": "Database", "content": "We use PostgreSQL.", "node_type": NodeType.FACT, "tags": []},
+            ]
+            result2 = graph.observe_conversation(user_message="PostgreSQL again.", assistant_response="Got it.")
+
+        # The second call should have reused (deduped) the first node, not created a new one
+        assert result2.reused_count >= 1, (
+            f"Expected dedup to fire on identical content; reused_count={result2.reused_count}"
+        )
+
+    def test_fallback_when_embed_batch_unavailable(self, tmp_path: Path) -> None:
+        """If embed_batch raises AttributeError/NotImplementedError, add_node must still succeed via its own embed()."""
+        from waggle.models import NodeType
+
+        graph = make_graph(tmp_path)
+
+        # Simulate a model backend that doesn't support embed_batch by
+        # shadowing it on the instance with a function that raises.
+        # (del on a class-defined method doesn't work; instance shadowing does.)
+        def _no_batch(texts: list[str]) -> np.ndarray:
+            """Stub that simulates a backend without embed_batch support."""
+            raise AttributeError("embed_batch not supported by this backend")
+
+        graph.embedding_model.embed_batch = _no_batch  # type: ignore[method-assign]
+
+        with patch("waggle.graph.extract_conversation_candidates") as mock_extract:
+            mock_extract.return_value = [
+                {"label": "Fallback A", "content": "Content A.", "node_type": NodeType.FACT, "tags": []},
+                {"label": "Fallback B", "content": "Content B.", "node_type": NodeType.FACT, "tags": []},
+            ]
+
+            result = graph.observe_conversation(
+                user_message="Fallback test.",
+                assistant_response="Noted.",
+            )
+
+        # Both nodes must still be stored even without embed_batch
+        assert result.verbatim_stored is True
+        assert len(result.stored_nodes) == 2
+        assert not result.extraction_errors
+
+    def test_malformed_batch_output_raises(self, tmp_path: Path) -> None:
+        """If embed_batch returns an array with the wrong length, it should raise a ValueError."""
+
+        graph = make_graph(tmp_path)
+
+        def _bad_batch(texts: list[str]) -> np.ndarray:
+            # Always return just one vector regardless of input length
+            return np.stack([graph.embedding_model.embed(texts[0])], axis=0)
+
+        graph.embedding_model.embed_batch = _bad_batch  # type: ignore[method-assign]
+
+        with patch("waggle.graph.extract_conversation_candidates") as mock_extract:
+            mock_extract.return_value = [
+                {"label": "Alpha", "content": "Alpha content.", "node_type": NodeType.FACT, "tags": []},
+                {"label": "Beta", "content": "Beta content.", "node_type": NodeType.FACT, "tags": []},
+            ]
+
+            result = graph.observe_conversation(
+                user_message="Alpha and Beta.",
+                assistant_response="Got it.",
+            )
+
+            # The ValueError from the shape guard is caught by observe_conversation
+            # and logged as a candidate application failure.
+            assert any("embed_batch returned 1 vectors, expected 2" in err for err in result.extraction_errors)
+            assert result.verbatim_stored is True


### PR DESCRIPTION
## Summary

### Changes
Updated `_apply_observation_candidates()` in `graph.py` to compute embeddings with a single `embed_batch()` call before iterating through candidates, then passed the precomputed vectors to `add_node()` via its existing `embedding` parameter. The test suite was updated by adding `embed_batch()` support to `FakeEmbeddingModel` and introducing a new `TestBatchEmbeddingAdoption` class containing four tests.

### Why
Previously, each extracted node triggered an individual `embed()` call, resulting in multiple serial model forward passes for a single observation. Since `embed_batch()` was already available and capable of processing multiple texts in one pass, adopting it reduces embedding overhead and improves throughput while preserving existing behavior.

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q` → **489 passed, 4 skipped**
- [x] `ruff check src/ tests/` → **All checks passed**
- [x] `ruff format --check src/ tests/` → **109 files already formatted**

## Checklist

- [x] I linked an issue or explained why one is not needed. *(Batch embedding adoption — sub-issue 1 of 2)*
- [x] I updated docs if user-facing behavior changed. *(No user-facing behavior changed — internal perf path only)*
- [x] I kept the PR focused on one logical change. *(Only `_apply_observation_candidates` + its test file touched)*
- [x] I did not commit secrets, local exports, or generated noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance when processing conversations with multiple nodes by batching embedding operations when supported by your embedding model
  * Maintains compatibility with embedding backends that don't support batch operations through graceful fallback to per-node processing

* **Tests**
  * Added comprehensive test coverage for batch embedding functionality and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->