### PR TITLE
ci: add VS Code extension build validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,27 @@ jobs:
         run: |
           pip install twine
           twine check dist/*
+
+  # ── VS Code extension ────────────────────────────────────────────────────
+  vscode-extension:
+    name: VS Code extension validation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/vscode-extension
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/vscode-extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile extension
+        run: npm run compile


### PR DESCRIPTION
## Summary
closes #172 
### What changed?

Added a VS Code extension validation job to the existing CI workflow.

The new job:

* Uses Node.js 20
* Installs extension dependencies with `npm ci`
* Compiles the extension using `npm run compile`
* Runs automatically as part of the existing CI workflow

### Why was it needed?

The repository already validates and packages the VS Code extension during release workflows, but extension builds were not validated during normal CI runs.

This could allow extension-specific build regressions to go unnoticed until release time. Adding build validation to CI provides earlier feedback on pull requests and helps ensure the extension remains buildable as changes are introduced.

## Testing

* [x] `WAGGLE_MODEL=deterministic pytest -q`
* [x] `ruff check src/ tests/`
* [x] `ruff format --check src/ tests/`

## Checklist

* [x] I linked an issue or explained why one is not needed.
* [ ] I updated docs if user-facing behavior changed.
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration pipeline to include automated validation of the VS Code extension build and compilation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->