### PR TITLE
Chore abhi not yet implemented

### DIFF
--- a/src/waggle/abhi.py
+++ b/src/waggle/abhi.py
@@ -512,7 +512,9 @@ def build_abhi_document(
                 "Use --include-deps or remove --strict-export."
             )
         if include_deps:
-            logger.info("Walking dangling edge targets to include referenced nodes (not yet implemented, continuing)")
+            # TODO(Vijitha14): implement dangling-edge walker to include referenced
+            # # nodes outside the current export scope.
+            pass
         else:
             logger.warning(
                 "Export contains %d dangling edge(s): %s",


### PR DESCRIPTION
## Summary

### What changed?

* Removed the runtime INFO log message containing `"not yet implemented"` from the dangling-edge walker path in `src/waggle/abhi.py`.
* Preserved the implementation intent with a TODO comment.

### Why was it needed?

The previous implementation emitted a runtime log message for an unimplemented feature while continuing execution. This created log noise without changing behavior. The intent is now preserved in source code while avoiding unnecessary runtime logging.

## Testing

* [x] `WAGGLE_MODEL=deterministic pytest -q`
* [x] `ruff check src/ tests/`
* [x] `ruff format --check src/ tests/`

### Test report

```text
546 passed, 5 skipped, 1 warning in 92.27s (0:01:32)
```

## Checklist

* [x] I linked an issue or explained why one is not needed.
* [x] I updated docs if user-facing behavior changed. (Not applicable)
* [x] I kept the PR focused on one logical change.
* [x] I did not commit secrets, local exports, or generated noise.

Closes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->