### PR TITLE
fix: auto-fix for issue #221

### DIFF
--- a/scripts/comprehensive_feature_demo.py
+++ b/scripts/comprehensive_feature_demo.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timezone
 from pathlib import Path
 from typing import Any
 

--- a/src/rlm/logger/rlm_logger.py
+++ b/src/rlm/logger/rlm_logger.py
@@ -8,7 +8,7 @@ RLMChatCompletion.metadata. Optionally writes the same data to JSON-lines files.
 import json
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from rlm.core.types import RLMIteration, RLMMetadata
 

--- a/src/waggle/auth.py
+++ b/src/waggle/auth.py
@@ -74,4 +74,4 @@ def principal_from_record(record: ApiKeyRecord | None, raw_api_key: str) -> Auth
 
 
 def iso_now() -> str:
-    return datetime.utcnow().isoformat() + "Z"
+    return datetime.now(timezone.utc).isoformat() + "Z"

--- a/src/waggle/evidence.py
+++ b/src/waggle/evidence.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from waggle.models import EvidenceRecord, Node
 

--- a/src/waggle/retrieval/rankers/temporal.py
+++ b/src/waggle/retrieval/rankers/temporal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal, TypeVar
 
 from waggle.retrieval.scorers.topic_relevance import TopicScore, score_topic_relevance

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -128,7 +128,7 @@ class TestJsonLogFormatter:
 
         # Should be able to parse as ISO format
         try:
-            from datetime import datetime
+            from datetime import datetime, timezone
 
             datetime.fromisoformat(data["timestamp"])
         except ValueError:


### PR DESCRIPTION
## Summary

This PR automatically fixes issue #221.

**Issue**: fix: iso_now() in auth.py uses deprecated datetime.utcnow()

## Changes

Auto-fix applied by GitHub Auto Fixer.

## Related Issues

Fixes #221

## Test plan

- [ ] Code compiles without errors
- [ ] Existing tests pass
- [ ] Manual testing completed

---
*Created by GitHub Auto Fixer Bot*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamp generation updated to use a UTC-aware current time and produce ISO-formatted timestamps for logs and records.

* **Tests**
  * Updated timestamp-related test to align with the new ISO/UTC timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->