### PR TITLE
docs: align codex config example with waggle.db default

### DIFF
--- a/examples/codex_config.example.toml
+++ b/examples/codex_config.example.toml
@@ -2,7 +2,7 @@
 command = "/Users/abhigyanshekhar/Desktop/MCP/.venv/bin/python"
 args = ["-m", "waggle.server"]
 cwd = "/Users/abhigyanshekhar/Desktop/MCP"
-env = { PYTHONPATH = "/Users/abhigyanshekhar/Desktop/MCP/src", WAGGLE_TRANSPORT = "stdio", WAGGLE_BACKEND = "sqlite", WAGGLE_DB_PATH = "/Users/abhigyanshekhar/.waggle/memory.db", WAGGLE_DEFAULT_TENANT_ID = "local-default", WAGGLE_MODEL = "all-MiniLM-L6-v2" }
+env = { PYTHONPATH = "/Users/abhigyanshekhar/Desktop/MCP/src", WAGGLE_TRANSPORT = "stdio", WAGGLE_BACKEND = "sqlite", WAGGLE_DB_PATH = "/Users/abhigyanshekhar/.waggle/waggle.db", WAGGLE_DEFAULT_TENANT_ID = "local-default", WAGGLE_MODEL = "all-MiniLM-L6-v2" }
 
 # Add this to your Codex global/project instructions so Waggle is used automatically:
 #


### PR DESCRIPTION
## Summary

Updated the Codex configuration example to use `waggle.db` instead of `memory.db`.

This aligns the example configuration with the repository's documented default database path and helps avoid confusion caused by inconsistent database file names.

## Testing

* [x] Documentation/example-only change
* [x] Verified the updated path in `examples/codex_config.example.toml`

## Test report

Not applicable (documentation/example configuration update only).

Related to #233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MCP Waggle server example configuration file with revised database path reference to reflect current setup guidelines for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->