### PR TITLE
Perf/model onnx export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ antigravity-waggle-export.json
 antigravity-waggle-export.md
 PAPER_SUMMARY.md
 waggle_complete_paper.tex
+onnx_model/

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ antigravity-waggle-export.json
 antigravity-waggle-export.md
 PAPER_SUMMARY.md
 waggle_complete_paper.tex
-onnx_model/
+onnx_model_export/

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -1,0 +1,90 @@
+"""
+waggle-mcp export onnx
+============================
+Loads the all-MiniLM-L6-v2 model via SentenceTransformer and exports it to ONNX format (either via backend="onnx" or optimum).
+
+Usage
+-----
+
+Requirements: pip install --upgrade onnx onnxscript sentence-transformers optimum[onnx]
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import onnx
+import onnxruntime
+from waggle.embeddings import EmbeddingModel
+import numpy as np
+import time
+from transformers import AutoTokenizer
+
+# ---------------------------------------------------------------------------
+# Load the model
+# ---------------------------------------------------------------------------
+embed_model = EmbeddingModel("deterministic")
+
+# ---------------------------------------------------------------------------
+# Export as ONNX + saving ONNX
+# ---------------------------------------------------------------------------
+onnx_program = torch.onnx.export(model=embed_model, dynamo=True)
+onnx_program.save("embeddings_model.onnx")
+
+# ---------------------------------------------------------------------------
+# Comparison - original model vs. ONNX-loaded model
+# ---------------------------------------------------------------------------
+
+contents = [
+    "We decided to use PostgreSQL as the primary database for the Acme web app. PostgreSQL offers ACID compliance, rich JSON support, and scales well for our expected load.",
+    "PostgreSQL was chosen because the team has prior experience with it, it supports JSONB for flexible schema evolution, and the managed RDS offering fits our AWS deployment plan.",
+    "For local development, we switched to SQLite to eliminate the Docker dependency and speed up onboarding. Production still targets PostgreSQL.",
+    "New engineers were spending 30+ minutes setting up Postgres locally. SQLite requires zero setup and the ORM abstracts the difference.",
+    "Final decision: use PostgreSQL in all environments (dev, staging, prod) via Docker Compose. The SQLite shortcut caused subtle migration drift. We added a one-command `make dev-up` to remove the setup friction.",
+    "SQLite and PostgreSQL handle NULL semantics, JSON operators, and transaction isolation differently. Two bugs in staging traced back to SQLite-only dev. Docker Compose with a health-check solves onboarding without sacrificing parity.",
+    "We will use Auth0 for authentication and SSO. Rolling our own OAuth is out of scope for v1. Auth0 supports SAML for enterprise customers.",
+    "The team has no dedicated security engineer. Auth0 handles MFA, breach detection, and compliance certifications. Estimated 3-week saving vs. building in-house.",
+    "We will deploy the web app on AWS ECS using Fargate. No EC2 instance management, auto-scaling, and integrates with our existing AWS account.",
+    "The team is 4 engineers. Fargate means no patching, no AMI management, and cost scales to zero when idle. Kubernetes was considered but deemed over-engineered for v1.",
+    "The team prefers TypeScript over plain JavaScript for all frontend work. Strict mode enabled. No `any` without a comment explaining why.",
+    "The team prefers dark mode as the default UI theme. Light mode should be available as a toggle but dark is the out-of-box experience.",
+    "The team strongly prefers small, focused PRs — ideally under 400 lines. Large PRs block review and increase merge conflict risk. Feature flags are the preferred mechanism for shipping incomplete features.",
+    "The Acme web app team has 4 engineers: 2 full-stack, 1 backend, 1 frontend/design. No dedicated DevOps or security engineer.",
+    "The target public launch date is end of Q3. The v1 scope is intentionally narrow: auth, core CRUD, and basic reporting. v2 will add integrations and advanced analytics."
+]
+
+# Option 1: original embedding model created from the EmbeddingModel class, embeddings extracted one by one
+embeddings_original = np.array([])
+start_time = time.perf_counter()
+for c in contents:
+    e = embed_model.embed(c)
+    embeddings_original = np.append(embeddings_original, e)
+end_time = time.perf_counter()
+elapsed_time = end_time - start_time
+print(f"Original model: embeddings obtained in {elapsed_time:.6f} seconds")
+
+# Option 2: original embedding model created from the EmbeddingModel class, batch-processed embeddings extraction
+start_time = time.perf_counter()
+embeddings_batched = embed_model.embed_batch(contents)
+end_time = time.perf_counter()
+elapsed_time = end_time - start_time
+print(f"Original model with batching: embeddings obtained in {elapsed_time:.6f} seconds")
+
+# Loading the saved ONNX file
+onnx_model = onnx.load("embeddings_model.onnx")
+onnx.checker.check_model(onnx_model)
+tokenizer = AutoTokenizer.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
+model_inputs = [tokenizer(c, return_tensors="np") for c in contents]
+ort_session = onnxruntime.InferenceSession(
+    "embeddings_model.onnx", providers=["CPUExecutionProvider"]
+)
+onnxruntime_input = {input_arg.name: input_value for input_arg, input_value in zip(ort_session.get_inputs(), model_inputs)}
+
+# Option 3: loaded ONNX model, embeddings extracted one by one
+start_time = time.perf_counter()
+output_onnx = onnx_model.run(None, dict(model_inputs))
+end_time = time.perf_counter()
+elapsed_time = end_time - start_time
+print(f"Original model: embeddings obtained in {elapsed_time:.6f} seconds")
+
+
+

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -1,40 +1,49 @@
 """
