### PR TITLE
security(graph_restore): make restore atomic with transaction and validation

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -1031,6 +1031,7 @@ class MemoryGraph:
         groups: list[dict[str, Any]] | None = None,
         collapsed_groups: list[str] | None = None,
         selected_nodes: list[str] | None = None,
+        connection: sqlite3.Connection | None = None,
     ) -> dict[str, Any]:
         normalized_project, normalized_agent, normalized_session = self._normalize_ui_scope(
             project=project, agent_id=agent_id, session_id=session_id
@@ -1048,7 +1049,7 @@ class MemoryGraph:
             "collapsed_groups": collapsed_groups if collapsed_groups is not None else current["collapsed_groups"],
             "selected_nodes": selected_nodes if selected_nodes is not None else current["selected_nodes"],
         }
-        with self._lock, self._connect() as connection:
+        if connection is not None:
             connection.execute(
                 """
                 INSERT INTO graph_ui_state (
@@ -1080,6 +1081,39 @@ class MemoryGraph:
                     utc_now().isoformat(),
                 ),
             )
+        else:
+            with self._lock, self._connect() as active_connection:
+                active_connection.execute(
+                    """
+                    INSERT INTO graph_ui_state (
+                        tenant_id, agent_id, project, session_id,
+                        positions, zoom, viewport, groups_json, collapsed_groups, selected_nodes, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(tenant_id, agent_id, project, session_id)
+                    DO UPDATE SET
+                        positions = excluded.positions,
+                        zoom = excluded.zoom,
+                        viewport = excluded.viewport,
+                        groups_json = excluded.groups_json,
+                        collapsed_groups = excluded.collapsed_groups,
+                        selected_nodes = excluded.selected_nodes,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        self.tenant_id,
+                        normalized_agent,
+                        normalized_project,
+                        normalized_session,
+                        json.dumps(merged["positions"], sort_keys=True),
+                        merged["zoom"],
+                        json.dumps(merged["viewport"], sort_keys=True),
+                        json.dumps(merged["groups"], sort_keys=True),
+                        json.dumps(merged["collapsed_groups"], sort_keys=True),
+                        json.dumps(merged["selected_nodes"], sort_keys=True),
+                        utc_now().isoformat(),
+                    ),
+                )
         return merged
 
     def create_api_key(
@@ -4281,6 +4315,188 @@ class MemoryGraph:
                 connection=connection,
             )
             return node
