### PR TITLE
test: cover readiness dependency checks

### DIFF
--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -2947,6 +2947,71 @@ class MCPHttpApp:
         return receive
 
 
+def _check_readiness(http_service: "MCPHttpApp") -> dict[str, Any]:
+    """Run all readiness sub-checks and return a structured result.
+
+    Keys:
+      ready     - bool: overall pass/fail
+      service   - "ok" | "not-ready" | "draining"
+      db        - "ok" | "error"
+      embedding - warmup_status string
+      lock      - "ok" | "contended" | "unknown"
+    """
+    checks: dict[str, Any] = {}
+
+    # 1. Service lifecycle check
+    if not http_service.ready:
+        checks["service"] = "not-ready"
+    elif http_service.draining:
+        checks["service"] = "draining"
+    else:
+        checks["service"] = "ok"
+
+    # 2. DB connectivity — SELECT 1
+    try:
+        graph = http_service.app_server._root_graph
+        with graph._connect() as _conn:
+            _conn.execute("SELECT 1").fetchone()
+        checks["db"] = "ok"
+    except Exception:
+        checks["db"] = "error"
+
+    # 3. Embedding model load state
+    try:
+        em = http_service.app_server._root_graph.embedding_model
+        checks["embedding"] = getattr(em, "warmup_status", "unknown")
+    except Exception:
+        checks["embedding"] = "unknown"
+
+    # 4. Lock / connection-pool availability
+    # There is no pool object; _ReadWriteLock serialises writes.
+    # Attempt a short read-lock to surface severe write-lock contention.
+    try:
+        lock = http_service.app_server._root_graph._lock
+        result_holder: list[bool] = []
+
+        def _try_acquire() -> None:
+            try:
+                with lock.read():
+                    result_holder.append(True)
+            except Exception:
+                result_holder.append(False)
+
+        t = threading.Thread(target=_try_acquire, daemon=True)
+        t.start()
+        t.join(timeout=0.1)
+        checks["lock"] = "ok" if (result_holder and result_holder[0]) else "contended"
+    except Exception:
+        checks["lock"] = "unknown"
+
+    checks["ready"] = (
+        checks["service"] == "ok"
+        and checks["db"] == "ok"
+        and checks["embedding"] not in ("failed",)
+    )
+    return checks
+
+
 def create_http_application(app_server: WaggleServer, config: AppConfig) -> Starlette:
     service = MCPHttpApp(app_server, config)
 
@@ -2962,9 +3027,10 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
 
     async def ready(request: Request) -> Response:
         http_service: MCPHttpApp = request.app.state.http_service
-        if not http_service.ready or http_service.draining:
-            return JSONResponse({"status": "not-ready"}, status_code=503)
-        return JSONResponse({"status": "ready"})
+        result = _check_readiness(http_service)
+        if not result["ready"]:
+            return JSONResponse({"status": "not-ready", **result}, status_code=503)
+        return JSONResponse({"status": "ready", **result})
 
     async def metrics_endpoint(request: Request) -> Response:
         return PlainTextResponse(request.app.state.http_service.metrics.render_prometheus())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2062,3 +2062,83 @@ def test_clear_cli_commands_dry_run(tmp_path: Path, capsys: pytest.CaptureFixtur
     payload = json.loads(capsys.readouterr().out)
     assert payload["dry_run"] is True
     assert payload["deleted_nodes"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #245 — /health/ready sub-checks
+# ---------------------------------------------------------------------------
+
+
+def test_check_readiness_happy_path(tmp_path: Path) -> None:
+    """All sub-checks pass when service is ready, DB is reachable, model is set."""
+    import waggle.server as _srv
+
+    app = make_app(tmp_path)
+
+    class _FakeHTTP:
+        ready = True
+        draining = False
+        app_server = app
+
+    result = _srv._check_readiness(_FakeHTTP())
+
+    assert result["ready"] is True
+    assert result["service"] == "ok"
+    assert result["db"] == "ok"
+    assert result["embedding"] in ("ready", "not_started", "warming_up", "disabled", "unknown")
+    assert result["lock"] in ("ok", "contended")
+
+
+def test_check_readiness_service_not_ready(tmp_path: Path) -> None:
+    """Returns not-ready when service flag is False."""
+    import waggle.server as _srv
+
+    app = make_app(tmp_path)
+
+    class _FakeHTTP:
+        ready = False
+        draining = False
+        app_server = app
+
+    result = _srv._check_readiness(_FakeHTTP())
+
+    assert result["ready"] is False
+    assert result["service"] == "not-ready"
+
+
+def test_check_readiness_db_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returns db=error and overall not-ready when DB is unreachable."""
+    import waggle.server as _srv
+
+    app = make_app(tmp_path)
+
+    class _FakeHTTP:
+        ready = True
+        draining = False
+        app_server = app
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("DB unavailable")
+
+    monkeypatch.setattr(app._root_graph, "_connect", _boom)
+    result = _srv._check_readiness(_FakeHTTP())
+
+    assert result["ready"] is False
+    assert result["db"] == "error"
+
+
+def test_check_readiness_draining(tmp_path: Path) -> None:
+    """Returns draining service status and overall not-ready."""
+    import waggle.server as _srv
+
+    app = make_app(tmp_path)
+
+    class _FakeHTTP:
+        ready = True
+        draining = True
+        app_server = app
+
+    result = _srv._check_readiness(_FakeHTTP())
+
+    assert result["ready"] is False
+    assert result["service"] == "draining"


### PR DESCRIPTION
## Summary

* Extended `/health/ready` readiness checks beyond the existing service-ready flag.
* Added dependency validation for database connectivity, embedding model readiness, and connection availability checks.
* Added tests covering readiness success and failure scenarios.

### Why was it needed?

Previously, `/health/ready` only checked whether the HTTP service had completed startup. A deployment could be marked as ready even when critical dependencies such as the database or embedding model were unavailable, causing requests to fail immediately after traffic was routed to the service.

The new readiness checks ensure the service only reports itself as ready when its required dependencies are operational.

## Testing

* [ ] `WAGGLE_MODEL=deterministic pytest -q`
* [ ] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/`

### Test report

Paste the output of `pytest -v` for the files you changed:

```text
<paste pytest output here>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced /health/ready endpoint now returns structured, detailed readiness info (service state, database connectivity, embedding warmup, and lock contention) and responds 200 when ready or 503 with status/details when not ready.

* **Tests**
  * Added comprehensive tests covering readiness scenarios (all good, service not ready/draining, database error, and related failure states).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->