### PR TITLE
docs: add pre-commit install step to CONTRIBUTING setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,12 @@ source .venv/bin/activate     # macOS/Linux
 # 3. Install project + all dev tools (ruff, mypy, pytest)
 pip install -e ".[dev]"
 
-# 4. Verify the setup
+# 4. Install pre-commit hooks (recommended)
+# One-time setup: wires up the existing .pre-commit-config.yaml so ruff
+# lint and format run automatically before every commit.
+pre-commit install
+
+# 5. Verify the setup
 waggle-mcp --help
 ```
 
@@ -229,7 +234,9 @@ The offline-safe embedding mode. Uses SHA-256 hashing to produce a 256-dim float
 2. **Fork and branch** from `main`. Use a descriptive branch name like `fix/dockerfile-version` or `feat/dry-run-import`.
 3. **Keep PRs focused.** One logical change per PR makes review faster.
 4. **Write a clear description.** Explain *what* changed, *why* it was needed, and how you verified it. Link the issue with `Fixes #123` or explain why no issue is needed.
-5. **Run tests before pushing:**
+5. **Run tests before pushing.** If you ran `pre-commit install` during setup,
+   `ruff check` and `ruff format` run automatically on every commit; otherwise
+   run them manually alongside the test suite:
    ```bash
    WAGGLE_MODEL=deterministic pytest -q
    ruff check src/ tests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ pip install -e ".[dev]"
 
 # 4. Install pre-commit hooks (recommended)
 # One-time setup: wires up the existing .pre-commit-config.yaml so ruff
-# lint and format run automatically before every commit.
+# check and format run automatically before every commit.
 pre-commit install
 
 # 5. Verify the setup


### PR DESCRIPTION
Fixes #252.

The repo ships a working `.pre-commit-config.yaml` (ruff lint + format), but the contributor setup instructions never mention installing it. As a result the hooks go unused and PRs fail CI on the initial linting checks.

**Changes (docs-only):**
- Add an `Install pre-commit hooks (recommended)` step (`pre-commit install`) to the Getting Started setup block, right after `pip install -e ".[dev]"`.
- Update step 5 of *How to Submit a PR* to note that the hooks run `ruff` automatically on commit, and that the checks should be run manually if the step was skipped.

**Testing:** Documentation-only change (no code paths touched). CI lint/test checks should pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved contribution guidelines: recommend installing pre-commit hooks during setup to enable automatic lint/format checks, clarify when lint/format run automatically vs. when to run them manually alongside tests, and streamline onboarding and PR instructions for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->