+
+    def restore_graph(
+        self,
+        *,
+        desired_nodes: dict[str, dict[str, Any]],
+        desired_edges: dict[str, dict[str, Any]],
+        ui: dict[str, Any] | None = None,
+        project: str = "",
+        agent_id: str = "",
+        session_id: str = "",
+    ) -> dict[str, Any]:
+        """Atomically replace the graph scope with a new snapshot.
+
+        Desired nodes/edges are validated for internal consistency first.
+        The entire mutation is wrapped in a single transaction so a failure
+        in any step rolls back all prior changes.
+        """
+        scope_str = f"project={project!r}, agent_id={agent_id!r}, session_id={session_id!r}"
+
+        # -- validate internal consistency before any mutation ---------------
+        desired_node_ids = set(desired_nodes)
+        for eid, edge in desired_edges.items():
+            src = str(edge.get("source_id", "")).strip()
+            tgt = str(edge.get("target_id", "")).strip()
+            if src and src not in desired_node_ids:
+                raise ValueError(f"Edge {eid} references unknown source node {src} in scope {scope_str}.")
+            if tgt and tgt not in desired_node_ids:
+                raise ValueError(f"Edge {eid} references unknown target node {tgt} in scope {scope_str}.")
+
+        with self._lock, self._connect() as connection:
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+
+                # 1. Load current state within this connection
+                current = self._build_backup_snapshot(connection)
+                current_nodes = {
+                    str(n["id"]).strip(): n
+                    for n in current.get("nodes", [])
+                    if str(n.get("id", "")).strip()
+                    and (
+                        not project or n.get("project", "") == project
+                    )
+                    and (
+                        not agent_id or n.get("agent_id", "") == agent_id
+                    )
+                    and (
+                        not session_id or n.get("session_id", "") == session_id
+                    )
+                }
+                current_edge_ids = {
+                    str(e["id"]).strip()
+                    for e in current.get("edges", [])
+                    if str(e.get("id", "")).strip()
+                }
+
+                # 2. Delete edges no longer desired
+                for eid in current_edge_ids:
+                    if eid not in desired_edges:
+                        connection.execute(
+                            "DELETE FROM edges WHERE id = ? AND tenant_id = ?",
+                            (eid, self.tenant_id),
+                        )
+
+                # 3. Delete nodes no longer desired
+                for nid in list(current_nodes):
+                    if nid not in desired_nodes:
+                        connection.execute(
+                            "DELETE FROM nodes WHERE id = ? AND tenant_id = ?",
+                            (nid, self.tenant_id),
+                        )
+
+                # 4. Upsert nodes
+                for nid, node_payload in desired_nodes.items():
+                    tags = [str(t).strip() for t in node_payload.get("tags", []) if str(t).strip()]
+                    if nid in current_nodes:
+                        updates: list[str] = []
+                        params: list[Any] = []
+                        for field in ("label", "content", "agent_id", "project", "session_id"):
+                            val = node_payload.get(field)
+                            if val is not None:
+                                updates.append(f"{field} = ?")
+                                params.append(str(val).strip() if isinstance(val, str) else val)
+                        if node_payload.get("node_type"):
+                            updates.append("node_type = ?")
+                            params.append(str(node_payload["node_type"]).strip())
+                        if tags:
+                            updates.append("tags = ?")
+                            params.append(json.dumps(tags))
+                        if node_payload.get("metadata"):
+                            updates.append("metadata = ?")
+                            params.append(json.dumps(node_payload["metadata"]) if isinstance(node_payload["metadata"], dict) else str(node_payload["metadata"]))
+                        if updates:
+                            params.append(nid)
+                            params.append(self.tenant_id)
+                            connection.execute(
+                                f"UPDATE nodes SET {', '.join(updates)} WHERE id = ? AND tenant_id = ?",
+                                tuple(params),
+                            )
+                    else:
+                        node_type_val = str(node_payload.get("node_type", "note")).strip() or "note"
+                        connection.execute(
+                            """
+                            INSERT OR IGNORE INTO nodes
+                                (id, tenant_id, agent_id, project, session_id, label, content, node_type, tags, metadata)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                            (
+                                nid,
+                                self.tenant_id,
+                                str(node_payload.get("agent_id", agent_id)).strip(),
+                                str(node_payload.get("project", project)).strip(),
+                                str(node_payload.get("session_id", session_id)).strip(),
+                                str(node_payload.get("label", "")).strip(),
+                                str(node_payload.get("content", "")).strip(),
+                                node_type_val,
+                                json.dumps(tags),
+                                json.dumps(node_payload.get("metadata", {})),
+                            ),
+                        )
+
+                # 5. Upsert edges
+                for eid, edge_payload in desired_edges.items():
+                    src = str(edge_payload.get("source_id", "")).strip()
+                    tgt = str(edge_payload.get("target_id", "")).strip()
+                    rel = str(edge_payload.get("relationship", "")).strip()
+                    w = edge_payload.get("weight")
+                    weight_val = float(w) if w is not None else 1.0
+                    if eid in current_edge_ids:
+                        connection.execute(
+                            """
+                            UPDATE edges
+                            SET source_id = ?, target_id = ?, relationship = ?, weight = ?
+                            WHERE id = ? AND tenant_id = ?
+                            """,
+                            (src, tgt, rel, weight_val, eid, self.tenant_id),
+                        )
+                    else:
+                        connection.execute(
+                            """
+                            INSERT OR IGNORE INTO edges
+                                (id, tenant_id, source_id, target_id, relationship, weight, metadata, created_at)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                            (
+                                eid,
+                                self.tenant_id,
+                                src,
+                                tgt,
+                                rel,
+                                weight_val,
+                                json.dumps(edge_payload.get("metadata", {})),
+                                utc_now().isoformat(),
+                            ),
+                        )
+
+                # 6. Save UI state
+                ui_payload = ui or {}
+                self.save_ui_state(
+                    project=project,
+                    agent_id=agent_id,
+                    session_id=session_id,
+                    positions=ui_payload.get("positions"),
+                    zoom=float(ui_payload["zoom"]) if "zoom" in ui_payload and ui_payload.get("zoom") is not None else None,
+                    viewport=ui_payload.get("viewport"),
+                    groups=ui_payload.get("groups"),
+                    collapsed_groups=ui_payload.get("collapsed_groups"),
+                    selected_nodes=ui_payload.get("selected_nodes"),
+                    connection=connection,
+                )
+
+                connection.execute("COMMIT")
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+
+        restored = self.get_graph_snapshot(project=project, agent_id=agent_id, session_id=session_id)
+        ui_state = self.get_ui_state(project=project, agent_id=agent_id, session_id=session_id)
+        return {
+            "nodes": restored.get("nodes", []),
+            "edges": restored.get("edges", []),
+            "ui": ui_state,
+        }
 
     def clear_session(self, *, session_id: str) -> ClearScopeResult:
         normalized_session = session_id.strip()

