### PR TITLE
docs(install): add a client support matrix to docs/install/README.md

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -19,6 +19,23 @@ No cloud account. No API key. Local by default.
 - [Troubleshooting](./troubleshooting.md)
 - [Windows setup & troubleshooting](./troubleshooting.md#windows-specific-troubleshooting)
 
+## Client support matrix
+
+Every path runs Waggle as a local **stdio** server, so begin with `pipx install waggle-mcp` in all cases. The table shows the quickest setup for each client and where its MCP config lives.
+
+| Client | Quickest install path | MCP config location |
+|---|---|---|
+| [VS Code](./vscode.md) | Marketplace extension (`Waggle: Enable for this Workspace`) | `.vscode/mcp.json` (`servers` root) |
+| [Smithery](./smithery.md) | `smithery.yaml` bundle (stdio) | root `smithery.yaml` |
+| [Claude Code](./claude-code.md) | CLI &mdash; `claude mcp add ... waggle` | CLI-managed (`.mcp.json` / user config) |
+| [Claude Desktop](./claude-desktop.md) | `waggle-mcp setup --yes --clients claude-desktop` | `claude_desktop_config.json` (OS path in guide) |
+| [Codex](./codex.md) | `waggle-mcp setup --yes` (writes `AGENTS.md` block) | `~/.codex/config.toml` |
+| [Cursor](./cursor.md) | `waggle-mcp setup --yes --clients cursor` | `~/.cursor/mcp.json` |
+| [Antigravity](./antigravity.md) | `waggle-mcp setup --yes --clients antigravity` | generic stdio JSON |
+| [Generic MCP clients](./generic-mcp.md) | manual stdio JSON | client's own MCP config |
+
+Prefer to wire it up by hand? Each guide above also documents a manual config block.
+
 ## One-line install
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #296.

The install landing page (`docs/install/README.md`) was just a link list. This PR adds a compact **client support matrix** right after the install-methods links so users can pick the correct setup path at a glance.

For each supported client the table shows:
- the **quickest install path** — extension / `setup --yes` / CLI / `smithery.yaml` bundle / manual
- **where the MCP config lives** (e.g. `.vscode/mcp.json`, `~/.cursor/mcp.json`, `~/.codex/config.toml`, Claude Desktop config, etc.)

A short intro note reminds readers every path is local-first over **stdio** and starts with `pipx install waggle-mcp`.

## Acceptance criteria
- [x] Table lists each supported client
- [x] Shows whether the path uses `setup --yes`, manual config, an extension, or a bundle
- [x] Notes where the MCP config lives for each client
- [x] Compact / easy to scan on GitHub mobile and desktop (3 columns)

Each row links to the existing per-client guide, which still documents the full manual config block. No other files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide with a new client support matrix mapping each supported client to the quickest setup path and corresponding MCP configuration location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->