### PR TITLE
fix(evidence): support disambiguating repeated evidence spans

### DIFF
--- a/src/waggle/evidence.py
+++ b/src/waggle/evidence.py
@@ -57,8 +57,9 @@ def build_observation_evidence(
     turn_index: int,
     observed_at: datetime,
     session_id: str = "",
+    search_start: int = 0,
 ) -> EvidenceRecord:
-    start = transcript.find(source_text)
+    start = transcript.find(source_text, search_start)
     if start < 0:
         start = None
         end = None

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from waggle.evidence import build_observation_evidence
+
+
+def test_build_observation_evidence_repeated_snippet():
+    transcript = "hello world hello world"
+
+    evidence = build_observation_evidence(
+        transcript=transcript,
+        source_text="hello world",
+        speaker="user",
+        turn_index=0,
+        observed_at=datetime.now(),
+        search_start=12,
+    )
+
+    assert evidence.source_span_start == 12
+    assert evidence.source_span_end == 23
+
+
+def test_build_observation_evidence_not_found():
+    evidence = build_observation_evidence(
+        transcript="hello world",
+        source_text="missing text",
+        speaker="user",
+        turn_index=0,
+        observed_at=datetime.now(),
+    )
+
+    assert evidence.source_span_start is None
+    assert evidence.source_span_end is None


### PR DESCRIPTION
## Summary

* Added an optional `search_start: int = 0` parameter to `build_observation_evidence`.
* Updated evidence lookup to use `transcript.find(source_text, search_start)` so callers can target the intended occurrence when the same text appears multiple times in a transcript.
* Added tests covering both repeated-snippet resolution and the not-found case.

### Why was it needed?

`str.find()` always returns the first occurrence. When `source_text` appears more than once in a transcript, the recorded evidence span can point to the wrong occurrence. This change makes the intended occurrence reachable while preserving existing behavior when the text is not found.

## Testing

* [x] `python -m pytest tests/test_evidence.py -v`
* [x] `ruff check src/ tests/`
* [x] `ruff format --check src/ tests/`

## Checklist

* [x] I linked an issue or explained why one is not needed. (#118)
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.

## Files Changed

* `src/waggle/evidence.py`
* `tests/test_evidence.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transcript searching to locate text snippets starting from a specified position, improving accuracy when handling repeated text occurrences.

* **Tests**
  * Added unit tests for snippet search functionality, covering cases with repeated occurrences and missing text scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->