--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -4354,20 +4354,12 @@ class MemoryGraph:
                     str(n["id"]).strip(): n
                     for n in current.get("nodes", [])
                     if str(n.get("id", "")).strip()
-                    and (
-                        not project or n.get("project", "") == project
-                    )
-                    and (
-                        not agent_id or n.get("agent_id", "") == agent_id
-                    )
-                    and (
-                        not session_id or n.get("session_id", "") == session_id
-                    )
+                    and (not project or n.get("project", "") == project)
+                    and (not agent_id or n.get("agent_id", "") == agent_id)
+                    and (not session_id or n.get("session_id", "") == session_id)
                 }
                 current_edge_ids = {
-                    str(e["id"]).strip()
-                    for e in current.get("edges", [])
-                    if str(e.get("id", "")).strip()
+                    str(e["id"]).strip() for e in current.get("edges", []) if str(e.get("id", "")).strip()
                 }
 
                 # 2. Delete edges no longer desired
@@ -4405,7 +4397,11 @@ class MemoryGraph:
                             params.append(json.dumps(tags))
                         if node_payload.get("metadata"):
                             updates.append("metadata = ?")
-                            params.append(json.dumps(node_payload["metadata"]) if isinstance(node_payload["metadata"], dict) else str(node_payload["metadata"]))
+                            params.append(
+                                json.dumps(node_payload["metadata"])
+                                if isinstance(node_payload["metadata"], dict)
+                                else str(node_payload["metadata"])
+                            )
                         if updates:
                             params.append(nid)
                             params.append(self.tenant_id)
@@ -4477,7 +4473,9 @@ class MemoryGraph:
                     agent_id=agent_id,
                     session_id=session_id,
                     positions=ui_payload.get("positions"),
-                    zoom=float(ui_payload["zoom"]) if "zoom" in ui_payload and ui_payload.get("zoom") is not None else None,
+                    zoom=float(ui_payload["zoom"])
+                    if "zoom" in ui_payload and ui_payload.get("zoom") is not None
+                    else None,
                     viewport=ui_payload.get("viewport"),
                     groups=ui_payload.get("groups"),
                     collapsed_groups=ui_payload.get("collapsed_groups"),

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3331,7 +3331,6 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
             "session_id": str(payload.get("session_id", "")).strip(),
         }
         graph, _ = _require_http_scope(request, "graph:write")
-        current = graph.get_graph_snapshot(**scope)
         desired_nodes = {
             str(node.get("id", "")).strip(): node
             for node in payload.get("nodes", [])
@@ -3342,86 +3341,14 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
             for edge in payload.get("edges", [])
             if str(edge.get("id", "")).strip()
         }
