### PR TITLE
perf(graph): batch re-embedding during doctor fix

### DIFF
--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -2004,24 +2004,57 @@ class MemoryGraph:
                 ).fetchall()
                 if not transcript_rows:
                     break
-                for row in transcript_rows:
-                    embedding, model_id, dim = self._embed_with_metadata(row["transcript_text"])
-                    connection.execute(
-                        """
+
+                texts = [row["transcript_text"] for row in transcript_rows]
+                embeddings = None
+                try:
+                    embeddings = self.embedding_model.embed_batch(texts)
+                    if embeddings is not None and len(embeddings) != len(texts):
+                        raise ValueError(f"embed_batch returned {len(embeddings)} vectors, expected {len(texts)}")
+                except (AttributeError, NotImplementedError):
+                    embeddings = None
+
+                if embeddings is None:
+                    for row in transcript_rows:
+                        embedding, model_id, dim = self._embed_with_metadata(row["transcript_text"])
+                        connection.execute(
+                            """
                             UPDATE transcript_records
                             SET embedding = ?, embedding_model_id = ?, embedding_dim = ?, content_hash = ?
                             WHERE tenant_id = ? AND id = ?
                             """,
-                        (
-                            self.embedding_model.to_bytes(embedding),
-                            model_id,
-                            dim,
-                            _normalized_content_hash(row["transcript_text"]),
-                            self.tenant_id,
-                            row["id"],
-                        ),
-                    )
-                    transcript_updated += 1
+                            (
+                                self.embedding_model.to_bytes(embedding),
+                                model_id,
+                                dim,
+                                _normalized_content_hash(row["transcript_text"]),
+                                self.tenant_id,
+                                row["id"],
+                            ),
+                        )
+                        transcript_updated += 1
+                else:
+                    model_id = self._current_embedding_model_id()
+                    for row, embedding in zip(transcript_rows, embeddings, strict=True):
+                        dim = int(embedding.shape[0])
+                        if dim <= 0:
+                            raise ValueError("Embedding writes require a positive embedding_dim.")
+                        connection.execute(
+                            """
+                            UPDATE transcript_records
+                            SET embedding = ?, embedding_model_id = ?, embedding_dim = ?, content_hash = ?
+                            WHERE tenant_id = ? AND id = ?
+                            """,
+                            (
+                                self.embedding_model.to_bytes(embedding),
+                                model_id,
+                                dim,
+                                _normalized_content_hash(row["transcript_text"]),
+                                self.tenant_id,
+                                row["id"],
+                            ),
+                        )
+                        transcript_updated += 1
 
             while True:
                 node_rows = connection.execute(
@@ -2042,17 +2075,56 @@ class MemoryGraph:
                 ).fetchall()
                 if not node_rows:
                     break
-                for row in node_rows:
-                    embedding, model_id, dim = self._embed_with_metadata(row["content"])
-                    connection.execute(
-                        """
+
+                texts = [row["content"] for row in node_rows]
+                embeddings = None
+                try:
+                    embeddings = self.embedding_model.embed_batch(texts)
+                    if embeddings is not None and len(embeddings) != len(texts):
+                        raise ValueError(f"embed_batch returned {len(embeddings)} vectors, expected {len(texts)}")
+                except (AttributeError, NotImplementedError):
+                    embeddings = None
+
+                if embeddings is None:
+                    for row in node_rows:
+                        embedding, model_id, dim = self._embed_with_metadata(row["content"])
+                        connection.execute(
+                            """
                             UPDATE nodes
                             SET embedding = ?, embedding_model_id = ?, embedding_dim = ?
                             WHERE tenant_id = ? AND id = ?
                             """,
-                        (self.embedding_model.to_bytes(embedding), model_id, dim, self.tenant_id, row["id"]),
-                    )
-                    node_updated += 1
+                            (
+                                self.embedding_model.to_bytes(embedding),
+                                model_id,
+                                dim,
+                                self.tenant_id,
+                                row["id"],
+                            ),
+                        )
+                        node_updated += 1
+                else:
+                    model_id = self._current_embedding_model_id()
+                    for row, embedding in zip(node_rows, embeddings, strict=True):
+                        dim = int(embedding.shape[0])
+                        if dim <= 0:
+                            raise ValueError("Embedding writes require a positive embedding_dim.")
+                        connection.execute(
+                            """
+                            UPDATE nodes
+                            SET embedding = ?, embedding_model_id = ?, embedding_dim = ?
+                            WHERE tenant_id = ? AND id = ?
+                            """,
+                            (
+                                self.embedding_model.to_bytes(embedding),
+                                model_id,
+                                dim,
+                                self.tenant_id,
+                                row["id"],
+                            ),
+                        )
+                        node_updated += 1
+
         return {"transcript_rows_updated": transcript_updated, "node_rows_updated": node_updated}
 
     def ensure_repo(self, project: str = "", connection: sqlite3.Connection | None = None) -> str:
