### PR TITLE
test(errors): cover code and status_code for WaggleError subclasses

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -31,12 +31,10 @@ EXPECTED_ERROR_METADATA = {
 
 assert set(WaggleError.__subclasses__()) == set(EXPECTED_ERROR_METADATA)
 
+
 @pytest.mark.parametrize(
     ("error_cls", "expected_code", "expected_status_code"),
-    [
-        (cls, code, status)
-        for cls, (code, status) in EXPECTED_ERROR_METADATA.items()
-    ],
+    [(cls, code, status) for cls, (code, status) in EXPECTED_ERROR_METADATA.items()],
 )
 def test_waggle_error_code_and_status_code(
     error_cls,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -13,22 +13,29 @@ from waggle.errors import (
     SchemaVersionError,
     ServiceUnavailableError,
     ValidationFailure,
+    WaggleError,
 )
 
+EXPECTED_ERROR_METADATA = {
+    AuthenticationError: ("authentication_failed", 401),
+    AuthorizationError: ("authorization_failed", 403),
+    RateLimitExceededError: ("rate_limited", 429),
+    PayloadTooLargeError: ("payload_too_large", 413),
+    ServiceUnavailableError: ("service_unavailable", 503),
+    ValidationFailure: ("validation_failed", 400),
+    ConflictResolutionError: ("conflict_resolution_failed", 400),
+    DanglingEdgeError: ("dangling_edge", 400),
+    HashVerificationError: ("hash_verification_failed", 400),
+    SchemaVersionError: ("schema_version_incompatible", 400),
+}
+
+assert set(WaggleError.__subclasses__()) == set(EXPECTED_ERROR_METADATA)
 
 @pytest.mark.parametrize(
     ("error_cls", "expected_code", "expected_status_code"),
     [
-        (AuthenticationError, "authentication_failed", 401),
-        (AuthorizationError, "authorization_failed", 403),
-        (RateLimitExceededError, "rate_limited", 429),
-        (PayloadTooLargeError, "payload_too_large", 413),
-        (ServiceUnavailableError, "service_unavailable", 503),
-        (ValidationFailure, "validation_failed", 400),
-        (ConflictResolutionError, "conflict_resolution_failed", 400),
-        (DanglingEdgeError, "dangling_edge", 400),
-        (HashVerificationError, "hash_verification_failed", 400),
-        (SchemaVersionError, "schema_version_incompatible", 400),
+        (cls, code, status)
+        for cls, (code, status) in EXPECTED_ERROR_METADATA.items()
     ],
 )
 def test_waggle_error_code_and_status_code(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from waggle.errors import (
+    AuthenticationError,
+    AuthorizationError,
+    ConflictResolutionError,
+    DanglingEdgeError,
+    HashVerificationError,
+    PayloadTooLargeError,
+    RateLimitExceededError,
+    SchemaVersionError,
+    ServiceUnavailableError,
+    ValidationFailure,
+)
+
+
+@pytest.mark.parametrize(
+    ("error_cls", "expected_code", "expected_status_code"),
+    [
+        (AuthenticationError, "authentication_failed", 401),
+        (AuthorizationError, "authorization_failed", 403),
+        (RateLimitExceededError, "rate_limited", 429),
+        (PayloadTooLargeError, "payload_too_large", 413),
+        (ServiceUnavailableError, "service_unavailable", 503),
+        (ValidationFailure, "validation_failed", 400),
+        (ConflictResolutionError, "conflict_resolution_failed", 400),
+        (DanglingEdgeError, "dangling_edge", 400),
+        (HashVerificationError, "hash_verification_failed", 400),
+        (SchemaVersionError, "schema_version_incompatible", 400),
+    ],
+)
+def test_waggle_error_code_and_status_code(
+    error_cls,
+    expected_code,
+    expected_status_code,
+) -> None:
+    error = error_cls("test message")
+    assert error.code == expected_code
+    assert error.status_code == expected_status_code


### PR DESCRIPTION
## Summary

### What changed?

* Added a new parametrized test covering every `WaggleError` subclass defined in `src/waggle/errors.py`.
* The test verifies that each subclass exposes the expected `.code` and `.status_code` values.

### Why was it needed?

* The project did not have test coverage validating the error codes and HTTP status codes for `WaggleError` subclasses.
* This test prevents accidental regressions, such as changing a status code or error code string without detection.

## Testing

* [x] `python -m pytest tests/test_errors.py -q`
* [x] `python -m ruff check tests/test_errors.py`
* [x] `python -m ruff format --check tests/test_errors.py`

## Checklist

* [x] Linked to Issue #108.
* [x] I updated docs if user-facing behavior changed. (Not needed; no user-facing behavior changed.)
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added parametrized tests that validate error classes' public codes and HTTP status mappings, and assert the set of exported error types matches expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->