### PR TITLE
fix(config): raise ValidationFailure for malformed numeric env vars

### DIFF
--- a/src/waggle/config.py
+++ b/src/waggle/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import os
 import tomllib
 from dataclasses import dataclass
@@ -54,10 +55,14 @@ def _parse_int(name: str, value: str) -> int:
 
 def _parse_float(name: str, value: str) -> float:
     try:
-        return float(value)
+        parsed = float(value)
     except ValueError as exc:
         raise ValidationFailure(f"{name} must be a float, got '{value}'.") from exc
 
+    if not math.isfinite(parsed):
+        raise ValidationFailure(f"{name} must be a finite float, got '{value}'.")
+
+    return parsed
 
 @dataclass(slots=True)
 class AppConfig:
@@ -105,7 +110,15 @@ class AppConfig:
     def from_env(cls) -> AppConfig:
         # Render (and other PaaS providers) commonly inject a dynamic `PORT` env var.
         # Prefer `WAGGLE_HTTP_PORT` when set, otherwise fall back to `PORT`.
-        resolved_http_port = os.environ.get("WAGGLE_HTTP_PORT") or os.environ.get("PORT") or "8080"
+        if os.environ.get("WAGGLE_HTTP_PORT") is not None:
+            http_port_name = "WAGGLE_HTTP_PORT"
+            resolved_http_port = os.environ["WAGGLE_HTTP_PORT"]
+        elif os.environ.get("PORT") is not None:
+            http_port_name = "PORT"
+            resolved_http_port = os.environ["PORT"]
+        else:
+            http_port_name = "WAGGLE_HTTP_PORT"
+            resolved_http_port = "8080"
         config = cls(
             backend=os.environ.get("WAGGLE_BACKEND", "sqlite").strip().lower(),
             transport=os.environ.get("WAGGLE_TRANSPORT", "stdio").strip().lower(),
@@ -114,7 +127,7 @@ class AppConfig:
             default_tenant_id=os.environ.get("WAGGLE_DEFAULT_TENANT_ID", "local-default").strip(),
             http_host=os.environ.get("WAGGLE_HTTP_HOST", "0.0.0.0"),
             http_port=_parse_int(
-                "WAGGLE_HTTP_PORT",
+                http_port_name,
                 resolved_http_port,
             ),
             log_level=os.environ.get("WAGGLE_LOG_LEVEL", "INFO"),

--- a/src/waggle/config.py
+++ b/src/waggle/config.py
@@ -45,6 +45,20 @@ def resolve_default_db_path() -> str:
     return DEFAULT_DB_PATH
 
 
+def _parse_int(name: str, value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValidationFailure(f"{name} must be an integer, got '{value}'.") from exc
+
+
+def _parse_float(name: str, value: str) -> float:
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ValidationFailure(f"{name} must be a float, got '{value}'.") from exc
+
+
 @dataclass(slots=True)
 class AppConfig:
     backend: str
@@ -99,35 +113,64 @@ class AppConfig:
             db_path=os.environ.get("WAGGLE_DB_PATH") or resolve_default_db_path(),
             default_tenant_id=os.environ.get("WAGGLE_DEFAULT_TENANT_ID", "local-default").strip(),
             http_host=os.environ.get("WAGGLE_HTTP_HOST", "0.0.0.0"),
-            http_port=int(resolved_http_port),
+            http_port=_parse_int(
+                "WAGGLE_HTTP_PORT",
+                resolved_http_port,
+            ),
             log_level=os.environ.get("WAGGLE_LOG_LEVEL", "INFO"),
-            rate_limit_rpm=int(os.environ.get("WAGGLE_RATE_LIMIT_RPM", "120")),
-            write_rate_limit_rpm=int(os.environ.get("WAGGLE_WRITE_RATE_LIMIT_RPM", "60")),
-            max_concurrent_requests=int(os.environ.get("WAGGLE_MAX_CONCURRENT_REQUESTS", "8")),
-            max_payload_bytes=int(os.environ.get("WAGGLE_MAX_PAYLOAD_BYTES", str(1024 * 1024))),
-            request_timeout_seconds=int(os.environ.get("WAGGLE_REQUEST_TIMEOUT_SECONDS", "30")),
-            recency_half_life_days=float(os.environ.get("WAGGLE_RECENCY_HALF_LIFE_DAYS", "30.0")),
-            hybrid_vector_weight=float(os.environ.get("WAGGLE_HYBRID_VECTOR_WEIGHT", "1.0")),
-            hybrid_bm25_weight=float(os.environ.get("WAGGLE_HYBRID_BM25_WEIGHT", "1.0")),
-            hybrid_graph_weight=float(os.environ.get("WAGGLE_HYBRID_GRAPH_WEIGHT", "1.0")),
-            hybrid_recency_weight=float(os.environ.get("WAGGLE_HYBRID_RECENCY_WEIGHT", "1.0")),
+            rate_limit_rpm=_parse_int("WAGGLE_RATE_LIMIT_RPM", os.environ.get("WAGGLE_RATE_LIMIT_RPM", "120")),
+            write_rate_limit_rpm=_parse_int(
+                "WAGGLE_WRITE_RATE_LIMIT_RPM", os.environ.get("WAGGLE_WRITE_RATE_LIMIT_RPM", "60")
+            ),
+            max_concurrent_requests=_parse_int(
+                "WAGGLE_MAX_CONCURRENT_REQUESTS", os.environ.get("WAGGLE_MAX_CONCURRENT_REQUESTS", "8")
+            ),
+            max_payload_bytes=_parse_int(
+                "WAGGLE_MAX_PAYLOAD_BYTES", os.environ.get("WAGGLE_MAX_PAYLOAD_BYTES", str(1024 * 1024))
+            ),
+            request_timeout_seconds=_parse_int(
+                "WAGGLE_REQUEST_TIMEOUT_SECONDS", os.environ.get("WAGGLE_REQUEST_TIMEOUT_SECONDS", "30")
+            ),
+            recency_half_life_days=_parse_float(
+                "WAGGLE_RECENCY_HALF_LIFE_DAYS", os.environ.get("WAGGLE_RECENCY_HALF_LIFE_DAYS", "30.0")
+            ),
+            hybrid_vector_weight=_parse_float(
+                "WAGGLE_HYBRID_VECTOR_WEIGHT", os.environ.get("WAGGLE_HYBRID_VECTOR_WEIGHT", "1.0")
+            ),
+            hybrid_bm25_weight=_parse_float(
+                "WAGGLE_HYBRID_BM25_WEIGHT", os.environ.get("WAGGLE_HYBRID_BM25_WEIGHT", "1.0")
+            ),
+            hybrid_graph_weight=_parse_float(
+                "WAGGLE_HYBRID_GRAPH_WEIGHT", os.environ.get("WAGGLE_HYBRID_GRAPH_WEIGHT", "1.0")
+            ),
+            hybrid_recency_weight=_parse_float(
+                "WAGGLE_HYBRID_RECENCY_WEIGHT", os.environ.get("WAGGLE_HYBRID_RECENCY_WEIGHT", "1.0")
+            ),
             hybrid_rerank_enabled=os.environ.get("WAGGLE_HYBRID_RERANK_ENABLED", "false").strip().lower() == "true",
             hybrid_rerank_model=os.environ.get("WAGGLE_HYBRID_RERANK_MODEL", "claude-3-5-sonnet-latest").strip(),
-            hybrid_rerank_top_k_in=int(os.environ.get("WAGGLE_HYBRID_RERANK_TOP_K_IN", "20")),
-            hybrid_rerank_top_k_out=int(os.environ.get("WAGGLE_HYBRID_RERANK_TOP_K_OUT", "5")),
+            hybrid_rerank_top_k_in=_parse_int(
+                "WAGGLE_HYBRID_RERANK_TOP_K_IN", os.environ.get("WAGGLE_HYBRID_RERANK_TOP_K_IN", "20")
+            ),
+            hybrid_rerank_top_k_out=_parse_int(
+                "WAGGLE_HYBRID_RERANK_TOP_K_OUT", os.environ.get("WAGGLE_HYBRID_RERANK_TOP_K_OUT", "5")
+            ),
             export_dir=os.environ.get("WAGGLE_EXPORT_DIR"),
             neo4j_uri=os.environ.get("WAGGLE_NEO4J_URI", "").strip(),
             neo4j_username=os.environ.get("WAGGLE_NEO4J_USERNAME", "").strip(),
             neo4j_password=os.environ.get("WAGGLE_NEO4J_PASSWORD", ""),
             neo4j_database=os.environ.get("WAGGLE_NEO4J_DATABASE", "").strip(),
             retention_enabled=os.environ.get("WAGGLE_RETENTION_ENABLED", "false").strip().lower() == "true",
-            retention_days=int(os.environ.get("WAGGLE_RETENTION_DAYS", "90")),
-            retention_prune_interval_hours=int(os.environ.get("WAGGLE_RETENTION_PRUNE_INTERVAL_HOURS", "24")),
+            retention_days=_parse_int("WAGGLE_RETENTION_DAYS", os.environ.get("WAGGLE_RETENTION_DAYS", "90")),
+            retention_prune_interval_hours=_parse_int(
+                "WAGGLE_RETENTION_PRUNE_INTERVAL_HOURS", os.environ.get("WAGGLE_RETENTION_PRUNE_INTERVAL_HOURS", "24")
+            ),
             startup_mode=os.environ.get("WAGGLE_STARTUP_MODE", STARTUP_MODE_NORMAL).strip().lower(),
             api_key_environment=os.environ.get("WAGGLE_API_KEY_ENVIRONMENT", "test").strip().lower(),
             tiered_retrieval=os.environ.get("WAGGLE_TIERED_RETRIEVAL", "false").strip().lower() == "true",
-            tiered_retrieval_top_k_windows=int(os.environ.get("WAGGLE_TIERED_TOP_K_WINDOWS", "3")),
-            dedup_threshold=float(os.environ.get("WAGGLE_DEDUP_THRESHOLD", "0.88")),
+            tiered_retrieval_top_k_windows=_parse_int(
+                "WAGGLE_TIERED_TOP_K_WINDOWS", os.environ.get("WAGGLE_TIERED_TOP_K_WINDOWS", "3")
+            ),
+            dedup_threshold=_parse_float("WAGGLE_DEDUP_THRESHOLD", os.environ.get("WAGGLE_DEDUP_THRESHOLD", "0.88")),
         )
         config.validate()
         return config

--- a/src/waggle/config.py
+++ b/src/waggle/config.py
@@ -64,6 +64,7 @@ def _parse_float(name: str, value: str) -> float:
 
     return parsed
 
+
 @dataclass(slots=True)
 class AppConfig:
     backend: str

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -12,7 +12,11 @@ from starlette.testclient import TestClient
 import waggle
 from waggle.auth import hash_api_key, verify_api_key
 from waggle.config import AppConfig
-from waggle.errors import AuthenticationError, RateLimitExceededError
+from waggle.errors import (
+    AuthenticationError,
+    RateLimitExceededError,
+    ValidationFailure,
+)
 from waggle.graph import MemoryGraph
 from waggle.models import NodeType
 from waggle.rate_limit import RateLimiter
@@ -228,6 +232,30 @@ def test_app_config_disables_hybrid_rerank_by_default(monkeypatch: pytest.Monkey
 
     assert config.hybrid_rerank_enabled is False
     assert config.hybrid_rerank_model == "claude-3-5-sonnet-latest"
+
+
+def test_app_config_invalid_http_port_raises_validation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WAGGLE_HTTP_PORT", "abc")
+
+    with pytest.raises(
+        ValidationFailure,
+        match="WAGGLE_HTTP_PORT must be an integer",
+    ):
+        AppConfig.from_env()
+
+
+def test_app_config_invalid_dedup_threshold_raises_validation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WAGGLE_DEDUP_THRESHOLD", "abc")
+
+    with pytest.raises(
+        ValidationFailure,
+        match="WAGGLE_DEDUP_THRESHOLD must be a float",
+    ):
+        AppConfig.from_env()
 
 
 def test_waggle_unknown_lazy_export_raises_attribute_error() -> None:


### PR DESCRIPTION
## Summary

* What changed?

Added `_parse_int()` and `_parse_float()` helpers in `config.py` to validate numeric environment variables and raise `ValidationFailure` with clear error messages instead of leaking raw `ValueError` exceptions.

Updated `AppConfig.from_env()` to use these helpers for integer and float environment variable parsing.

Added regression tests covering malformed integer and float environment variables.

* Why was it needed?

Previously, malformed numeric environment variables such as `WAGGLE_HTTP_PORT=abc` caused a raw `ValueError` and stack trace, making it difficult for users to identify which configuration value was invalid.

This change raises `ValidationFailure` with a clear message naming the offending environment variable and value, matching the existing configuration validation style.

## Testing

* [x] `WAGGLE_MODEL=deterministic pytest -q`
* [x] `ruff check src/ tests/`
* [x] `ruff format --check src/ tests/`

## Checklist

* [x] I linked an issue or explained why one is not needed.
* [x] Updation of docs is not required
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.

Closes #109



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric environment variables now produce clear, field-specific validation errors for invalid integers/floats; non-finite float values (NaN/inf) are rejected. Empty HTTP port variables are treated as present and validated rather than silently falling back, improving startup validation and error clarity.

* **Tests**
  * Added tests to confirm invalid integer/float config values raise the expected validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->