### PR TITLE
fix: improve subprocess failure handling in comprehensive feature demo

### DIFF
--- a/scripts/comprehensive_feature_demo.py
+++ b/scripts/comprehensive_feature_demo.py
@@ -86,15 +86,35 @@ async def run_demo() -> tuple[list[dict[str, Any]], str]:
     logs: list[dict[str, Any]] = []
 
     # CLI features guide (outside MCP tool call)
-    cli = subprocess.run(
-        [sys.executable, "-m", "waggle.server", "features"],
-        cwd=str(ROOT),
-        env=build_env(DB_PATH),
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    features_output = (cli.stdout or "") + ("\n" + cli.stderr if cli.stderr else "")
+    try:
+        cli = subprocess.run(
+            [sys.executable, "-m", "waggle.server", "features"],
+            cwd=str(ROOT),
+            env=build_env(DB_PATH),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        features_output = (
+        (cli.stdout or "")
+        + ("\n" + cli.stderr if cli.stderr else "")
+        )
+
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+        "waggle.server features command timed out after 30 seconds.\n"
+        f"Stdout:\n{exc.stdout or ''}\n"
+        f"Stderr:\n{exc.stderr or ''}"
+    ) from exc
+
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+        "waggle.server features command failed.\n"
+        f"Return code: {exc.returncode}\n"
+        f"Stdout:\n{exc.stdout or ''}\n"
+        f"Stderr:\n{exc.stderr or ''}"
+    ) from exc
 
     server_params = StdioServerParameters(
         command=sys.executable,


### PR DESCRIPTION
## Summary
Improve subprocess reliability and error handling in the comprehensive feature demo script.

This PR fixes silent subprocess failures in the CLI feature execution flow by adding proper error handling, timeout protection, and explicit failure reporting for subprocess.run(...).
Changes made-:

- Replaced check=False with check=True
- Added timeout protection for CLI subprocess execution
- Added explicit handling for: subprocess.TimeoutExpired and subprocess.CalledProcessError
- Improved debugging output by including: return code, stdout and stderr
- Prevented silent setup failures before demo/report generation

These changes make the comprehensive feature demo more deterministic, easier to debug, and safer for CI execution.

Closes #174 

## Testing

- [X] `WAGGLE_MODEL=deterministic pytest -q`
- [X] `ruff check src/ tests/`
- [X] `ruff format --check src/ tests/`

## Checklist

- [X] I linked an issue or explained why one is not needed.
- [ ] I updated docs if user-facing behavior changed.
- [X] I kept the PR focused on one logical change.
- [X] I did not commit secrets, local exports, or generated noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made the feature demonstration workflow stricter by turning subprocess failures into explicit errors, adding a 30s timeout, and surfacing captured output and exit details for easier debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->