### PR TITLE
test: cover relationship normalization aliases

### DIFF
--- a/src/waggle/models.py
+++ b/src/waggle/models.py
@@ -40,20 +40,13 @@ class RelationType(StrEnum):
     SIMILAR_TO = "similar_to"
 
 
-RELATIONSHIP_ALIASES = {
-    "related": RelationType.RELATES_TO.value,
-    "related_to": RelationType.RELATES_TO.value,
-    "relate_to": RelationType.RELATES_TO.value,
-}
-
-
 def normalize_relationship(value: Any) -> str:
     if isinstance(value, RelationType):
         return value.value
     text = str(value).strip().lower()
     if not text:
         raise ValueError("Relationship cannot be empty.")
-    return RELATIONSHIP_ALIASES.get(text, text)
+    return text
 
 
 class Node(BaseModel):

--- a/src/waggle/models.py
+++ b/src/waggle/models.py
@@ -40,13 +40,20 @@ class RelationType(StrEnum):
     SIMILAR_TO = "similar_to"
 
 
+RELATIONSHIP_ALIASES = {
+    "related": RelationType.RELATES_TO.value,
+    "related_to": RelationType.RELATES_TO.value,
+    "relate_to": RelationType.RELATES_TO.value,
+}
+
+
 def normalize_relationship(value: Any) -> str:
     if isinstance(value, RelationType):
         return value.value
     text = str(value).strip().lower()
     if not text:
         raise ValueError("Relationship cannot be empty.")
-    return text
+    return RELATIONSHIP_ALIASES.get(text, text)
 
 
 class Node(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,10 +50,8 @@ def test_normalize_relationship_accepts_canonical_relation_types(relation_type: 
     ("raw_value", "expected"),
     [
         ("  RELATES_TO  ", RelationType.RELATES_TO.value),
-        ("related", RelationType.RELATES_TO.value),
-        ("related_to", RelationType.RELATES_TO.value),
-        ("relate_to", RelationType.RELATES_TO.value),
         ("Contradicts", RelationType.CONTRADICTS.value),
+        ("related_to", "related_to"),
     ],
 )
 def test_normalize_relationship_handles_common_aliases_and_variations(raw_value: str, expected: str) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,9 +40,28 @@ def test_relation_type_values_include_expected_defaults() -> None:
         RelationType("unknown")
 
 
-def test_normalize_relationship_accepts_enum_and_normalizes_strings() -> None:
-    assert normalize_relationship(RelationType.RELATES_TO) == "relates_to"
-    assert normalize_relationship("  RELATES_TO  ") == "relates_to"
+@pytest.mark.parametrize("relation_type", list(RelationType))
+def test_normalize_relationship_accepts_canonical_relation_types(relation_type: RelationType) -> None:
+    assert normalize_relationship(relation_type) == relation_type.value
+    assert normalize_relationship(relation_type.value) == relation_type.value
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        ("  RELATES_TO  ", RelationType.RELATES_TO.value),
+        ("related", RelationType.RELATES_TO.value),
+        ("related_to", RelationType.RELATES_TO.value),
+        ("relate_to", RelationType.RELATES_TO.value),
+        ("Contradicts", RelationType.CONTRADICTS.value),
+    ],
+)
+def test_normalize_relationship_handles_common_aliases_and_variations(raw_value: str, expected: str) -> None:
+    assert normalize_relationship(raw_value) == expected
+
+
+def test_normalize_relationship_preserves_unknown_non_empty_strings() -> None:
+    assert normalize_relationship("  custom_edge  ") == "custom_edge"
 
     with pytest.raises(ValueError, match="Relationship cannot be empty"):
         normalize_relationship("   ")


### PR DESCRIPTION
## Summary
- expand `tests/test_models.py` coverage for `NodeType` and `RelationType` enum defaults
- cover `normalize_relationship()` canonical enum inputs, canonical strings, case/spacing normalization, `related_to` fallback behavior, unknown non-empty fallback, and empty-string validation
- keep this PR test-only; no runtime behavior changes are intended

## Testing
- `WAGGLE_MODEL=deterministic /Users/dhyana/.dharma/forge_external_beast/venvs/abhigyan-shekhar-waggle-mcp-py311/bin/pytest tests/test_models.py -q`
- `ruff check tests/test_models.py src/waggle/models.py`
- `git diff --check`

Prepared by an AI coding agent under operator-approved external-action mode.

Fixes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for relationship value normalization with parametrized checks for canonical types, common string variants, and edge cases.

* **Chores**
  * Improved subprocess execution in the feature demo with timeout protection and enhanced error diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->