### PR TITLE
perf: add import safety tests for #255

### DIFF
--- a/tests/test_import_safety.py
+++ b/tests/test_import_safety.py
@@ -6,6 +6,7 @@ This is a regression guard for https://github.com/Abhigyan-Shekhar/Waggle-mcp/is
 
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -47,7 +48,7 @@ def _check_heavy_modules(code: str) -> set[str]:
     lines = [l for l in result.stdout.strip().split("\n") if l.strip()]
     if not lines:
         raise RuntimeError(f"No output from subprocess:\n{result.stderr}")
-    return eval(lines[-1])  # safe: repr of a set of strings
+    return ast.literal_eval(lines[-1])  # safe: repr of a set of strings
 
 
 def test_import_waggle_does_not_import_heavy_modules() -> None:
@@ -97,8 +98,8 @@ def test_embedding_deterministic_mode_does_not_import_heavy_modules() -> None:
         "import os\n"
         "os.environ['WAGGLE_MODEL'] = 'deterministic'\n"
         "from waggle.embeddings import EmbeddingModel\n"
-        "m = EmbeddingModel('deterministic')\n"
-        "m.start_background_warmup()\n"
+        "model = EmbeddingModel('deterministic')\n"
+        "model.start_background_warmup()\n"
         "heavy = {m for m in sys.modules\n"
         "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
         "print(repr(heavy))"

--- a/tests/test_import_safety.py
+++ b/tests/test_import_safety.py
@@ -1,0 +1,122 @@
+"""Verify that heavy ML imports (torch, sentence_transformers) do not
+happen on simple CLI invocations like --help or doctor.
+
+This is a regression guard for https://github.com/Abhigyan-Shekhar/Waggle-mcp/issues/255
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Modules whose import at startup should be considered a bug.
+# sentence_transformers transitively pulls in torch (~800 MB) and is not
+# needed for --help, doctor, or any deterministic-mode operations.
+HEAVY_MODULES = frozenset({"sentence_transformers", "torch"})
+
+
+def _check_heavy_modules(code: str) -> set[str]:
+    """Run *code* in a clean subprocess and return the set of heavy modules
+    (sentence_transformers / torch) that were loaded after execution.
+
+    The *code* should print ``repr(the_set)`` as the *last* line of stdout
+    so we can safely eval it back.
+    """
+    src = str(Path(__file__).resolve().parents[1] / "src")
+    wrapper = (
+        "import sys\n"
+        f"sys.path.insert(0, {src!r})\n"
+        f"{code}\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", wrapper],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"subprocess failed (exit={result.returncode}):\n"
+            f"--- stderr ---\n{result.stderr}\n"
+            f"--- stdout ---\n{result.stdout}"
+        )
+    # The last non-empty line of stdout should be the repr(set)
+    lines = [l for l in result.stdout.strip().split("\n") if l.strip()]
+    if not lines:
+        raise RuntimeError(f"No output from subprocess:\n{result.stderr}")
+    return eval(lines[-1])  # safe: repr of a set of strings
+
+
+def test_import_waggle_does_not_import_heavy_modules() -> None:
+    """Simply importing the ``waggle`` package must NOT trigger
+    ``sentence_transformers`` or ``torch`` to be loaded."""
+    loaded = _check_heavy_modules(
+        "import waggle\n"
+        "heavy = {m for m in sys.modules\n"
+        "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
+        "print(repr(heavy))"
+    )
+    assert not HEAVY_MODULES.intersection(loaded), (
+        f"Heavy modules loaded by 'import waggle': {loaded}"
+    )
+
+
+def test_import_waggle_server_does_not_import_heavy_modules() -> None:
+    """Importing the server module (entry-point) must not pull in heavy deps."""
+    loaded = _check_heavy_modules(
+        "from waggle.server import _build_parser\n"
+        "heavy = {m for m in sys.modules\n"
+        "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
+        "print(repr(heavy))"
+    )
+    assert not HEAVY_MODULES.intersection(loaded), (
+        f"Heavy modules loaded by 'from waggle.server import _build_parser': {loaded}"
+    )
+
+
+def test_import_waggle_graph_does_not_import_heavy_modules() -> None:
+    """Importing the graph module must not pull in heavy deps."""
+    loaded = _check_heavy_modules(
+        "from waggle.graph import MemoryGraph\n"
+        "heavy = {m for m in sys.modules\n"
+        "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
+        "print(repr(heavy))"
+    )
+    assert not HEAVY_MODULES.intersection(loaded), (
+        f"Heavy modules loaded by 'from waggle.graph import MemoryGraph': {loaded}"
+    )
+
+
+def test_embedding_deterministic_mode_does_not_import_heavy_modules() -> None:
+    """Instantiating ``EmbeddingModel`` with ``WAGGLE_MODEL=deterministic``
+    must not import heavy modules until *embed()* is actually called."""
+    loaded = _check_heavy_modules(
+        "import os\n"
+        "os.environ['WAGGLE_MODEL'] = 'deterministic'\n"
+        "from waggle.embeddings import EmbeddingModel\n"
+        "m = EmbeddingModel('deterministic')\n"
+        "m.start_background_warmup()\n"
+        "heavy = {m for m in sys.modules\n"
+        "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
+        "print(repr(heavy))"
+    )
+    assert not HEAVY_MODULES.intersection(loaded), (
+        f"Heavy modules loaded by deterministic EmbeddingModel setup: {loaded}"
+    )
+
+
+def test_server_forward_refs_do_not_leak_heavy_imports() -> None:
+    """Type hints/forward references in server.py should not force eager
+    imports of sentence_transformers or torch."""
+    loaded = _check_heavy_modules(
+        "from waggle.server import main\n"
+        "heavy = {m for m in sys.modules\n"
+        "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
+        "print(repr(heavy))"
+    )
+    assert not HEAVY_MODULES.intersection(loaded), (
+        f"Heavy modules loaded by 'from waggle.server import main': {loaded}"
+    )

--- a/tests/test_import_safety.py
+++ b/tests/test_import_safety.py
@@ -19,6 +19,16 @@ import pytest
 HEAVY_MODULES = frozenset({"sentence_transformers", "torch"})
 
 
+def _any_heavy_prefix(loaded: set[str]) -> bool:
+    """Check if *loaded* contains any module under a ``HEAVY_MODULES`` root.
+
+    Uses prefix matching so that e.g. ``torch.utils`` is caught even if the
+    bare ``torch`` root is not in the set (defence in depth against false
+    negatives from the subprocess collection).
+    """
+    return any(m.startswith(p) for m in loaded for p in HEAVY_MODULES)
+
+
 def _check_heavy_modules(code: str) -> set[str]:
     """Run *code* in a clean subprocess and return the set of heavy modules
     (sentence_transformers / torch) that were loaded after execution.
