### PR TITLE
Share embedding cache across EmbeddingModel instances

### DIFF
--- a/src/waggle/embeddings.py
+++ b/src/waggle/embeddings.py
@@ -48,6 +48,10 @@ class EmbeddingModel:
 
     _DETERMINISTIC_MODELS = {"fake", "fake-model", "deterministic", "offline-demo"}
 
+    _GLOBAL_EMBED_CACHE: OrderedDict[str, bytes] = OrderedDict()
+    _GLOBAL_EMBED_CACHE_MAXSIZE = 512
+    _GLOBAL_EMBED_CACHE_LOCK = threading.Lock()
+
     def __init__(self, model_name: str = "all-MiniLM-L6-v2") -> None:
         self.model_name = model_name
         self._model: Any | None = None
@@ -64,8 +68,6 @@ class EmbeddingModel:
         # Keyed by normalised text; value is a pre-computed bytes blob so we
         # can return a fresh np.frombuffer view on each hit without re-encoding.
         # 512 entries x 384 dims x 4 bytes ~= 750 KB -- negligible overhead.
-        self._embed_cache: OrderedDict[str, bytes] = OrderedDict()
-        self._embed_cache_maxsize: int = 512
 
     # ------------------------------------------------------------------
     # Public API: background warmup
@@ -170,10 +172,10 @@ class EmbeddingModel:
             raise ValueError("Cannot embed empty text.")
 
         # Fast path: return cached embedding (copy so callers can mutate freely)
-        with self._lock:
-            if normalized in self._embed_cache:
-                self._embed_cache.move_to_end(normalized)
-                return np.frombuffer(self._embed_cache[normalized], dtype=np.float32).copy()
+        with EmbeddingModel._GLOBAL_EMBED_CACHE_LOCK:
+            if normalized in EmbeddingModel._GLOBAL_EMBED_CACHE:
+                EmbeddingModel._GLOBAL_EMBED_CACHE.move_to_end(normalized)
+                return np.frombuffer(EmbeddingModel._GLOBAL_EMBED_CACHE[normalized], dtype=np.float32).copy()
 
         if self.uses_deterministic_mode:
             # Canonical deterministic path — always safe to cache.
@@ -201,14 +203,14 @@ class EmbeddingModel:
         # Store in cache only when the result is canonical (not a transient fallback)
         if should_cache:
             blob = result.tobytes()
-            with self._lock:
-                if normalized in self._embed_cache:
-                    # Already written by a concurrent caller — just refresh LRU order
-                    self._embed_cache.move_to_end(normalized)
+            with EmbeddingModel._GLOBAL_EMBED_CACHE_LOCK:
+                if normalized in EmbeddingModel._GLOBAL_EMBED_CACHE:
+                    EmbeddingModel._GLOBAL_EMBED_CACHE.move_to_end(normalized)
                 else:
-                    if len(self._embed_cache) >= self._embed_cache_maxsize:
-                        self._embed_cache.popitem(last=False)
-                    self._embed_cache[normalized] = blob
+                    if len(EmbeddingModel._GLOBAL_EMBED_CACHE) >= EmbeddingModel._GLOBAL_EMBED_CACHE_MAXSIZE:
+                        EmbeddingModel._GLOBAL_EMBED_CACHE.popitem(last=False)
+
+                EmbeddingModel._GLOBAL_EMBED_CACHE[normalized] = blob
         return result
 
     def embed_batch(self, texts: list[str], *, wait_timeout: float = 30.0) -> np.ndarray:

--- a/src/waggle/embeddings.py
+++ b/src/waggle/embeddings.py
@@ -48,7 +48,7 @@ class EmbeddingModel:
 
     _DETERMINISTIC_MODELS = {"fake", "fake-model", "deterministic", "offline-demo"}
 
-    _GLOBAL_EMBED_CACHE: OrderedDict[str, bytes] = OrderedDict()
+    _GLOBAL_EMBED_CACHE: OrderedDict[tuple[str, str], bytes] = OrderedDict()
     _GLOBAL_EMBED_CACHE_MAXSIZE = 512
     _GLOBAL_EMBED_CACHE_LOCK = threading.Lock()
 