-waggle-mcp export onnx
-============================
-Loads the all-MiniLM-L6-v2 model via SentenceTransformer and exports it to ONNX format (either via backend="onnx" or optimum).
+scripts/export_onnx.py
 
-Usage
------
+Part of ONNX Runtime migration (Issue #121).
+Exports `all-MiniLM-L6-v2` to ONNX and validates numerical parity and timing against PyTorch.
 
-Requirements: pip install --upgrade onnx onnxscript sentence-transformers optimum[onnx]
+Requirements:
+    pip install "sentence-transformers>=2.7.0" "optimum[onnxruntime]"
 """
 
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
-import onnx
-import onnxruntime
-from waggle.embeddings import EmbeddingModel
-import numpy as np
+import os
 import time
-from transformers import AutoTokenizer
+import shutil
+import numpy as np
+from pathlib import Path
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.util import cos_sim
 
-# ---------------------------------------------------------------------------
-# Load the model
-# ---------------------------------------------------------------------------
-embed_model = EmbeddingModel("deterministic")
+def get_dir_size_mb(path: str) -> float:
+    total_size = sum(f.stat().st_size for f in Path(path).glob('**/*') if f.is_file())
+    return total_size / (1024 * 1024)
 
-# ---------------------------------------------------------------------------
-# Export as ONNX + saving ONNX
-# ---------------------------------------------------------------------------
-onnx_program = torch.onnx.export(model=embed_model, dynamo=True)
-onnx_program.save("embeddings_model.onnx")
+def main():
+    model_name = "all-MiniLM-L6-v2"
+    export_dir = "../onnx_model"
 
-# ---------------------------------------------------------------------------
-# Comparison - original model vs. ONNX-loaded model
-# ---------------------------------------------------------------------------
+    print(f"=== 1. Loading original PyTorch model: {model_name} ===")
+    model_pt = SentenceTransformer(model_name)
 
-contents = [
+    print(f"\n=== 2. Exporting to ONNX format ===")
+    # Using ST-native ONNX backend. 
+    # model_kwargs={"export": True} forces optimum to build the ONNX graph locally.
+    model_onnx = SentenceTransformer(
+        model_name, 
+        backend="onnx", 
+        model_kwargs={"export": True}
+    )
+    
+    # Save the artifact to fulfill the issue requirements
+    if os.path.exists(export_dir):
+        shutil.rmtree(export_dir)
+    model_onnx.save(export_dir)
+    print(f"ONNX artifact and tokenizer saved to ./{export_dir}/")
+
+    print("\n=== 3. Validating Output Parity ===")
+    sentences = [
     "We decided to use PostgreSQL as the primary database for the Acme web app. PostgreSQL offers ACID compliance, rich JSON support, and scales well for our expected load.",
     "PostgreSQL was chosen because the team has prior experience with it, it supports JSONB for flexible schema evolution, and the managed RDS offering fits our AWS deployment plan.",
     "For local development, we switched to SQLite to eliminate the Docker dependency and speed up onboarding. Production still targets PostgreSQL.",
@@ -50,41 +59,50 @@ contents = [
     "The team strongly prefers small, focused PRs — ideally under 400 lines. Large PRs block review and increase merge conflict risk. Feature flags are the preferred mechanism for shipping incomplete features.",
     "The Acme web app team has 4 engineers: 2 full-stack, 1 backend, 1 frontend/design. No dedicated DevOps or security engineer.",
     "The target public launch date is end of Q3. The v1 scope is intentionally narrow: auth, core CRUD, and basic reporting. v2 will add integrations and advanced analytics."
-]
+    ]
 
-# Option 1: original embedding model created from the EmbeddingModel class, embeddings extracted one by one
-embeddings_original = np.array([])
-start_time = time.perf_counter()
-for c in contents:
-    e = embed_model.embed(c)
-    embeddings_original = np.append(embeddings_original, e)
-end_time = time.perf_counter()
-elapsed_time = end_time - start_time
-print(f"Original model: embeddings obtained in {elapsed_time:.6f} seconds")
+    embeddings_pt = model_pt.encode(sentences, convert_to_numpy=True)
+    embeddings_onnx = model_onnx.encode(sentences, convert_to_numpy=True)
 
-# Option 2: original embedding model created from the EmbeddingModel class, batch-processed embeddings extraction
-start_time = time.perf_counter()
-embeddings_batched = embed_model.embed_batch(contents)
-end_time = time.perf_counter()
-elapsed_time = end_time - start_time
-print(f"Original model with batching: embeddings obtained in {elapsed_time:.6f} seconds")
+    print("Checking cosine similarity for each sentence pair...")
+    for i, text in enumerate(sentences):
+        # Calculate cosine similarity between the Torch and ONNX vectors
+        sim = cos_sim(embeddings_pt[i], embeddings_onnx[i]).item()
+        print(f"  Sentence {i+1} similarity: {sim:.6f}")
+        
+        # Assert parity >= 0.999 per acceptance criteria
+        assert sim >= 0.999, f"Parity failed for sentence {i+1}: similarity = {sim}"
+        
+    print("Parity check passed! All similarities are >= 0.999.")
 
-# Loading the saved ONNX file
-onnx_model = onnx.load("embeddings_model.onnx")
-onnx.checker.check_model(onnx_model)
-tokenizer = AutoTokenizer.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
-model_inputs = [tokenizer(c, return_tensors="np") for c in contents]
-ort_session = onnxruntime.InferenceSession(
-    "embeddings_model.onnx", providers=["CPUExecutionProvider"]
-)
-onnxruntime_input = {input_arg.name: input_value for input_arg, input_value in zip(ort_session.get_inputs(), model_inputs)}
+    print("\n=== 4. Performance and Size Comparison ===")
+    
+    onnx_size = get_dir_size_mb(export_dir)
+    print(f"  Exported ONNX Directory Size: {onnx_size:.2f} MB")
 
-# Option 3: loaded ONNX model, embeddings extracted one by one
-start_time = time.perf_counter()
-output_onnx = onnx_model.run(None, dict(model_inputs))
-end_time = time.perf_counter()
-elapsed_time = end_time - start_time
-print(f"Original model: embeddings obtained in {elapsed_time:.6f} seconds")
+    iterations = 50
+    print(f"\nBenchmarking over {iterations} iterations (Batch size: {len(sentences)})...")
+    
+    # Warmup
+    _ = model_pt.encode(sentences)
+    _ = model_onnx.encode(sentences)
 
+    # PyTorch timing
+    start_pt = time.perf_counter()
+    for _ in range(iterations):
+        _ = model_pt.encode(sentences)
+    time_pt = time.perf_counter() - start_pt
+    
+    # ONNX timing
+    start_onnx = time.perf_counter()
+    for _ in range(iterations):
+        _ = model_onnx.encode(sentences)
+    time_onnx = time.perf_counter() - start_onnx
 
+    print(f"PyTorch Time : {time_pt:.4f}s")
+    print(f"ONNX Time    : {time_onnx:.4f}s")
+    print(f"Speedup      : {time_pt / time_onnx:.2f}x faster")
+
+if __name__ == "__main__":
+    main()
 

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -5,7 +5,7 @@ Part of ONNX Runtime migration (Issue #121).
 Exports `all-MiniLM-L6-v2` to ONNX and validates numerical parity and timing against PyTorch.
 
 Requirements:
-    pip install "sentence-transformers>=2.7.0" "optimum[onnxruntime]"
+    pip install onnx onnxruntime sentence-transformers>=3.2.0 optimum[onnxruntime]
 """
 
 import argparse

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -8,34 +8,35 @@ Requirements:
     pip install "sentence-transformers>=2.7.0" "optimum[onnxruntime]"
 """
 
+import argparse
 import os
-import time
 import shutil
-import numpy as np
+import time
 from pathlib import Path
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.util import cos_sim
+
 
 def get_dir_size_mb(path: str) -> float:
     total_size = sum(f.stat().st_size for f in Path(path).glob('**/*') if f.is_file())
     return total_size / (1024 * 1024)
 
-def main():
+def main(export_dir: str):
     model_name = "all-MiniLM-L6-v2"
-    export_dir = "../onnx_model"
 
     print(f"=== 1. Loading original PyTorch model: {model_name} ===")
     model_pt = SentenceTransformer(model_name)
 
-    print(f"\n=== 2. Exporting to ONNX format ===")
-    # Using ST-native ONNX backend. 
+    print("\n=== 2. Exporting to ONNX format ===")
+    # Using ST-native ONNX backend.
     # model_kwargs={"export": True} forces optimum to build the ONNX graph locally.
     model_onnx = SentenceTransformer(
-        model_name, 
-        backend="onnx", 
+        model_name,
+        backend="onnx",
         model_kwargs={"export": True}
     )
-    
+
     # Save the artifact to fulfill the issue requirements
     if os.path.exists(export_dir):
         shutil.rmtree(export_dir)
@@ -65,24 +66,24 @@ def main():
     embeddings_onnx = model_onnx.encode(sentences, convert_to_numpy=True)
 
     print("Checking cosine similarity for each sentence pair...")
-    for i, text in enumerate(sentences):
+    for i, _ in enumerate(sentences):
         # Calculate cosine similarity between the Torch and ONNX vectors
         sim = cos_sim(embeddings_pt[i], embeddings_onnx[i]).item()
         print(f"  Sentence {i+1} similarity: {sim:.6f}")
-        
+
         # Assert parity >= 0.999 per acceptance criteria
         assert sim >= 0.999, f"Parity failed for sentence {i+1}: similarity = {sim}"
-        
+
     print("Parity check passed! All similarities are >= 0.999.")
 
     print("\n=== 4. Performance and Size Comparison ===")
-    
+
     onnx_size = get_dir_size_mb(export_dir)
     print(f"  Exported ONNX Directory Size: {onnx_size:.2f} MB")
 
     iterations = 50
     print(f"\nBenchmarking over {iterations} iterations (Batch size: {len(sentences)})...")
-    
+
     # Warmup
     _ = model_pt.encode(sentences)
     _ = model_onnx.encode(sentences)
@@ -92,7 +93,7 @@ def main():
     for _ in range(iterations):
         _ = model_pt.encode(sentences)
     time_pt = time.perf_counter() - start_pt
-    
+
     # ONNX timing
     start_onnx = time.perf_counter()
     for _ in range(iterations):
@@ -104,5 +105,13 @@ def main():
     print(f"Speedup      : {time_pt / time_onnx:.2f}x faster")
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Export all-MiniLM-L6-v2 to ONNX and validate output parity.")
+    parser.add_argument(
+        "-o", "--output-dir",
+        type=str,
+        default="onnx_model_export",
+        help="The directory where the ONNX model and tokenizer will be saved (default: onnx_model_export)"
+    )
 
+    args = parser.parse_args()
+    main(args.output_dir)


### PR DESCRIPTION
# perf(embeddings): add a script to export all-MiniLM-L6-v2 to ONNX and validate output parity (fixes #121 )

## What's in this PR
Added `scripts/export_onnx.py` to handle the exportation of the `all-MiniLM-L6-v2` model to ONNX format. The script embeds sample sentences and validates numerical parity (cosine similarity >= 0.999) between the original PyTorch model and the exported ONNX model, while benchmarking size and inference performance.

### Export approach

Used `sentence-transformers` (>=2.7.0) with native `backend="onnx"` integration, passing `model_kwargs={"export": True}`. 
This is the cleanest and most maintainable approach because it uses Hugging Face's `optimum` to safely trace and build the ONNX graph directly within the `SentenceTransformer` pipeline: thus avoiding the need to manually re-implement tokenization and mean pooling logic.

## Testing

### Sentence set:
[
    "We decided to use PostgreSQL as the primary database for the Acme web app. PostgreSQL offers ACID compliance, rich JSON support, and scales well for our expected load.",
    "PostgreSQL was chosen because the team has prior experience with it, it supports JSONB for flexible schema evolution, and the managed RDS offering fits our AWS deployment plan.",
    "For local development, we switched to SQLite to eliminate the Docker dependency and speed up onboarding. Production still targets PostgreSQL.",
    "New engineers were spending 30+ minutes setting up Postgres locally. SQLite requires zero setup and the ORM abstracts the difference.",
    "Final decision: use PostgreSQL in all environments (dev, staging, prod) via Docker Compose. The SQLite shortcut caused subtle migration drift. We added a one-command `make dev-up` to remove the setup friction.",
    "SQLite and PostgreSQL handle NULL semantics, JSON operators, and transaction isolation differently. Two bugs in staging traced back to SQLite-only dev. Docker Compose with a health-check solves onboarding without sacrificing parity.",
    "We will use Auth0 for authentication and SSO. Rolling our own OAuth is out of scope for v1. Auth0 supports SAML for enterprise customers.",
    "The team has no dedicated security engineer. Auth0 handles MFA, breach detection, and compliance certifications. Estimated 3-week saving vs. building in-house.",
    "We will deploy the web app on AWS ECS using Fargate. No EC2 instance management, auto-scaling, and integrates with our existing AWS account.",
    "The team is 4 engineers. Fargate means no patching, no AMI management, and cost scales to zero when idle. Kubernetes was considered but deemed over-engineered for v1.",
    "The team prefers TypeScript over plain JavaScript for all frontend work. Strict mode enabled. No `any` without a comment explaining why.",
    "The team prefers dark mode as the default UI theme. Light mode should be available as a toggle but dark is the out-of-box experience.",
    "The team strongly prefers small, focused PRs — ideally under 400 lines. Large PRs block review and increase merge conflict risk. Feature flags are the preferred mechanism for shipping incomplete features.",
    "The Acme web app team has 4 engineers: 2 full-stack, 1 backend, 1 frontend/design. No dedicated DevOps or security engineer.",
    "The target public launch date is end of Q3. The v1 scope is intentionally narrow: auth, core CRUD, and basic reporting. v2 will add integrations and advanced analytics."
    ]

```bash
=== 3. Validating Output Parity ===
Checking cosine similarity for each sentence pair...
  Sentence 1 similarity: 1.000000
  Sentence 2 similarity: 1.000000
  Sentence 3 similarity: 1.000000
  Sentence 4 similarity: 1.000000
  Sentence 5 similarity: 1.000000
  Sentence 6 similarity: 1.000000
  Sentence 7 similarity: 1.000000
  Sentence 8 similarity: 1.000000
  Sentence 9 similarity: 1.000000
  Sentence 10 similarity: 1.000000
  Sentence 11 similarity: 1.000000
  Sentence 12 similarity: 1.000000
  Sentence 13 similarity: 1.000000
  Sentence 14 similarity: 1.000000
  Sentence 15 similarity: 1.000000
Parity check passed! All similarities are >= 0.999.

=== 4. Performance and Size Comparison ===
  Exported ONNX Directory Size: 87.09 MB

Benchmarking over 50 iterations (Batch size: 15)...
PyTorch Time : 3.5874s
ONNX Time    : 3.0015s
Speedup      : 1.20x faster
```

NOTE: ruff check . and ruff format . have been run successfully (message obtained: All checks passed!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ONNX export tool that performs numerical parity checks with the original model, reports exported model size, benchmarks encoding performance, and offers a CLI to choose the output directory.

* **Chores**
  * Updated ignore rules to exclude exported model directories from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->