### PR TITLE
docs: add pre-commit install step to CONTRIBUTING.md setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,10 @@ pip install -e ".[dev]"
 
 # 4. Verify the setup
 waggle-mcp --help
+
+# 5. Install pre-commit hooks (runs ruff lint, ruff format, trailing whitespace,
+#    YAML/TOML checks, large file checks, and merge conflict detection before each commit)
+pre-commit install
 ```
 
 ### Before opening an issue


### PR DESCRIPTION
## Summary
- Added  as step 5 in the Getting Started section of CONTRIBUTING.md
- Documents the hooks that  provides (ruff lint, ruff format, trailing whitespace, YAML/TOML checks, large file detection, merge conflict markers)

## Why
The repo ships a working  but the contributor setup guide never mentioned running . This has caused contributors to push commits that fail lint/format in CI.

## Testing
- Verified the added text renders correctly in the markdown
- Confirmed the step number sequence is correct (1-5)

Fixes #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions to include pre-commit hooks for automated code quality checks, including linting, formatting, and merge conflict detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->