### PR TITLE
fix: replace deprecated datetime.utcnow() with datetime.now(UTC)

### DIFF
--- a/src/waggle/auth.py
+++ b/src/waggle/auth.py
@@ -74,4 +74,4 @@ def principal_from_record(record: ApiKeyRecord | None, raw_api_key: str) -> Auth
 
 
 def iso_now() -> str:
-    return datetime.utcnow().isoformat() + "Z"
+    return datetime.now(UTC).isoformat()


### PR DESCRIPTION
Fixes #221

`datetime.utcnow()` is deprecated since Python 3.12. Changed to `datetime.now(UTC).isoformat()`. UTC is already imported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UTC timestamp formatting to comply with standard ISO-8601 representation for improved consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->