### PR TITLE
docs(issue-templates): link issue templates to support docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,6 +10,8 @@ body:
         Thanks for filing a bug. Please include enough detail for someone new to the codebase to reproduce it.
         
         Before you submit:
+        - check the troubleshooting guide: https://github.com/Abhigyan-Shekhar/Waggle-mcp/blob/main/docs/install/troubleshooting.md
+        - report exploitable vulnerabilities through the security policy instead: https://github.com/Abhigyan-Shekhar/Waggle-mcp/security/policy
         - install Waggle from PyPI: https://pypi.org/project/waggle-mcp/
         - install the VS Code extension: https://marketplace.visualstudio.com/items?itemName=Abhigyan-Shekhar.waggle-memory
         - attach a screenshot of the issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,8 @@ body:
     attributes:
       value: |
         Before you submit:
+        - check the repository map for likely implementation areas: https://github.com/Abhigyan-Shekhar/Waggle-mcp/blob/main/docs/repository-map.md
+        - review the security policy if the request touches secrets, exports, sharing, or auth: https://github.com/Abhigyan-Shekhar/Waggle-mcp/security/policy
         - install Waggle from PyPI: https://pypi.org/project/waggle-mcp/
         - install the VS Code extension: https://marketplace.visualstudio.com/items?itemName=Abhigyan-Shekhar.waggle-memory
         - attach a screenshot or mockup that shows the issue, gap, or requested UX
@@ -36,7 +38,7 @@ body:
     id: scope
     attributes:
       label: Suggested implementation scope
-      description: Mention likely files, modules, or commands if you know them.
+      description: Mention likely files, modules, or commands if you know them. The repository map can help narrow the scope.
       placeholder: src/waggle/server.py, docs/install/, tests/test_server.py
   - type: textarea
     id: screenshot


### PR DESCRIPTION
## Summary

- Added direct support links to the bug report form for the troubleshooting guide and security policy.
- Added feature request guidance links for the repository map and security policy, and clarified the implementation scope prompt.
- This was needed so reporters can find the right troubleshooting, repository scope, and security-reporting guidance before opening an issue.

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

### Test report

No pytest files were added or changed in this PR; this only updates GitHub issue template YAML files.

```text
628 passed, 5 skipped, 1 warning in 61.84s (0:01:01)
```

Closes #297


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bug report issue template with a new checklist item directing users to properly report exploitable security vulnerabilities through the repository's security policy
  * Enhanced feature request issue template with additional guidance links to repository documentation and security resources, helping contributors scope and submit feature requests more effectively

<!-- end of auto-generated comment: release notes by coderabbit.ai -->