### PR TITLE
docs: add Mermaid architecture diagrams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,11 +124,12 @@ flowchart LR
     C --> D[MemoryGraph.store_node]
     C --> F[MemoryGraph.store_edge]
     D --> E[Embedding generation]
-    D --> G[(SQLite)]
-    D --> H[(Neo4j)]
+    D --> G[(SQLite or Neo4j)]
     F --> G
-    F --> H
 ```
+
+Note: The runtime instantiates either MemoryGraph (SQLite) or Neo4jMemoryGraph based on config.backend.
+
 
 ### Query graph flow
 
@@ -140,8 +141,7 @@ flowchart LR
     D --> E[MemoryGraph._expand_node_depths]
     E --> F[RecursiveContextController.assemble]
     F --> G[Context returned]
-    D --> H[(SQLite)]
-    D --> I[(Neo4j)]
+    D --> H[(SQLite or Neo4j)]
 ```
 
 ### Transport layer
@@ -152,10 +152,8 @@ flowchart TB
     Client -->|MCP| S
     S --> OC[observe_conversation]
     S --> QG[query_graph / build_context]
-    OC --> G[(SQLite)]
-    OC --> N[(Neo4j)]
+    OC --> G[(SQLite or Neo4j)]
     QG --> G
-    QG --> N
 
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,53 @@ query_graph() / build_context()
     └─► RecursiveContextController.assemble()  ← token-budgeted pack
 ```
 
+
+
+
+### Observe conversation flow
+
+```mermaid
+flowchart LR
+    A[Conversation input] --> B[observe_conversation]
+    B --> C[intelligence.extract_conversation_candidates]
+    C --> D[MemoryGraph.store_node]
+    C --> F[MemoryGraph.store_edge]
+    D --> E[Embedding generation]
+    D --> G[(SQLite)]
+    D --> H[(Neo4j)]
+    F --> G
+    F --> H
+```
+
+### Query graph flow
+
+```mermaid
+flowchart LR
+    A[Query input] --> B[query_graph / build_context]
+    B --> C[EmbeddingModel.embed query]
+    C --> D[HybridRetriever.retrieve]
+    D --> E[MemoryGraph._expand_node_depths]
+    E --> F[RecursiveContextController.assemble]
+    F --> G[Context returned]
+    D --> H[(SQLite)]
+    D --> I[(Neo4j)]
+```
+
+### Transport layer
+
+```mermaid
+flowchart TB
+    Client -->|HTTP| S[server.py]
+    Client -->|MCP| S
+    S --> OC[observe_conversation]
+    S --> QG[query_graph / build_context]
+    OC --> G[(SQLite)]
+    OC --> N[(Neo4j)]
+    QG --> G
+    QG --> N
+
+```
+
 ### Scoping / Tenancy
 
 Every node and transcript record carries three scope fields:


### PR DESCRIPTION
## Summary

Added Mermaid diagrams to supplement the existing ASCII architecture overview in `CONTRIBUTING.md`, providing a visual representation of the observe and query data flows.

### What changed?

* Added an `observe_conversation` flow diagram
* Added a `query_graph / build_context` flow diagram
* Added a transport layer diagram showing HTTP/MCP entry points through `server.py`
* Kept the existing architecture documentation intact

### Why was it needed?

The existing architecture overview was text-based only. Mermaid diagrams provide a visual representation of the data flow and component relationships, making the architecture easier to understand at a glance while remaining consistent with the existing documentation.

## Testing

* [x] Verified Mermaid diagrams render correctly in GitHub Markdown preview
* [x] Documentation-only change
* [ ] `WAGGLE_MODEL=deterministic pytest -q`
* [ ] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/`

### Test report

Not applicable (documentation-only change; no code modified).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three visual flowcharts to the contribution guidelines illustrating end-to-end data flow, query/context assembly, and client–server transport.
  * Clarified runtime backend selection behavior so contributors can understand how different storage/retrieval paths are chosen and interact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->