-        current_nodes = {
-            str(node.get("id", "")).strip(): node
-            for node in current.get("nodes", [])
-            if str(node.get("id", "")).strip()
-        }
-        current_edges = {
-            str(edge.get("id", "")).strip(): edge
-            for edge in current.get("edges", [])
-            if str(edge.get("id", "")).strip()
-        }
-
-        for edge_id in list(current_edges):
-            if edge_id not in desired_edges:
-                graph.delete_edge(edge_id=edge_id)
-
-        for node_id in list(current_nodes):
-            if node_id not in desired_nodes:
-                graph.delete_node(node_id=node_id)
-
-        for node_id, node_payload in desired_nodes.items():
-            tags = [str(tag).strip() for tag in node_payload.get("tags", []) if str(tag).strip()]
-            if node_id in current_nodes:
-                graph.update_node(
-                    node_id=node_id,
-                    label=node_payload.get("label"),
-                    content=node_payload.get("content"),
-                    tags=tags,
-                )
-                continue
-            graph.add_node(
-                node_id=node_id,
-                label=str(node_payload.get("label", "")).strip(),
-                content=str(node_payload.get("content", "")).strip(),
-                node_type=NodeType(str(node_payload.get("node_type", "note")).strip() or "note"),
-                tags=tags,
-                agent_id=str(node_payload.get("agent_id", scope["agent_id"])).strip(),
-                project=str(node_payload.get("project", scope["project"])).strip(),
-                session_id=str(node_payload.get("session_id", scope["session_id"])).strip(),
-            )
-
-        for edge_id, edge_payload in desired_edges.items():
-            if edge_id in current_edges:
-                graph.update_edge(
-                    edge_id=edge_id,
-                    source_id=str(edge_payload.get("source_id", "")).strip() or None,
-                    target_id=str(edge_payload.get("target_id", "")).strip() or None,
-                    relationship=str(edge_payload.get("relationship", "")).strip() or None,
-                    weight=float(edge_payload["weight"])
-                    if "weight" in edge_payload and edge_payload.get("weight") is not None
-                    else None,
-                )
-                continue
-            graph.add_edge(
-                edge_id=edge_id,
-                source_id=str(edge_payload.get("source_id", "")).strip(),
-                target_id=str(edge_payload.get("target_id", "")).strip(),
-                relationship=str(edge_payload.get("relationship", "")).strip(),
-                weight=float(edge_payload.get("weight", 1.0)),
-            )
-
         ui = payload.get("ui", {}) or {}
-        saved = graph.save_ui_state(
-            project=scope["project"],
-            agent_id=scope["agent_id"],
-            session_id=scope["session_id"],
-            positions=ui.get("positions"),
-            zoom=float(ui["zoom"]) if "zoom" in ui and ui.get("zoom") is not None else None,
-            viewport=ui.get("viewport"),
-            groups=ui.get("groups"),
-            collapsed_groups=ui.get("collapsed_groups"),
-            selected_nodes=ui.get("selected_nodes"),
+        result = graph.restore_graph(
+            desired_nodes=desired_nodes,
+            desired_edges=desired_edges,
+            ui=ui,
+            **scope,
         )
-        restored = graph.get_graph_snapshot(**scope)
-        return JSONResponse(
-            {
-                "nodes": restored.get("nodes", []),
-                "edges": restored.get("edges", []),
-                "ui": saved,
-            }
-        )
+        return JSONResponse(result)
 
     async def graph_create_node(request: Request) -> Response:
         payload = await request.json()


### PR DESCRIPTION
Closes #195

Replace the fragile multi-call restore in \graph_restore\ with a new \estore_graph()\ method on \MemoryGraph\ that:

1. **Validates first** — checks every edge endpoint exists in the desired node set before any mutation
2. **Runs in a single transaction** — \BEGIN IMMEDIATE\ / \COMMIT\ / \ROLLBACK\ so partial failures cannot leave data in an inconsistent state  
3. **Accepts a connection parameter** — refactors \save_ui_state\ to participate in the same transaction when a connection is passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added atomic graph restoration for consistent state synchronization across project and session scopes.

* **Improvements**
  * Enhanced database transaction handling for more reliable UI state persistence.
  * Optimized graph reconciliation operations to improve consistency and reliability during state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->