### PR TITLE
perf(graph): cap replay query rows to avoid scanning entire tenant

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -3781,14 +3781,19 @@ class MemoryGraph:
             elif agent_id.strip():
                 filters.append("agent_id = ?")
                 params.append(agent_id.strip())
+            # Cap the rows fetched so we don't scan and score the entire tenant.
+            # The downstream scorer uses up to max_hits results; read a generous
+            # multiple so semantic ranking still has a good pool to draw from.
+            fetch_limit = min(max(500, max_hits * 4), 5000)
             rows = connection.execute(
                 f"""
                 SELECT id, tenant_id, agent_id, project, session_id, observed_at, turn_index, role, transcript_text, embedding, metadata
                 FROM transcript_records
                 WHERE {" AND ".join(filters)}
                 ORDER BY observed_at DESC, turn_index DESC
+                LIMIT ?
                 """,
-                tuple(params),
+                (*params, fetch_limit),
             ).fetchall()
         if not rows:
             return []
@@ -3863,14 +3868,16 @@ class MemoryGraph:
             elif agent_id.strip():
                 filters.append("agent_id = ?")
                 params.append(agent_id.strip())
+            fetch_limit = 5000
             rows = connection.execute(
                 f"""
                 SELECT id, tenant_id, agent_id, project, session_id, observed_at, turn_index, role, transcript_text, embedding, metadata
                 FROM transcript_records
                 WHERE {" AND ".join(filters)}
                 ORDER BY observed_at DESC, turn_index DESC
+                LIMIT ?
                 """,
-                tuple(params),
+                (*params, fetch_limit),
             ).fetchall()
         if not rows:
             return {}


### PR DESCRIPTION
Closes #198

Add \LIMIT\ clauses to \_query_replay_hits\ and \_query_replay_session_scores\ so they stop fetching and scoring every matching transcript record in the tenant. Combined with the composite indexes added in #200, this ensures query latency scales with the requested scope rather than total tenant history.