### PR TITLE
fix(networking): read TCP length header fully before unpacking

### DIFF
--- a/src/rlm/core/comms_utils.py
+++ b/src/rlm/core/comms_utils.py
@@ -161,9 +161,17 @@ def socket_recv(sock: socket.socket) -> dict:
     Raises:
         ConnectionError: If connection closes mid-message.
     """
-    raw_len = sock.recv(4)
-    if not raw_len:
-        return {}
+    raw_len = b""
+
+    while len(raw_len) < 4:
+        chunk = sock.recv(4 - len(raw_len))
+
+        if not chunk:
+            if len(raw_len) == 0:
+                return {}
+
+            raise ConnectionError("Connection closed before length header complete")
+        raw_len += chunk
 
     length = struct.unpack(">I", raw_len)[0]
     payload = b""

--- a/tests/test_comms_utils.py
+++ b/tests/test_comms_utils.py
@@ -1,0 +1,28 @@
+import json
+import struct
+
+from rlm.core.comms_utils import socket_recv
+
+
+class FakeSocket:
+    """Socket test double that simulates fragmented TCP header delivery."""
+    def __init__(self):
+        payload = json.dumps({"hello": "world"}).encode("utf-8")
+        header = struct.pack(">I", len(payload))
+
+        self.chunks = [
+            header[:2],      # partial header
+            header[2:],      # rest of header
+            payload,
+        ]
+
+    def recv(self, _size):
+        """Return the next chunk of socket data."""
+        return self.chunks.pop(0)
+
+
+def test_socket_recv_handles_partial_header():
+    """Verify socket_recv reconstructs fragmented TCP length headers."""
+    result = socket_recv(FakeSocket())
+
+    assert result == {"hello": "world"}

--- a/tests/test_comms_utils.py
+++ b/tests/test_comms_utils.py
@@ -6,13 +6,14 @@ from rlm.core.comms_utils import socket_recv
 
 class FakeSocket:
     """Socket test double that simulates fragmented TCP header delivery."""
+
     def __init__(self):
         payload = json.dumps({"hello": "world"}).encode("utf-8")
         header = struct.pack(">I", len(payload))
 
         self.chunks = [
-            header[:2],      # partial header
-            header[2:],      # rest of header
+            header[:2],  # partial header
+            header[2:],  # rest of header
             payload,
         ]
 


### PR DESCRIPTION
## Summary

Fixes #269

`socket_recv()` previously assumed that `sock.recv(4)` would always return the complete 4-byte length header.

TCP does not guarantee that a single `recv()` call returns all requested bytes. Under fragmentation or network buffering conditions, fewer than 4 bytes may be returned, causing `struct.unpack(">I", raw_len)` to fail or process an incomplete header.

This change introduces logic to read the length prefix completely before unpacking it and preserves the existing behavior for payload reads.

## Changes

* Added logic to read the full 4-byte length header before calling `struct.unpack`
* Preserved existing payload receive behavior
* Added regression tests covering partial header delivery
* Verified existing socket protocol tests continue to pass

## Why

The socket protocol uses a fixed-size 4-byte big-endian length prefix.

The previous implementation assumed:

```python
raw_len = sock.recv(4)
```

always returned 4 bytes.

In TCP, this assumption is incorrect because reads may be fragmented across packets.

The fix ensures the header is read completely before decoding the message length.

## Testing

* Added regression test for partial header reads
* Ran project test suite
* Verified normal message handling still works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network receive logic so fragmented or partially delivered packets (including split length headers) are handled reliably, reducing connection errors and incomplete reads.

* **Tests**
  * Added unit tests to validate correct handling of fragmented and partial network data during message receipt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->