### PR TITLE
feat: print a startup banner with version, backend, model, db_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ waggle-mcp import-graph-backup --input-path my_memory.json
 | `waggle-mcp doctor --fix` | Re-embed stale rows after a `WAGGLE_MODEL` change. |
 | `waggle-mcp setup --yes` | Non-interactive one-line setup for all detected clients. |
 | `waggle-mcp init` | Interactive setup wizard for one client. |
-| `waggle-mcp serve` | Run the MCP server (usually started by your client). |
+| `waggle-mcp serve` | Run the MCP server (usually started by your client); interactive terminals show a short startup banner. |
 | `waggle-mcp demo` | Run the 60-second local demo with a pre-loaded example graph. |
 | `waggle-mcp edit-graph` | Launch Graph Studio in the browser. |
 | `waggle-mcp uninstall-hooks` | Remove the waggle-managed hooks block from Claude Code settings. |

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -51,7 +51,7 @@ waggle-mcp serve --transport stdio
 
 Then restart the client and verify the MCP entry is enabled.
 
-If you run `waggle-mcp serve` in a terminal, you may also see a short startup banner; it is skipped automatically for stdio/non-TTY runs, and you can disable it with `--quiet` or `WAGGLE_BANNER=false`.
+If you run `waggle-mcp serve` in a terminal, you may also see a short startup banner; it is skipped automatically when stdout is not a TTY, and you can disable it with `--quiet` or `WAGGLE_BANNER=false`.
 
 ## Run Waggle diagnostics
 

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -51,6 +51,8 @@ waggle-mcp serve --transport stdio
 
 Then restart the client and verify the MCP entry is enabled.
 
