### PR TITLE
ci: add Graph Studio build validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,26 @@ jobs:
 
       - name: Compile extension
         run: npm run compile
+
+  graph-studio:
+    name: Graph Studio validation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mcp/graph-ui
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/mcp/graph-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Graph Studio
+        run: npm run build


### PR DESCRIPTION
## Summary

* Added a new CI job to validate Graph Studio builds during pull requests.
* The new job installs dependencies for `apps/mcp/graph-ui` and runs the existing production build command.
* This helps detect frontend build regressions earlier and ensures Graph Studio remains buildable as changes are introduced.

### Why was it needed?

Graph Studio had a production build process, but it was not validated in the standard CI workflow. As a result, build-breaking changes could go unnoticed until manual testing or later stages of development. Adding build validation provides earlier feedback and improves confidence in frontend-related changes.

## Testing

* [x] `WAGGLE_MODEL=deterministic pytest -q`
* [x] `ruff check src/ tests/`
* [x] `ruff format --check src/ tests/`

### Test report

```text
cd apps/mcp/graph-ui
npm ci

npm run build

vite v7.3.2 building client environment for production...
✓ 438 modules transformed.
✓ built in 7.05s
```
closes  #190