@@ -171,11 +171,13 @@ class EmbeddingModel:
         if not normalized:
             raise ValueError("Cannot embed empty text.")
 
+        cache_key = (self.model_name, normalized)
+
         # Fast path: return cached embedding (copy so callers can mutate freely)
         with EmbeddingModel._GLOBAL_EMBED_CACHE_LOCK:
-            if normalized in EmbeddingModel._GLOBAL_EMBED_CACHE:
-                EmbeddingModel._GLOBAL_EMBED_CACHE.move_to_end(normalized)
-                return np.frombuffer(EmbeddingModel._GLOBAL_EMBED_CACHE[normalized], dtype=np.float32).copy()
+            if cache_key in EmbeddingModel._GLOBAL_EMBED_CACHE:
+                EmbeddingModel._GLOBAL_EMBED_CACHE.move_to_end(cache_key)
+                return np.frombuffer(EmbeddingModel._GLOBAL_EMBED_CACHE[cache_key], dtype=np.float32).copy()
 
         if self.uses_deterministic_mode:
             # Canonical deterministic path — always safe to cache.
@@ -204,13 +206,13 @@ class EmbeddingModel:
         if should_cache:
             blob = result.tobytes()
             with EmbeddingModel._GLOBAL_EMBED_CACHE_LOCK:
-                if normalized in EmbeddingModel._GLOBAL_EMBED_CACHE:
-                    EmbeddingModel._GLOBAL_EMBED_CACHE.move_to_end(normalized)
+                if cache_key in EmbeddingModel._GLOBAL_EMBED_CACHE:
+                    EmbeddingModel._GLOBAL_EMBED_CACHE.move_to_end(cache_key)
                 else:
                     if len(EmbeddingModel._GLOBAL_EMBED_CACHE) >= EmbeddingModel._GLOBAL_EMBED_CACHE_MAXSIZE:
                         EmbeddingModel._GLOBAL_EMBED_CACHE.popitem(last=False)
 