@@ -60,7 +70,7 @@ def test_import_waggle_does_not_import_heavy_modules() -> None:
         "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
         "print(repr(heavy))"
     )
-    assert not HEAVY_MODULES.intersection(loaded), (
+    assert not _any_heavy_prefix(loaded), (
         f"Heavy modules loaded by 'import waggle': {loaded}"
     )
 
@@ -73,7 +83,7 @@ def test_import_waggle_server_does_not_import_heavy_modules() -> None:
         "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
         "print(repr(heavy))"
     )
-    assert not HEAVY_MODULES.intersection(loaded), (
+    assert not _any_heavy_prefix(loaded), (
         f"Heavy modules loaded by 'from waggle.server import _build_parser': {loaded}"
     )
 
@@ -86,7 +96,7 @@ def test_import_waggle_graph_does_not_import_heavy_modules() -> None:
         "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
         "print(repr(heavy))"
     )
-    assert not HEAVY_MODULES.intersection(loaded), (
+    assert not _any_heavy_prefix(loaded), (
         f"Heavy modules loaded by 'from waggle.graph import MemoryGraph': {loaded}"
     )
 
@@ -104,7 +114,7 @@ def test_embedding_deterministic_mode_does_not_import_heavy_modules() -> None:
         "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
         "print(repr(heavy))"
     )
-    assert not HEAVY_MODULES.intersection(loaded), (
+    assert not _any_heavy_prefix(loaded), (
         f"Heavy modules loaded by deterministic EmbeddingModel setup: {loaded}"
     )
 
@@ -118,6 +128,6 @@ def test_server_forward_refs_do_not_leak_heavy_imports() -> None:
         "        if m.startswith('sentence_transformers') or m.startswith('torch')}\n"
         "print(repr(heavy))"
     )
-    assert not HEAVY_MODULES.intersection(loaded), (
+    assert not _any_heavy_prefix(loaded), (
         f"Heavy modules loaded by 'from waggle.server import main': {loaded}"
     )


### PR DESCRIPTION
## perf: lazy-import sentence-transformers and torch only when needed (#255)

### Audit Results
After a thorough search of the entire `src/waggle/` codebase:

✅ `embeddings.py` — `sentence_transformers` import is already function-local
  inside `_load_transformer_model()` — no change needed.

✅ `server.py` — no sentence_transformers or torch imports found

✅ `graph.py` — no sentence_transformers or torch imports found

✅ `hybrid.py` — no sentence_transformers or torch imports found

✅ `__init__.py` — uses lazy `__getattr__` pattern, no eager imports

### What This PR Adds
1. **Import safety tests** (`tests/test_import_safety.py`) — 5 regression tests
   that verify no heavy ML imports leak at startup. This prevents future
   regressions if someone adds a top-level import of sentence_transformers.

### Benchmark
`waggle-mcp --help` starts in ~0.1s without touching PyTorch.

### Verification
- `waggle-mcp --help` does NOT import torch or sentence_transformers ✓
- `WAGGLE_MODEL=deterministic waggle-mcp serve` does NOT import them ✓
- Real `embed()` calls still lazy-load sentence_transformers on first use ✓
- All existing tests pass (599 passed, 5 skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests to ensure heavyweight ML dependencies (e.g., sentence-transformers, torch) are not eagerly loaded during typical import and setup paths.
  * Validates behavior across common entry points, server and graph imports, deterministic embedding warmup, and server forward-reference scenarios to keep startup lightweight and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->