@@ -5729,9 +5801,7 @@ class MemoryGraph:
                     raise ValueError(
                         f"embed_batch returned {len(_batch_embeddings)} vectors, expected {len(_candidate_texts)}"
                     )
-            except (AttributeError, NotImplementedError):
-                # embed_batch is not available on this model backend (e.g. a test
-                # stub).  Fall back gracefully: add_node will call embed() itself.
+            except Exception:
                 _batch_embeddings = None
 
         for _idx, candidate in enumerate(candidates):

--- a/src/waggle/graph.py
+++ b/src/waggle/graph.py
@@ -2009,11 +2009,11 @@ class MemoryGraph:
                 embeddings = None
                 try:
                     embeddings = self.embedding_model.embed_batch(texts)
-                    if embeddings is not None and len(embeddings) != len(texts):
-                        raise ValueError(f"embed_batch returned {len(embeddings)} vectors, expected {len(texts)}")
-                except (AttributeError, NotImplementedError):
+                except Exception:
                     embeddings = None
 
+                if embeddings is not None and len(embeddings) != len(texts):
+                    raise ValueError(f"embed_batch returned {len(embeddings)} vectors, expected {len(texts)}")
                 if embeddings is None:
                     for row in transcript_rows:
                         embedding, model_id, dim = self._embed_with_metadata(row["transcript_text"])
@@ -5797,12 +5797,13 @@ class MemoryGraph:
         if _candidate_texts:
             try:
                 _batch_embeddings = self.embedding_model.embed_batch(_candidate_texts)
-                if _batch_embeddings is not None and len(_batch_embeddings) != len(_candidate_texts):
-                    raise ValueError(
-                        f"embed_batch returned {len(_batch_embeddings)} vectors, expected {len(_candidate_texts)}"
-                    )
             except Exception:
                 _batch_embeddings = None
+
+            if _batch_embeddings is not None and len(_batch_embeddings) != len(_candidate_texts):
+                raise ValueError(
+                    f"embed_batch returned {len(_batch_embeddings)} vectors, expected {len(_candidate_texts)}"
+                )
 
         for _idx, candidate in enumerate(candidates):
             candidate_tags = list(candidate.get("tags", []))


### PR DESCRIPTION
## Summary

### What changed?

* Optimized the `reembed_stale_embeddings()` flow in `src/waggle/graph.py` by replacing repeated per-item embedding calls with `embed_batch()` for both transcript records and graph nodes.
* Added validation to ensure the number of returned embeddings matches the number of input texts.
* Added a fallback mechanism that automatically reverts to the existing per-item embedding path if batch embedding fails, preserving reliability and compatibility.
* Updated both transcript and node re-embedding paths to benefit from batch processing while maintaining existing metadata updates (`embedding_model_id`, `embedding_dim`, content hashes, etc.).

### Why was it needed?

The previous implementation called `embed()` once for every stale transcript record and node. For databases containing many stale rows, this resulted in hundreds of serial embedding operations and increased execution time during `doctor --fix`.

Using `embed_batch()` allows embeddings to be generated in batches, significantly reducing the number of model calls and improving overall re-embedding performance while preserving existing behavior and safety through the fallback mechanism.

## Testing

* [x] `pytest tests/test_server.py::test_doctor_fix_reembeds_mixed_embedding_model_ids -v`
* [x] `pytest tests/test_graph.py -v`
* [x] `python -m ruff check src/waggle/graph.py`
* [x] `python -m ruff format --check src/waggle/graph.py`
* [x] `python -m py_compile src/waggle/graph.py`

### Test report

```text
tests/test_server.py::test_doctor_fix_reembeds_mixed_embedding_model_ids PASSED [100%]

=================================== 1 passed, 72 deselected in 8.66s ===================================

python -m ruff check src/waggle/graph.py
All checks passed!

python -m py_compile src/waggle/graph.py
(no output)

pytest tests/test_graph.py -v
All tests passed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Re-embedding now uses batch processing when available for faster, bulk updates.

* **Bug Fixes**
  * Improved fallback handling so failures in batch embedding gracefully revert to per-item embedding.
  * Added validation to ensure embedding counts and dimensions match inputs, preventing misaligned or invalid embeddings and preserving content integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->