### PR TITLE
bug(config): validate hybrid retrieval weights

### DIFF
--- a/src/waggle/config.py
+++ b/src/waggle/config.py
@@ -169,6 +169,14 @@ class AppConfig:
             raise ValidationFailure("WAGGLE_RETENTION_DAYS must be at least 1.")
         if self.retention_prune_interval_hours < 1:
             raise ValidationFailure("WAGGLE_RETENTION_PRUNE_INTERVAL_HOURS must be at least 1.")
+        if self.hybrid_vector_weight < 0:
+            raise ValidationFailure("WAGGLE_HYBRID_VECTOR_WEIGHT must be non-negative.")
+        if self.hybrid_bm25_weight < 0:
+            raise ValidationFailure("WAGGLE_HYBRID_BM25_WEIGHT must be non-negative.")
+        if self.hybrid_graph_weight < 0:
+            raise ValidationFailure("WAGGLE_HYBRID_GRAPH_WEIGHT must be non-negative.")
+        if self.hybrid_recency_weight < 0:
+            raise ValidationFailure("WAGGLE_HYBRID_RECENCY_WEIGHT must be non-negative.")
 
     def hybrid_retrieval_config(self) -> HybridRetrievalConfig:
         return HybridRetrievalConfig(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from waggle.config import AppConfig
+from waggle.errors import ValidationFailure
+
+
+@pytest.mark.parametrize(
+    ("field_name", "error_message"),
+    [
+        ("hybrid_vector_weight", "WAGGLE_HYBRID_VECTOR_WEIGHT"),
+        ("hybrid_bm25_weight", "WAGGLE_HYBRID_BM25_WEIGHT"),
+        ("hybrid_graph_weight", "WAGGLE_HYBRID_GRAPH_WEIGHT"),
+        ("hybrid_recency_weight", "WAGGLE_HYBRID_RECENCY_WEIGHT"),
+    ],
+)
+def test_negative_hybrid_weights_raise_validation_failure(
+    field_name: str,
+    error_message: str,
+) -> None:
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="test",
+        db_path="test.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+    setattr(config, field_name, -1.0)
+
+    with pytest.raises(ValidationFailure, match=error_message):
+        config.validate()
+
+
+def test_zero_hybrid_weights_are_allowed() -> None:
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="test",
+        db_path="test.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+        hybrid_vector_weight=0.0,
+        hybrid_bm25_weight=0.0,
+        hybrid_graph_weight=0.0,
+        hybrid_recency_weight=0.0,
+    )
+
+    config.validate()


### PR DESCRIPTION
## Summary

### What changed?

* Added validation in `AppConfig.validate()` to reject negative hybrid retrieval weights.
* Added tests covering all hybrid retrieval weight fields:

  * `hybrid_vector_weight`
  * `hybrid_bm25_weight`
  * `hybrid_graph_weight`
  * `hybrid_recency_weight`
* Added a test verifying that zero-valued hybrid weights remain valid.

### Why was it needed?

* Negative hybrid retrieval weights were accepted without validation and could invert the contribution of a retrieval lane, producing unexpected ranking behavior.
* The new validation ensures that hybrid retrieval weights are non-negative while still allowing zero to disable a retrieval lane.

## Testing

* [x] `python -m pytest tests/test_config.py -q`
* [x] `python -m ruff check tests/test_config.py`
* [x] `python -m ruff format --check tests/test_config.py`

## Checklist

* [x] Linked to Issue #110.
* [x] I updated docs if user-facing behavior changed. (Not applicable; no user-facing documentation changes required.)
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.

Closes #110



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now strictly prevents all hybrid search weight parameters from accepting negative values, ensuring proper system configuration and stable operation.

* **Tests**
  * Comprehensive test coverage added for hybrid weight validation to verify that negative values are properly rejected while zero values remain acceptable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->