### PR TITLE
docs(graph-ui): document screenshot refresh workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,8 @@ A local browser-based graph editor for inspecting and editing memory directly. F
 
 `waggle-mcp push` encrypts `.abhi` exports by default. Export paths refuse to proceed if transcript text contains likely secrets unless you pass `--force`.
 
+*Note: Screenshot assets belong under [assets/](./assets/). See [apps/mcp/graph-ui/README.md](./apps/mcp/graph-ui/README.md) for screenshot update guidelines and local development review instructions.*
+
 ---
 
 ## Model Support

--- a/apps/mcp/graph-ui/README.md
+++ b/apps/mcp/graph-ui/README.md
@@ -82,6 +82,17 @@ The dev server reads these from the shell or a `.env` file in `apps/mcp/graph-ui
 
 ---
 
-## Screenshots
+## Screenshots & Preview Artifacts
 
-> Run `waggle-mcp edit-graph` to launch Graph Studio in your browser.
+### Screenshot Maintenance
+
+* **Storage:** Screenshot assets belong under the version-controlled `assets/` directory at the repository root.
+* **Updates:** Screenshots should be refreshed manually after Graph Studio UI changes, and related documentation should be updated to match.
+* **Optimization:** Checked-in images should remain lightweight.
+
+### Historical Artifacts
+
+* `sample-preview.html` was a standalone preview artifact used during earlier Graph Studio development and review workflows.
+* The file has been removed from the active codebase and is no longer maintained.
+* Current Graph Studio review and verification should use the active development workflow described in this document.
+

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -275,19 +275,20 @@ What this feature does:
 Primary files:
 - `src/waggle/graph_ui.py`
 - `apps/mcp/graph-ui/**`
-- `assets/**`
+- `assets/**` (Storage directory for version-controlled documentation assets)
 
 Change here when:
 - UI pages fail to load
 - Static assets are broken
-- The Graph Studio flow needs improvement
+- The Graph Studio flow needs improvement or UI changes require refreshing screenshots
+
+Asset & Preview Guidelines:
+- **Screenshots:** Screenshot assets belong in `assets/`. They must remain lightweight and be updated manually when the UI changes. Ensure matching documentation files are updated alongside them.
+- **Historical Previews:** The standalone `sample-preview.html` file is historical and has been removed. Local UI reviews must use the current Graph Studio development workflow documented in [apps/mcp/graph-ui/README.md](../apps/mcp/graph-ui/README.md).
 
 Tests and checks:
 - Read `apps/mcp/graph-ui/README.md`
 - If changing frontend code, verify the UI manually after the change
-
-Blast radius:
-- Medium. Usually isolated, but packaging and asset paths can leak into the server surface.
 
 ### 9. Packaging and external distributions
 

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -290,6 +290,8 @@ Tests and checks:
 - Read `apps/mcp/graph-ui/README.md`
 - If changing frontend code, verify the UI manually after the change
 
+Blast radius:
+- Medium. Usually isolated, but packaging and asset paths can leak into the server surface.
 ### 9. Packaging and external distributions
 
 What this feature does:


### PR DESCRIPTION
Fixes #303

## Summary

- Documented where Graph Studio screenshot assets belong
- Added guidance for manually refreshing screenshots after UI changes
- Documented the historical role of sample-preview.html
- Added Graph Studio asset guidance to the repository map

## Testing

Documentation-only change.

## Notes

Kept instructions lightweight and based on existing repository workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidelines for storing and managing screenshot and preview assets in the repository
  * Added guidance on when/how to refresh and keep preview materials lightweight
  * Updated workflow and quality expectations for UI-related documentation and preview artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->