### PR TITLE
test: add edge-case tests for api_key_prefix

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,10 +2,7 @@ from waggle.auth import api_key_prefix
 
 
 def test_api_key_prefix_standard_format():
-    assert (
-        api_key_prefix("sk_live_abc123.secret_part_here")
-        == "sk_live_abc123"
-    )
+    assert api_key_prefix("sk_live_abc123.secret_part_here") == "sk_live_abc123"
 
 
 def test_api_key_prefix_multiple_dots_only_splits_on_first():
@@ -26,10 +23,7 @@ def test_api_key_prefix_exactly_sixteen_characters():
 
 
 def test_api_key_prefix_strips_whitespace():
-    assert (
-        api_key_prefix("   sk_live_abc.secret   ")
-        == "sk_live_abc"
-    )
+    assert api_key_prefix("   sk_live_abc.secret   ") == "sk_live_abc"
 
 
 def test_api_key_prefix_empty_string():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,58 @@
+from waggle.auth import api_key_prefix
+
+
+def test_api_key_prefix_standard_format():
+    assert (
+        api_key_prefix("sk_live_abc123.secret_part_here")
+        == "sk_live_abc123"
+    )
+
+
+def test_api_key_prefix_multiple_dots_only_splits_on_first():
+    assert api_key_prefix("sk_test_a.b.c") == "sk_test_a"
+
+
+def test_api_key_prefix_short_key_without_dot():
+    assert api_key_prefix("short") == "short"
+
+
+def test_api_key_prefix_long_key_without_dot():
+    assert api_key_prefix("a" * 100) == "a" * 16
+
+
+def test_api_key_prefix_exactly_sixteen_characters():
+    key = "a" * 16
+    assert api_key_prefix(key) == key
+
+
+def test_api_key_prefix_strips_whitespace():
+    assert (
+        api_key_prefix("   sk_live_abc.secret   ")
+        == "sk_live_abc"
+    )
+
+
+def test_api_key_prefix_empty_string():
+    assert api_key_prefix("") == ""
+
+
+def test_api_key_prefix_whitespace_only():
+    assert api_key_prefix("   ") == ""
+
+
+def test_api_key_prefix_dot_only():
+    assert api_key_prefix(".") == ""
+
+
+def test_api_key_prefix_never_exceeds_sixteen_characters_without_dot():
+    samples = [
+        "",
+        "a",
+        "short",
+        "a" * 16,
+        "a" * 32,
+        "a" * 100,
+    ]
+
+    for sample in samples:
+        assert len(api_key_prefix(sample)) <= 16


### PR DESCRIPTION
## Summary

* Added a new `tests/test_auth.py` file with dedicated edge-case tests for `api_key_prefix`.
* Covered all scenarios listed in Issue #254, including standard API keys, multiple dots, short and long keys without dots, exact 16-character keys, whitespace handling, empty inputs, dot-only inputs, and the length-bound property assertion.
* This was needed because `api_key_prefix` is used in security-relevant logging and audit paths but previously had no dedicated edge-case test coverage.

## Testing

* [x] `WAGGLE_MODEL=deterministic pytest -q`
* [x] `ruff check src/ tests/`
* [x] `ruff format --check src/ tests/`

Additional verification:

* [x] `python -m pytest tests/test_auth.py -q`
* [x] `python -m ruff check tests/test_auth.py`

### Test report

```text
$ python -m pytest tests/test_auth.py -q

..........                                                               [100%]
10 passed in 2.50s

$ WAGGLE_MODEL=deterministic pytest -q

608 passed, 5 skipped, 1 warning in 131.69s
```

Notes:

* `ruff check src/ tests/` passed locally.
* The full test suite passed locally after installing the project's development dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for authentication key validation with comprehensive unit tests covering various input scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->