### PR TITLE
perf(graph): add composite indexes for transcript project and agent queries

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -492,6 +492,8 @@ CREATE INDEX IF NOT EXISTS idx_transcripts_tenant_observed ON transcript_records
 CREATE INDEX IF NOT EXISTS idx_transcripts_tenant_session_turn ON transcript_records(tenant_id, session_id, turn_index);
 CREATE INDEX IF NOT EXISTS idx_transcripts_tenant_content_hash ON transcript_records(tenant_id, content_hash);
 CREATE INDEX IF NOT EXISTS idx_transcripts_tenant_turn_pair ON transcript_records(tenant_id, turn_pair_id);
+CREATE INDEX IF NOT EXISTS idx_transcripts_tenant_project ON transcript_records(tenant_id, project);
+CREATE INDEX IF NOT EXISTS idx_transcripts_tenant_agent ON transcript_records(tenant_id, agent_id);
 CREATE INDEX IF NOT EXISTS idx_nodes_source_turn_pair ON nodes(tenant_id, source_turn_pair_id);
 CREATE INDEX IF NOT EXISTS idx_api_keys_tenant ON api_keys(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash);

--- a/src/waggle/neo4j_graph.py
+++ b/src/waggle/neo4j_graph.py
@@ -342,6 +342,18 @@ class Neo4jMemoryGraph:
             ).consume()
             session.run(
                 """
+                CREATE INDEX waggle_transcript_tenant_project IF NOT EXISTS
+                FOR (t:MemoryTranscript) ON (t.tenant_id, t.project)
+                """
+            ).consume()
+            session.run(
+                """
+                CREATE INDEX waggle_transcript_tenant_agent IF NOT EXISTS
+                FOR (t:MemoryTranscript) ON (t.tenant_id, t.agent_id)
+                """
+            ).consume()
+            session.run(
+                """
                 CREATE INDEX waggle_api_key_hash IF NOT EXISTS
                 FOR (a:GraphApiKey) ON (a.key_hash)
                 """


### PR DESCRIPTION
Closes #200

Adds \idx_transcripts_tenant_project\ and \idx_transcripts_tenant_agent\ to the SQLite schema so \list_transcript_records\ and \count_transcript_records\ can seek via index when filtering by project or agent_id alone. Adds matching indexes to the Neo4j backend.