### PR TITLE
test: guard Codex config docs against drift

### DIFF
--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -24,12 +24,12 @@ Add Waggle to `~/.codex/config.toml`:
 [mcp_servers.waggle]
 command = "waggle-mcp"
 args = ["serve", "--transport", "stdio"]
-env = {
-  WAGGLE_BACKEND = "sqlite",
-  WAGGLE_DB_PATH = "~/.waggle/waggle.db",
-  WAGGLE_DEFAULT_TENANT_ID = "local-default",
-  WAGGLE_MODEL = "all-MiniLM-L6-v2"
-}
+
+[mcp_servers.waggle.env]
+WAGGLE_BACKEND = "sqlite"
+WAGGLE_DB_PATH = "~/.waggle/waggle.db"
+WAGGLE_DEFAULT_TENANT_ID = "local-default"
+WAGGLE_MODEL = "all-MiniLM-L6-v2"
 ```
 
 A pre-filled example is available at

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -71,3 +71,25 @@ def test_graph_ui_bundle_contains_expected_static_assets() -> None:
         + ", ".join(missing)
         + ". Rebuild or restore src/waggle/static/graph before packaging."
     )
+
+
+def _extract_toml_fence(markdown: str, *, expected_table: str) -> str:
+    for match in re.finditer(r"```toml\n(.*?)\n```", markdown, re.DOTALL):
+        block = match.group(1)
+        if expected_table in block:
+            return block
+
+    raise AssertionError(f"Could not find a TOML code fence containing {expected_table!r}.")
+
+
+def test_codex_install_guide_matches_shipped_example_config() -> None:
+    codex_guide = (ROOT / "docs" / "install" / "codex.md").read_text()
+    example_config = (ROOT / "examples" / "codex_config.example.toml").read_text()
+
+    documented = tomllib.loads(_extract_toml_fence(codex_guide, expected_table="[mcp_servers.waggle]"))
+    shipped = tomllib.loads(example_config)
+
+    assert documented["mcp_servers"]["waggle"] == shipped["mcp_servers"]["waggle"], (
+        "docs/install/codex.md drifted from examples/codex_config.example.toml. "
+        "Keep the documented Waggle command, args, and env values aligned."
+    )


### PR DESCRIPTION
## Summary

- add a packaging regression test that parses the Codex install guide TOML snippet and compares it against `examples/codex_config.example.toml`
- switch the documented `env` block in `docs/install/codex.md` to valid nested TOML so the guide is copy-pasteable and structurally matches the shipped example
- close #301

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

### Test report

```text
$ source .venv/bin/activate && pytest tests/test_packaging_metadata.py -q
.......                                                                  [100%]
7 passed in 0.01s

$ source .venv/bin/activate && ruff check tests/test_packaging_metadata.py docs/install/codex.md
All checks passed!

$ source .venv/bin/activate && ruff format --check tests/test_packaging_metadata.py
1 file already formatted
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated manual install guide to show Waggle environment variables using TOML table syntax with explicit WAGGLE_* keys for clarity.

* **Tests**
  * Added a new test and supporting parsing helper to automatically verify the documented TOML configuration matches the shipped example config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->