### PR TITLE
docs: make screenshot guidance conditional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,9 +12,9 @@ body:
         Before you submit:
         - install Waggle from PyPI: https://pypi.org/project/waggle-mcp/
         - install the VS Code extension: https://marketplace.visualstudio.com/items?itemName=Abhigyan-Shekhar.waggle-memory
-        - attach a screenshot of the issue
-        
-        Issues without a screenshot will not be considered.
+        - attach a screenshot when it helps explain or reproduce the issue
+
+        Screenshots are encouraged when they help explain or reproduce the issue, but CLI errors, logs, stack traces, packaging issues, accessibility concerns, and security-related reports may be reported without screenshots.
   - type: textarea
     id: summary
     attributes:
@@ -87,11 +87,9 @@ body:
   - type: textarea
     id: screenshot
     attributes:
-      label: Screenshot
-      description: Attach or paste a screenshot that shows the issue. Issues without a screenshot will not be considered.
+      label: Screenshot (optional)
+      description: Attach a screenshot if it helps demonstrate the issue. For CLI errors, test failures, packaging issues, accessibility concerns, or security-related reports, logs and detailed descriptions may be sufficient.
       placeholder: Paste the screenshot link or drag the screenshot into the issue body.
-    validations:
-      required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,9 +10,9 @@ body:
         Before you submit:
         - install Waggle from PyPI: https://pypi.org/project/waggle-mcp/
         - install the VS Code extension: https://marketplace.visualstudio.com/items?itemName=Abhigyan-Shekhar.waggle-memory
-        - attach a screenshot or mockup that shows the issue, gap, or requested UX
+        - attach a screenshot or mockup when it helps explain the issue, gap, or requested UX
 
-        Issues without a screenshot will not be considered.
+        Screenshots and mockups are encouraged when they help clarify the request, but they are not required for every feature request.
   - type: textarea
     id: problem
     attributes:
@@ -41,8 +41,6 @@ body:
   - type: textarea
     id: screenshot
     attributes:
-      label: Screenshot or mockup
-      description: Attach or paste a screenshot or mockup that makes the request concrete. Issues without one will not be considered.
+      label: Screenshot or mockup (optional)
+      description: Optional. Include a screenshot or mockup when it helps clarify the request.
       placeholder: Paste the screenshot link or drag the image into the issue body.
-    validations:
-      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,9 +267,10 @@ Use the default `pytorch` backend unless you specifically want ONNX Runtime infe
    Install and verify the current PyPI package and the VS Code extension before filing:
    `https://pypi.org/project/waggle-mcp/`
    `https://marketplace.visualstudio.com/items?itemName=Abhigyan-Shekhar.waggle-memory`
+
    Screenshots are encouraged when they help explain a bug report or feature request, but they are not required for every report.
 
-    For CLI errors, logs, stack traces, packaging issues, accessibility concerns, and security-related reports, detailed descriptions and logs may be more useful than screenshots.
+   For CLI errors, logs, stack traces, packaging issues, accessibility concerns, and security-related reports, detailed descriptions and logs may be more useful than screenshots.
 2. **Fork and branch** from `main`. Use a descriptive branch name like `fix/dockerfile-version` or `feat/dry-run-import`.
 3. **Keep PRs focused.** One logical change per PR makes review faster.
 4. **Write a clear description.** Explain *what* changed, *why* it was needed, and how you verified it. Link the issue with `Fixes #123` or explain why no issue is needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,9 @@ Use the default `pytorch` backend unless you specifically want ONNX Runtime infe
    Install and verify the current PyPI package and the VS Code extension before filing:
    `https://pypi.org/project/waggle-mcp/`
    `https://marketplace.visualstudio.com/items?itemName=Abhigyan-Shekhar.waggle-memory`
-   If an issue does not include a screenshot of the problem, it will not be considered.
+   Screenshots are encouraged when they help explain a bug report or feature request, but they are not required for every report.
+
+    For CLI errors, logs, stack traces, packaging issues, accessibility concerns, and security-related reports, detailed descriptions and logs may be more useful than screenshots.
 2. **Fork and branch** from `main`. Use a descriptive branch name like `fix/dockerfile-version` or `feat/dry-run-import`.
 3. **Keep PRs focused.** One logical change per PR makes review faster.
 4. **Write a clear description.** Explain *what* changed, *why* it was needed, and how you verified it. Link the issue with `Fixes #123` or explain why no issue is needed.


### PR DESCRIPTION
## Summary

This PR updates issue templates and contributing documentation to encourage screenshots when helpful rather than requiring them for every report.

## Changes

- Updated bug report template guidance
- Updated feature request template guidance
- Made screenshot and mockup fields optional
- Updated CONTRIBUTING.md guidance

## Why

CLI errors, logs, stack traces, packaging issues, accessibility concerns, and security-related reports are often better explained with logs or detailed text than screenshots.

Fixes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue templates to make screenshots optional rather than required for bug reports and feature requests.
  * Added guidance clarifying that CLI errors, logs, stack traces, packaging issues, accessibility concerns, and security-related reports can be submitted without visual documentation.
  * Contribution guidelines now encourage but do not mandate screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->