### PR TITLE
fix(config): surface invalid numeric env vars as ValidationFailure

### DIFF
--- a/src/waggle/config.py
+++ b/src/waggle/config.py
@@ -45,6 +45,25 @@ def resolve_default_db_path() -> str:
     return DEFAULT_DB_PATH
 
 
+def _parse_int_env(name: str, default: str) -> int:
+    value = os.environ.get(name, default)
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValidationFailure(
+            f"{name} must be an integer."
+        ) from exc
+
+
+def _parse_float_env(name: str, default: str) -> float:
+    value = os.environ.get(name, default)
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ValidationFailure(
+            f"{name} must be a valid number."
+        ) from exc
+    
 @dataclass(slots=True)
 class AppConfig:
     backend: str
@@ -108,13 +127,13 @@ class AppConfig:
             http_host=os.environ.get("WAGGLE_HTTP_HOST", "0.0.0.0"),
             http_port=int(resolved_http_port),
             log_level=os.environ.get("WAGGLE_LOG_LEVEL", "INFO"),
-            rate_limit_rpm=int(os.environ.get("WAGGLE_RATE_LIMIT_RPM", "120")),
+            rate_limit_rpm=_parse_int_env("WAGGLE_RATE_LIMIT_RPM","120",),
             write_rate_limit_rpm=int(os.environ.get("WAGGLE_WRITE_RATE_LIMIT_RPM", "60")),
             max_concurrent_requests=int(os.environ.get("WAGGLE_MAX_CONCURRENT_REQUESTS", "8")),
             max_payload_bytes=int(os.environ.get("WAGGLE_MAX_PAYLOAD_BYTES", str(1024 * 1024))),
             request_timeout_seconds=int(os.environ.get("WAGGLE_REQUEST_TIMEOUT_SECONDS", "30")),
             recency_half_life_days=float(os.environ.get("WAGGLE_RECENCY_HALF_LIFE_DAYS", "30.0")),
-            hybrid_vector_weight=float(os.environ.get("WAGGLE_HYBRID_VECTOR_WEIGHT", "1.0")),
+            hybrid_vector_weight=_parse_float_env("WAGGLE_HYBRID_VECTOR_WEIGHT","1.0",),
             hybrid_bm25_weight=float(os.environ.get("WAGGLE_HYBRID_BM25_WEIGHT", "1.0")),
             hybrid_graph_weight=float(os.environ.get("WAGGLE_HYBRID_GRAPH_WEIGHT", "1.0")),
             hybrid_recency_weight=float(os.environ.get("WAGGLE_HYBRID_RECENCY_WEIGHT", "1.0")),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -95,3 +95,15 @@ def test_zero_hybrid_weights_are_allowed() -> None:
     )
 
     config.validate()
+def test_invalid_rate_limit_rpm_raises_validation_failure(monkeypatch):
+    monkeypatch.setenv("WAGGLE_RATE_LIMIT_RPM", "abc")
+
+    with pytest.raises(ValidationFailure, match="WAGGLE_RATE_LIMIT_RPM"):
+        AppConfig.from_env()
+
+
+def test_invalid_hybrid_vector_weight_raises_validation_failure(monkeypatch):
+    monkeypatch.setenv("WAGGLE_HYBRID_VECTOR_WEIGHT", "abc")
+
+    with pytest.raises(ValidationFailure, match="WAGGLE_HYBRID_VECTOR_WEIGHT"):
+        AppConfig.from_env()


### PR DESCRIPTION
## Summary

Fixes #293.

`AppConfig.from_env()` previously performed direct numeric parsing for environment variables such as:

* `WAGGLE_RATE_LIMIT_RPM`
* `WAGGLE_HYBRID_VECTOR_WEIGHT`

Malformed values (for example `"abc"`) raised raw Python `ValueError` exceptions before Waggle's configuration validation flow could handle them.

This change introduces safe parsing helpers that convert parsing failures into `ValidationFailure` exceptions with configuration-specific error messages.

## Changes

* Added helper functions for integer and float environment variable parsing.
* Converted invalid numeric parsing failures into `ValidationFailure`.
* Added regression tests covering:

  * Invalid `WAGGLE_RATE_LIMIT_RPM`
  * Invalid `WAGGLE_HYBRID_VECTOR_WEIGHT`

## Testing

```bash
python -m pytest tests/test_config.py -v
```

Result:

```text
10 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable validation for rate limit and hybrid vector weight configuration with more descriptive error messages when non-numeric values are encountered.

* **Tests**
  * Added test cases to verify proper validation and error handling for invalid configuration values from environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->