+If you run `waggle-mcp serve` in a terminal, you may also see a short startup banner; it is skipped automatically for stdio/non-TTY runs, and you can disable it with `--quiet` or `WAGGLE_BANNER=false`.
+
 ## Run Waggle diagnostics
 
 ```bash

--- a/src/waggle/__init__.py
+++ b/src/waggle/__init__.py
@@ -1,7 +1,8 @@
 """Persistent graph memory MCP server."""
 
 from importlib import import_module
-from importlib.metadata import PackageNotFoundError, version as metadata_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as metadata_version
 
 _LAZY_EXPORTS = {
     "MemoryGraph": ("waggle.graph", "MemoryGraph"),
@@ -47,6 +48,7 @@ _LAZY_EXPORTS = {
 }
 
 __all__ = sorted(_LAZY_EXPORTS)
+FALLBACK_VERSION = "0.0.1"
 
 
 def __getattr__(name: str):
@@ -63,6 +65,6 @@ def __getattr__(name: str):
 try:  # pragma: no cover
     __version__ = metadata_version("waggle-mcp")
 except PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.0.1"
+    __version__ = FALLBACK_VERSION
 
 runtime_version = __version__

--- a/src/waggle/__init__.py
+++ b/src/waggle/__init__.py
@@ -1,7 +1,7 @@
 """Persistent graph memory MCP server."""
 
 from importlib import import_module
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, version as metadata_version
 
 _LAZY_EXPORTS = {
     "MemoryGraph": ("waggle.graph", "MemoryGraph"),
@@ -61,8 +61,8 @@ def __getattr__(name: str):
 
 
 try:  # pragma: no cover
-    __version__ = version("waggle-mcp")
+    __version__ = metadata_version("waggle-mcp")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.1"
 
-version = __version__
+runtime_version = __version__

--- a/src/waggle/__init__.py
+++ b/src/waggle/__init__.py
@@ -64,3 +64,5 @@ try:  # pragma: no cover
     __version__ = version("waggle-mcp")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.1"
+
+version = __version__

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -40,6 +40,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 import waggle
+from waggle import __version__
 from waggle.abhi import (
     ABHI_MERGE_STRATEGIES,
     DEFAULT_ABHI_MERGE_STRATEGY,

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3940,7 +3940,7 @@ _APP: WaggleServer | None = None
 
 
 def _resolve_runtime_version() -> str:
-    version = getattr(waggle, "version", None)
+    version = getattr(waggle, "runtime_version", None)
     if isinstance(version, str) and version.strip():
         return version
     version = getattr(waggle, "__version__", None)
@@ -3959,21 +3959,22 @@ def _is_falsey_banner_value(value: str | None) -> bool:
 def format_runtime_banner(config: AppConfig) -> str:
     return "\n".join(
         [
-        f"Waggle MCP {_resolve_runtime_version()}",
-        f"  Backend:    {config.backend}",
-        f"  Model:      {config.model_name}",
-        f"  DB path:    {config.db_path}",
-        f"  Transport:  {config.transport}",
-        f"  Tenant:     {config.default_tenant_id}",
+            f"Waggle MCP {_resolve_runtime_version()}",
+            f"  Backend:    {config.backend}",
+            f"  Model:      {config.model_name}",
+            f"  DB path:    {config.db_path}",
+            f"  Transport:  {config.transport}",
+            f"  Tenant:     {config.default_tenant_id}",
         ]
     )
 
 
 def should_print_banner(config: AppConfig, quiet: bool) -> bool:
-    del config
     if quiet:
         return False
     if _is_falsey_banner_value(os.environ.get("WAGGLE_BANNER")):
+        return False
+    if config.transport == "stdio" and not sys.stdout.isatty():
         return False
     return sys.stdout.isatty()
 

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import base64
+from importlib.metadata import PackageNotFoundError, version as metadata_version
 import getpass
 import json
 import logging
@@ -37,7 +38,7 @@ from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from waggle import __version__
+import waggle
 from waggle.abhi import (
     ABHI_MERGE_STRATEGIES,
     DEFAULT_ABHI_MERGE_STRATEGY,
@@ -3938,6 +3939,49 @@ def _run_graph_editor_command(config: AppConfig, args: argparse.Namespace) -> in
 _APP: WaggleServer | None = None
 
 
+def _resolve_runtime_version() -> str:
+    version = getattr(waggle, "version", None)
+    if isinstance(version, str) and version.strip():
+        return version
+    version = getattr(waggle, "__version__", None)
+    if isinstance(version, str) and version.strip():
+        return version
+    try:
+        return metadata_version("waggle-mcp")
+    except PackageNotFoundError:  # pragma: no cover
+        return "0.0.1"
+
+
+def _is_falsey_banner_value(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"0", "false", "no", "off"}
+
+
+def format_runtime_banner(config: AppConfig) -> str:
+    return "\n".join(
+        [
+        f"Waggle MCP {_resolve_runtime_version()}",
+        f"  Backend:    {config.backend}",
+        f"  Model:      {config.model_name}",
+        f"  DB path:    {config.db_path}",
+        f"  Transport:  {config.transport}",
+        f"  Tenant:     {config.default_tenant_id}",
+        ]
+    )
+
+
+def should_print_banner(config: AppConfig, quiet: bool) -> bool:
+    del config
+    if quiet:
+        return False
+    if _is_falsey_banner_value(os.environ.get("WAGGLE_BANNER")):
+        return False
+    return sys.stdout.isatty()
+
+
+def _print_startup_banner(config: AppConfig) -> None:
+    print(format_runtime_banner(config))
+
+
 def _default_graph(config: AppConfig | None = None) -> Any:
     try:
         return _build_backend(config or AppConfig.from_env())
@@ -4066,6 +4110,8 @@ Common workflows
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    common_runtime = argparse.ArgumentParser(add_help=False)
+    common_runtime.add_argument("--quiet", action="store_true", help="Suppress the startup banner.")
     parser = argparse.ArgumentParser(
         prog="waggle-mcp",
         description=(
@@ -4075,10 +4121,15 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
         epilog="Examples: 'waggle-mcp setup --yes', 'waggle-mcp serve', 'waggle-mcp features'.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[common_runtime],
     )
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {_resolve_runtime_version()}")
     subparsers = parser.add_subparsers(dest="command")
-    serve = subparsers.add_parser("serve", help="Run the MCP server using the configured stdio or HTTP transport.")
+    serve = subparsers.add_parser(
+        "serve",
+        help="Run the MCP server using the configured stdio or HTTP transport.",
+        parents=[common_runtime],
+    )
     serve.add_argument(
         "--transport",
         choices=["stdio", "http"],
@@ -4092,6 +4143,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Start the Waggle HTTP app for local graph editing and open /graph in the browser by default. "
             "Use this for mouse-and-keyboard graph editing: add, remove, connect, reposition, import, and export."
         ),
+        parents=[common_runtime],
     )
     graph_editor.add_argument("--host", default="127.0.0.1")
     graph_editor.add_argument("--port", type=int, default=8686)
@@ -4101,6 +4153,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "view-graph",
         help="Launch the visual graph viewer/editor in a browser window.",
         description="Alias for edit-graph. Starts the local graph UI and opens it in the browser by default.",
+        parents=[common_runtime],
     )
     graph_viewer.add_argument("--host", default="127.0.0.1")
     graph_viewer.add_argument("--port", type=int, default=8686)
@@ -4110,6 +4163,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "ui",
         help="Launch the local graph UI in the browser.",
         description="Alias for edit-graph. Starts the localhost Graph Studio and opens it by default.",
+        parents=[common_runtime],
     )
     graph_ui.add_argument("--host", default="127.0.0.1")
     graph_ui.add_argument("--port", type=int, default=8686)
@@ -4119,6 +4173,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "graph-studio",
         help="Alias for the local Graph Studio browser UI.",
         description="Alias for ui/edit-graph. Starts the localhost Graph Studio and opens it by default.",
+        parents=[common_runtime],
     )
     graph_studio.add_argument("--host", default="127.0.0.1")
     graph_studio.add_argument("--port", type=int, default=8686)
@@ -4128,6 +4183,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "open-studio",
         help="Alias for graph-studio.",
         description="Alias for graph-studio/ui/edit-graph. Starts the localhost Graph Studio and opens it by default.",
+        parents=[common_runtime],
     )
     open_studio.add_argument("--host", default="127.0.0.1")
     open_studio.add_argument("--port", type=int, default=8686)
@@ -6550,6 +6606,9 @@ def main() -> None:
     if command == "serve" and getattr(args, "transport", None):
         config.transport = str(args.transport).strip().lower()
         config.validate()
+    quiet = bool(getattr(args, "quiet", False))
+    if command in {"serve", "edit-graph", "view-graph", "ui", "graph-studio", "open-studio"} and should_print_banner(config, quiet):
+        _print_startup_banner(config)
     log_stream = sys.stderr if config.transport == "stdio" else sys.stdout
     configure_logging(config.log_level, stream=log_stream)
     LOGGER.info("waggle_startup")

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import base64
-from importlib.metadata import PackageNotFoundError, version as metadata_version
 import getpass
 import json
 import logging
@@ -19,6 +18,8 @@ import webbrowser
 from contextlib import asynccontextmanager, suppress
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as metadata_version
 from pathlib import Path
 from typing import Any
 
@@ -3949,10 +3950,10 @@ def _resolve_runtime_version() -> str:
     try:
         return metadata_version("waggle-mcp")
     except PackageNotFoundError:  # pragma: no cover
-        return "0.0.1"
+        return waggle.FALLBACK_VERSION
 
 
-def _is_falsey_banner_value(value: str | None) -> bool:
+def _is_falsy_banner_value(value: str | None) -> bool:
     return value is not None and value.strip().lower() in {"0", "false", "no", "off"}
 
 
@@ -3973,7 +3974,7 @@ def should_print_banner(config: AppConfig, quiet: bool) -> bool:
     isatty = sys.stdout.isatty()
     if quiet:
         return False
-    if _is_falsey_banner_value(os.environ.get("WAGGLE_BANNER")):
+    if _is_falsy_banner_value(os.environ.get("WAGGLE_BANNER")):
         return False
     if config.transport == "stdio" and not isatty:
         return False
@@ -3981,8 +3982,6 @@ def should_print_banner(config: AppConfig, quiet: bool) -> bool:
 
 
 def _print_startup_banner(config: AppConfig) -> None:
-    import sys
-
     print(format_runtime_banner(config), file=sys.stderr)
 
 

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -6610,7 +6610,9 @@ def main() -> None:
         config.transport = str(args.transport).strip().lower()
         config.validate()
     quiet = bool(getattr(args, "quiet", False))
-    if command in {"serve", "edit-graph", "view-graph", "ui", "graph-studio", "open-studio"} and should_print_banner(config, quiet):
+    if command in {"serve", "edit-graph", "view-graph", "ui", "graph-studio", "open-studio"} and should_print_banner(
+        config, quiet
+    ):
         _print_startup_banner(config)
     log_stream = sys.stderr if config.transport == "stdio" else sys.stdout
     configure_logging(config.log_level, stream=log_stream)

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -3970,17 +3970,20 @@ def format_runtime_banner(config: AppConfig) -> str:
 
 
 def should_print_banner(config: AppConfig, quiet: bool) -> bool:
+    isatty = sys.stdout.isatty()
     if quiet:
         return False
     if _is_falsey_banner_value(os.environ.get("WAGGLE_BANNER")):
         return False
-    if config.transport == "stdio" and not sys.stdout.isatty():
+    if config.transport == "stdio" and not isatty:
         return False
-    return sys.stdout.isatty()
+    return isatty
 
 
 def _print_startup_banner(config: AppConfig) -> None:
-    print(format_runtime_banner(config))
+    import sys
+
+    print(format_runtime_banner(config), file=sys.stderr)
 
 
 def _default_graph(config: AppConfig | None = None) -> Any:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import io
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -1591,6 +1592,119 @@ def test_cli_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
     captured = capsys.readouterr()
     assert excinfo.value.code == 0
     assert f"waggle-mcp {waggle.__version__}" in captured.out
+
+
+def test_runtime_version_falls_back_to_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server_module.waggle, "version", "")
+    monkeypatch.setattr(server_module.waggle, "__version__", "")
+    monkeypatch.setattr(server_module, "metadata_version", lambda package_name: "9.9.9")
+
+    assert server_module._resolve_runtime_version() == "9.9.9"
+
+
+def test_format_runtime_banner() -> None:
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="all-MiniLM-L6-v2",
+        db_path="C:/Users/waggle/.waggle/waggle.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024 * 1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+
+    banner = server_module.format_runtime_banner(config)
+    assert f"Waggle MCP {waggle.__version__}" in banner
+    assert "Backend:    sqlite" in banner
+    assert "Model:      all-MiniLM-L6-v2" in banner
+    assert "DB path:    C:/Users/waggle/.waggle/waggle.db" in banner
+    assert "Transport:  stdio" in banner
+    assert "Tenant:     local-default" in banner
+
+
+def test_should_print_banner_suppression(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="all-MiniLM-L6-v2",
+        db_path="C:/Users/waggle/.waggle/waggle.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024 * 1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+    monkeypatch.setattr(server_module.sys, "stdout", SimpleNamespace(isatty=lambda: False))
+    monkeypatch.delenv("WAGGLE_BANNER", raising=False)
+
+    assert server_module.should_print_banner(config, quiet=False) is False
+
+    monkeypatch.setattr(server_module.sys, "stdout", SimpleNamespace(isatty=lambda: True))
+    assert server_module.should_print_banner(config, quiet=True) is False
+
+    monkeypatch.setenv("WAGGLE_BANNER", "false")
+    assert server_module.should_print_banner(config, quiet=False) is False
+
+
+def test_startup_banner_prints_in_interactive_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="all-MiniLM-L6-v2",
+        db_path="C:/Users/waggle/.waggle/waggle.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024 * 1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+    class TtyBuffer(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    buffer = TtyBuffer()
+    monkeypatch.setattr(server_module.sys, "stdout", buffer)
+    monkeypatch.delenv("WAGGLE_BANNER", raising=False)
+
+    if server_module.should_print_banner(config, quiet=False):
+        server_module._print_startup_banner(config)
+
+    banner = buffer.getvalue()
+    assert f"Waggle MCP {waggle.__version__}" in banner
+    assert "Backend:    sqlite" in banner
+    assert "Model:      all-MiniLM-L6-v2" in banner
+    assert "DB path:    C:/Users/waggle/.waggle/waggle.db" in banner
+    assert "Transport:  stdio" in banner
+    assert "Tenant:     local-default" in banner
 
 
 def test_store_node_reports_deduplication(tmp_path: Path) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1595,7 +1595,7 @@ def test_cli_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_runtime_version_falls_back_to_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server_module.waggle, "version", "")
+    monkeypatch.setattr(server_module.waggle, "runtime_version", "")
     monkeypatch.setattr(server_module.waggle, "__version__", "")
     monkeypatch.setattr(server_module, "metadata_version", lambda package_name: "9.9.9")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,6 +121,31 @@ def write_waggle_codex_config(home: Path, db_path: Path) -> None:
     )
 
 
+def make_runtime_banner_config(**overrides: object) -> AppConfig:
+    values = {
+        "backend": "sqlite",
+        "transport": "stdio",
+        "model_name": "all-MiniLM-L6-v2",
+        "db_path": "C:/Users/waggle/.waggle/waggle.db",
+        "default_tenant_id": "local-default",
+        "http_host": "127.0.0.1",
+        "http_port": 8080,
+        "log_level": "INFO",
+        "rate_limit_rpm": 120,
+        "write_rate_limit_rpm": 60,
+        "max_concurrent_requests": 8,
+        "max_payload_bytes": 1024 * 1024,
+        "request_timeout_seconds": 30,
+        "export_dir": None,
+        "neo4j_uri": "",
+        "neo4j_username": "",
+        "neo4j_password": "",
+        "neo4j_database": "",
+    }
+    values.update(overrides)
+    return AppConfig(**values)
+
+
 def test_store_node_and_stats_tool(tmp_path: Path) -> None:
     app = make_app(tmp_path)
 
@@ -1603,26 +1628,7 @@ def test_runtime_version_falls_back_to_metadata(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_format_runtime_banner() -> None:
-    config = AppConfig(
-        backend="sqlite",
-        transport="stdio",
-        model_name="all-MiniLM-L6-v2",
-        db_path="C:/Users/waggle/.waggle/waggle.db",
-        default_tenant_id="local-default",
-        http_host="127.0.0.1",
-        http_port=8080,
-        log_level="INFO",
-        rate_limit_rpm=120,
-        write_rate_limit_rpm=60,
-        max_concurrent_requests=8,
-        max_payload_bytes=1024 * 1024,
-        request_timeout_seconds=30,
-        export_dir=None,
-        neo4j_uri="",
-        neo4j_username="",
-        neo4j_password="",
-        neo4j_database="",
-    )
+    config = make_runtime_banner_config()
 
     banner = server_module.format_runtime_banner(config)
     assert f"Waggle MCP {waggle.__version__}" in banner
@@ -1634,26 +1640,7 @@ def test_format_runtime_banner() -> None:
 
 
 def test_should_print_banner_suppression(monkeypatch: pytest.MonkeyPatch) -> None:
-    config = AppConfig(
-        backend="sqlite",
-        transport="stdio",
-        model_name="all-MiniLM-L6-v2",
-        db_path="C:/Users/waggle/.waggle/waggle.db",
-        default_tenant_id="local-default",
-        http_host="127.0.0.1",
-        http_port=8080,
-        log_level="INFO",
-        rate_limit_rpm=120,
-        write_rate_limit_rpm=60,
-        max_concurrent_requests=8,
-        max_payload_bytes=1024 * 1024,
-        request_timeout_seconds=30,
-        export_dir=None,
-        neo4j_uri="",
-        neo4j_username="",
-        neo4j_password="",
-        neo4j_database="",
-    )
+    config = make_runtime_banner_config()
     monkeypatch.setattr(server_module.sys, "stdout", SimpleNamespace(isatty=lambda: False))
     monkeypatch.delenv("WAGGLE_BANNER", raising=False)
 
@@ -1668,38 +1655,22 @@ def test_should_print_banner_suppression(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_startup_banner_prints_in_interactive_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    config = AppConfig(
-        backend="sqlite",
-        transport="stdio",
-        model_name="all-MiniLM-L6-v2",
-        db_path="C:/Users/waggle/.waggle/waggle.db",
-        default_tenant_id="local-default",
-        http_host="127.0.0.1",
-        http_port=8080,
-        log_level="INFO",
-        rate_limit_rpm=120,
-        write_rate_limit_rpm=60,
-        max_concurrent_requests=8,
-        max_payload_bytes=1024 * 1024,
-        request_timeout_seconds=30,
-        export_dir=None,
-        neo4j_uri="",
-        neo4j_username="",
-        neo4j_password="",
-        neo4j_database="",
-    )
+    config = make_runtime_banner_config()
+
     class TtyBuffer(io.StringIO):
         def isatty(self) -> bool:
             return True
 
-    buffer = TtyBuffer()
-    monkeypatch.setattr(server_module.sys, "stdout", buffer)
+    stdout = TtyBuffer()
+    stderr = io.StringIO()
+    monkeypatch.setattr(server_module.sys, "stdout", stdout)
+    monkeypatch.setattr(server_module.sys, "stderr", stderr)
     monkeypatch.delenv("WAGGLE_BANNER", raising=False)
 
     if server_module.should_print_banner(config, quiet=False):
         server_module._print_startup_banner(config)
 
-    banner = buffer.getvalue()
+    banner = stderr.getvalue()
     assert f"Waggle MCP {waggle.__version__}" in banner
     assert "Backend:    sqlite" in banner
     assert "Model:      all-MiniLM-L6-v2" in banner

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1662,8 +1662,9 @@ def test_should_print_banner_suppression(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(server_module.sys, "stdout", SimpleNamespace(isatty=lambda: True))
     assert server_module.should_print_banner(config, quiet=True) is False
 
-    monkeypatch.setenv("WAGGLE_BANNER", "false")
-    assert server_module.should_print_banner(config, quiet=False) is False
+    for value in ["0", "false", "no", "off", " FALSE ", " Off "]:
+        monkeypatch.setenv("WAGGLE_BANNER", value)
+        assert server_module.should_print_banner(config, quiet=False) is False
 
 
 def test_startup_banner_prints_in_interactive_mode(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Title
Add interactive startup banner for waggle-mcp serve

Summary

Added a short startup banner for interactive CLI runs of waggle-mcp serve.
The banner shows Waggle version, backend, model, DB path, transport, and tenant.
Banner output is suppressed for stdio/non-TTY runs, --quiet, and WAGGLE_BANNER=false to avoid corrupting MCP streams.
Added a version fallback so the banner and --version resolve from waggle.version, then waggle.__version__, then package metadata.
Updated docs to mention the banner and how to disable it.
Tests

Added coverage for banner formatting, interactive printing, TTY suppression, quiet mode, banner env suppression, and version fallback.
Verified with python -m pytest tests/test_server.py

@ard12 please check it, and if every thing off add SSoC26 badge and hardness level and close the pr

closes #253 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup banner shown for `waggle-mcp serve` and related UI commands in interactive terminals; can be disabled with `--quiet` or `WAGGLE_BANNER=false`; skipped for non-TTY runs.
  * `--version` reports the resolved runtime version.

* **Documentation**
  * CLI reference and troubleshooting updated to describe banner behavior, TTY handling, and disable options.

* **Tests**
  * Added tests for version resolution and banner display/suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->