### PR TITLE
docs: remove outdated contributing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,9 +789,3 @@ Run `waggle-mcp doctor` first — it catches the most common issues automaticall
 - **Automatic memory rules (copy-pasteable):** `docs/automatic-memory-rules.md`
 - **Hook integration details:** `docs/hooks.md`
 - **.abhi format spec:** `docs/abhi-format-v2.md`
-
----
-
-## Contributing
-
-This repository is maintained privately. Internal contributors can use the docs in this repo as the source of truth.


### PR DESCRIPTION
## Summary

* Removed the outdated contributing note from the README.
* The repository is public and accepts community contributions, so the previous note was no longer accurate.

Fixes #280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation references in the README to include the format specification guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->