-                EmbeddingModel._GLOBAL_EMBED_CACHE[normalized] = blob
+                EmbeddingModel._GLOBAL_EMBED_CACHE[cache_key] = blob
         return result
 
     def embed_batch(self, texts: list[str], *, wait_timeout: float = 30.0) -> np.ndarray:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -51,6 +51,7 @@ def test_uncached_transformer_falls_back_to_deterministic_embeddings(monkeypatch
     assert np.isclose(np.linalg.norm(vector), 1.0)
 
 def test_embedding_cache_shared_across_instances(monkeypatch: pytest.MonkeyPatch) -> None:
+    EmbeddingModel._GLOBAL_EMBED_CACHE.clear()
     class CountingModel:
         def __init__(self) -> None:
             self.calls = 0
@@ -79,3 +80,55 @@ def test_embedding_cache_shared_across_instances(monkeypatch: pytest.MonkeyPatch
     model_b.embed("foo")
 
     assert counting_model.calls == 1
+
+def test_embedding_cache_isolates_different_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    EmbeddingModel._GLOBAL_EMBED_CACHE.clear()
+
+    calls = {"a": 0, "b": 0}
+
+    def resolve_model(self, timeout):
+        if self.model_name == "model-a":
+
+            class ModelA:
+                def encode(
+                    self,
+                    text,
+                    normalize_embeddings=True,
+                    convert_to_numpy=True,
+                ):
+                    calls["a"] += 1
+                    return np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+            return ModelA()
+
+        class ModelB:
+            def encode(
+                self,
+                text,
+                normalize_embeddings=True,
+                convert_to_numpy=True,
+            ):
+                calls["b"] += 1
+                return np.array([4.0, 5.0], dtype=np.float32)
+
+        return ModelB()
+
+    monkeypatch.setattr(
+        EmbeddingModel,
+        "_resolve_model",
+        resolve_model,
+    )
+
+    model_a = EmbeddingModel("model-a")
+    model_b = EmbeddingModel("model-b")
+
+    vec_a = model_a.embed("foo")
+    vec_b = model_b.embed("foo")
+
+    assert calls["a"] == 1
+    assert calls["b"] == 1
+
+    assert vec_a.shape == (3,)
+    assert vec_b.shape == (2,)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -50,8 +50,10 @@ def test_uncached_transformer_falls_back_to_deterministic_embeddings(monkeypatch
     assert vector.shape == (256,)
     assert np.isclose(np.linalg.norm(vector), 1.0)
 
+
 def test_embedding_cache_shared_across_instances(monkeypatch: pytest.MonkeyPatch) -> None:
     EmbeddingModel._GLOBAL_EMBED_CACHE.clear()
+
     class CountingModel:
         def __init__(self) -> None:
             self.calls = 0
@@ -80,6 +82,7 @@ def test_embedding_cache_shared_across_instances(monkeypatch: pytest.MonkeyPatch
     model_b.embed("foo")
 
     assert counting_model.calls == 1
+
 
 def test_embedding_cache_isolates_different_models(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -49,3 +49,33 @@ def test_uncached_transformer_falls_back_to_deterministic_embeddings(monkeypatch
     assert model.uses_deterministic_mode is True
     assert vector.shape == (256,)
     assert np.isclose(np.linalg.norm(vector), 1.0)
+
+def test_embedding_cache_shared_across_instances(monkeypatch: pytest.MonkeyPatch) -> None:
+    class CountingModel:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def encode(
+            self,
+            text,
+            normalize_embeddings=True,
+            convert_to_numpy=True,
+        ):
+            self.calls += 1
+            return np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+    counting_model = CountingModel()
+
+    monkeypatch.setattr(
+        EmbeddingModel,
+        "_resolve_model",
+        lambda self, timeout: counting_model,
+    )
+
+    model_a = EmbeddingModel("shared-model")
+    model_b = EmbeddingModel("shared-model")
+
+    model_a.embed("foo")
+    model_b.embed("foo")
+
+    assert counting_model.calls == 1


### PR DESCRIPTION
# Summary

## What changed?
- Replaced the per-instance embedding cache with a process-wide shared cache in EmbeddingModel.
- Added a global lock to ensure thread-safe cache access and preserve existing LRU eviction behavior.
- Added a regression test to verify that embeddings are reused across multiple EmbeddingModel instances.

## Why was it needed?
The previous cache was scoped to individual EmbeddingModel instances, causing identical text to be encoded multiple times when different model instances were used in the same process (e.g., multiple MemoryGraph instances). Sharing the cache across instances eliminates redundant encoding work and improves efficiency.

closes #65 

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

### Test report
basan@Monica MINGW64 ~/waggle-mcp (fix-global-embedding-cache)
$ python -m pytest tests/test_embeddings.py -v
============================= test session starts ===============================
platform win32 -- Python 3.11.9, pytest-9.0.3, pluggy-1.6.0 -- C:\Users\basan\waggle-mcp\.venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\basan\waggle-mcp
configfile: pyproject.toml
plugins: anyio-4.13.0, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 6 items

tests/test_embeddings.py::test_embedding_bytes_round_trip PASSED                                                                                                                                           [ 16%]
tests/test_embeddings.py::test_cosine_similarity_handles_orthogonal_vectors PASSED                                                                                                                         [ 33%]
tests/test_embeddings.py::test_cosine_similarity_returns_zero_for_shape_mismatch PASSED                                                                                                                    [ 50%]
tests/test_embeddings.py::test_fake_model_is_deterministic_and_normalized PASSED                                                                                                                           [ 66%]
tests/test_embeddings.py::test_uncached_transformer_falls_back_to_deterministic_embeddings PASSED                                                                                                          [ 83%]
tests/test_embeddings.py::test_embedding_cache_shared_across_instances PASSED                                                                                                                              [100%]

==============================6 passed in 1.68s ===============================
(.venv)

$ python -m pytest tests/test_embeddings.py tests/test_graph.py tests/test_hybrid_retrieval.py -v ============================= 102 passed in 46.09s =============================


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Embedding cache was consolidated to a global shared cache, reducing duplicate work and improving performance across multiple embedding instances.

* **Tests**
  * Added tests that verify cache sharing across instances and isolation between different model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->