### PR TITLE
feat(setup): add --hooks for per-tool hook selection (#323) 

### DIFF
--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -6182,6 +6182,7 @@ def _run_setup(args: argparse.Namespace) -> int:
     db_path = str(Path(db_path_raw).expanduser().resolve())
     python_exe = _python_exe()
     clients = _setup_clients_from_args(args.clients)
+    hook_tools = _hook_tools_from_args(getattr(args, "hooks", "auto"), bool(getattr(args, "no_hooks", False)))
 
     print()
     print(_c(_BOLD, "waggle-mcp setup"))
@@ -6193,6 +6194,9 @@ def _run_setup(args: argparse.Namespace) -> int:
         print("  mode: dry-run")
         for client in clients:
             _ok(f"Would configure {client}")
+        if "Claude Code" in hook_tools:
+            hooks_path = _find_claude_settings()
+            _ok(f"Would install Claude Code hooks in {hooks_path}")
         if args.project_instructions and "Codex" in clients:
             agents_path = (Path.cwd() / "AGENTS.md").resolve()
             _ok(f"Would write Codex automatic-memory instructions to {agents_path}")
@@ -6230,7 +6234,6 @@ def _run_setup(args: argparse.Namespace) -> int:
     print()
 
     # Install automatic memory hooks for the selected hook-capable tools
-    hook_tools = _hook_tools_from_args(getattr(args, "hooks", "auto"), bool(getattr(args, "no_hooks", False)))
     if hook_tools and not args.dry_run:
         if "Claude Code" in hook_tools:
             hook_dir = Path(__file__).resolve().parent / "hooks" / "claude_code"

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -4555,7 +4555,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     setup.add_argument("--dry-run", action="store_true", help="Show what would change without writing files.")
     setup.add_argument("--run-doctor", action=argparse.BooleanOptionalAction, default=True)
-    setup.add_argument("--no-hooks", action="store_true", help="Skip Claude Code hook installation.")
+    setup.add_argument(
+        "--hooks",
+        default="auto",
+        help=(
+            "Which hook-capable tools to install automatic memory hooks for: "
+            "'auto' (all detected, currently Claude Code), 'none', or a comma-separated "
+            "list (currently supported: claude-code)."
+        ),
+    )
+    setup.add_argument(
+        "--no-hooks",
+        action="store_true",
+        help="Deprecated alias for --hooks none. Skip all hook installation.",
+    )
 
     subparsers.add_parser("init", help="Interactive setup wizard — configure an MCP client to use waggle-mcp.")
     subparsers.add_parser(
@@ -5830,6 +5843,48 @@ def _setup_clients_from_args(raw_clients: str) -> list[str]:
     return _normalize_setup_clients(raw_clients)
 
 
+# ── Hook-capable tool selection ──────────────────────────────────
+# Hooks are currently Claude-Code-specific (written to ~/.claude/settings.json),
+# separate from the MCP client config writers above. This map is the extension
+# point for future hook-capable tools.
+_HOOK_TOOL_ALIASES = {
+    "claude-code": "Claude Code",
+    "claude_code": "Claude Code",
+    "claudecode": "Claude Code",
+}
+_ALL_HOOK_TOOLS = ["Claude Code"]
+
+
+def _hook_tools_from_args(raw_hooks: str, no_hooks: bool) -> list[str]:
+    """Resolve which hook-capable tools should receive automatic memory hooks.
+
+    'auto' selects all hook-capable tools (currently Claude Code); 'none' selects
+    none. --no-hooks is a deprecated alias for --hooks none. A comma-separated
+    list selects specific tools by alias.
+    """
+    raw = (raw_hooks or "auto").strip().lower()
+    if no_hooks:
+        raw = "none"
+    if raw == "none":
+        return []
+    if raw == "auto":
+        return list(_ALL_HOOK_TOOLS)
+    tools: list[str] = []
+    for part in raw.split(","):
+        key = part.strip().lower()
+        if not key:
+            continue
+        tool = _HOOK_TOOL_ALIASES.get(key)
+        if tool is None:
+            supported = ", ".join(sorted(_HOOK_TOOL_ALIASES))
+            raise ValidationFailure(f"Unsupported hook target: {part!r}. Supported values: auto, none, {supported}.")
+        if tool not in tools:
+            tools.append(tool)
+    if not tools:
+        raise ValidationFailure("No hook targets were provided.")
+    return tools
+
+
 # ── Claude Code hook constants ────────────────────────────────────────────────
 _CLAUDE_HOOKS_BLOCK_HEADER = "# >>> waggle-managed >>>"
 _CLAUDE_HOOKS_BLOCK_FOOTER = "# <<< waggle-managed <<<"
@@ -6174,18 +6229,19 @@ def _run_setup(args: argparse.Namespace) -> int:
         print(f"  {_c(_CYAN, chr(0x27A1))}  {_RESTART_HINTS[client]}")
     print()
 
-    # Install Claude Code hooks if not suppressed
-    no_hooks = bool(getattr(args, "no_hooks", False))
-    if not no_hooks and not args.dry_run:
-        hook_dir = Path(__file__).resolve().parent / "hooks" / "claude_code"
-        if hook_dir.exists():
-            try:
-                hooks_path = _install_claude_hooks(hook_dir)
-                if hooks_path is not None:
-                    _ok(f"Claude Code hooks installed in {hooks_path}")
-            except OSError as exc:
-                # Non-fatal: hooks are optional
-                LOGGER.warning("claude_hooks_install_failed", extra={"error": str(exc)})
+    # Install automatic memory hooks for the selected hook-capable tools
+    hook_tools = _hook_tools_from_args(getattr(args, "hooks", "auto"), bool(getattr(args, "no_hooks", False)))
+    if hook_tools and not args.dry_run:
+        if "Claude Code" in hook_tools:
+            hook_dir = Path(__file__).resolve().parent / "hooks" / "claude_code"
+            if hook_dir.exists():
+                try:
+                    hooks_path = _install_claude_hooks(hook_dir)
+                    if hooks_path is not None:
+                        _ok(f"Claude Code hooks installed in {hooks_path}")
+                except OSError as exc:
+                    # Non-fatal: hooks are optional
+                    LOGGER.warning("claude_hooks_install_failed", extra={"error": str(exc)})
 
     if args.run_doctor:
         doctor_config = AppConfig.from_env()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2094,3 +2094,20 @@ class TestHookToolsFromArgs:
         # A client that has config support but no hooks (e.g. cursor) is rejected.
         with pytest.raises(ValidationFailure):
             _hook_tools_from_args("cursor", no_hooks=False)
+
+    def test_dry_run_validates_hooks(self):
+        # Regression for CodeRabbit review: invalid --hooks must be caught
+        # even in dry-run mode (validation happens before the early return).
+        args = SimpleNamespace(
+            yes=True,
+            dry_run=True,
+            db="",
+            model="all-MiniLM-L6-v2",
+            clients="codex",
+            hooks="bogus",
+            no_hooks=False,
+            project_instructions=False,
+            run_doctor=False,
+        )
+        with pytest.raises(ValidationFailure):
+            _run_setup(args)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ import pytest
 import waggle
 import waggle.server as server_module
 from waggle.config import AppConfig
+from waggle.errors import ValidationFailure
 from waggle.graph import MemoryGraph
 from waggle.models import NodeType, RelationType
 from waggle.server import (
@@ -20,6 +21,7 @@ from waggle.server import (
     _assert_runtime_feature_parity,
     _build_parser,
     _default_graph,
+    _hook_tools_from_args,
     _run_admin_command,
     _run_doctor,
     _run_graph_editor_command,
@@ -2062,3 +2064,33 @@ def test_clear_cli_commands_dry_run(tmp_path: Path, capsys: pytest.CaptureFixtur
     payload = json.loads(capsys.readouterr().out)
     assert payload["dry_run"] is True
     assert payload["deleted_nodes"] > 0
+
+
+# ── Tests for --hooks per-tool selection ─────────────────────────
+
+
+class TestHookToolsFromArgs:
+    def test_auto_selects_claude_code(self):
+        # Default behavior: 'auto' installs hooks for all hook-capable tools.
+        assert _hook_tools_from_args("auto", no_hooks=False) == ["Claude Code"]
+
+    def test_empty_defaults_to_auto(self):
+        assert _hook_tools_from_args("", no_hooks=False) == ["Claude Code"]
+
+    def test_none_selects_nothing(self):
+        assert _hook_tools_from_args("none", no_hooks=False) == []
+
+    def test_no_hooks_flag_overrides_to_none(self):
+        # --no-hooks is a deprecated alias for --hooks none and wins over auto.
+        assert _hook_tools_from_args("auto", no_hooks=True) == []
+
+    def test_explicit_claude_code(self):
+        assert _hook_tools_from_args("claude-code", no_hooks=False) == ["Claude Code"]
+
+    def test_underscore_alias(self):
+        assert _hook_tools_from_args("claude_code", no_hooks=False) == ["Claude Code"]
+
+    def test_unknown_tool_raises(self):
+        # A client that has config support but no hooks (e.g. cursor) is rejected.
+        with pytest.raises(ValidationFailure):
+            _hook_tools_from_args("cursor", no_hooks=False)


### PR DESCRIPTION
## Summary

- **What changed?** Added a `--hooks` flag to `waggle-mcp setup` that selects which hook-capable tools get automatic memory hooks: `auto` (all detected — currently Claude Code), `none`, or a comma-separated tool list (currently `claude-code`). `--no-hooks` is kept as a deprecated alias for `--hooks none`. The default (`--hooks auto`) preserves the existing behavior exactly, so current install scripts are unaffected.
- **Why was it needed?** Closes #323. Hook installation was previously all-or-nothing via the global `--no-hooks` switch. `--hooks` introduces a per-tool selection model. Hooks are currently Claude-Code-specific (written to `~/.claude/settings.json`), so today the practical effect is enable/disable for Claude Code — but the flag is structured as the extension point for future hook-capable tools rather than hard-coding a single boolean. The per-tool resolver is independent of `--clients` because hooks target Claude Code, which isn't one of the MCP client config writers.

Changes:
- `src/waggle/server.py`: added the `--hooks` argument, a `_hook_tools_from_args` resolver (auto/none/alias-list, with `--no-hooks` as a back-compat alias), and wired it into `_run_setup` in place of the global boolean check.
- `tests/test_server.py`: added unit tests for the selection logic (auto, none, the `--no-hooks` alias override, explicit/underscore aliases, empty-defaults-to-auto, and rejection of non-hook-capable tools).
- `docs/hooks.md`: documented `--hooks`, the `--no-hooks` alias, and noted that hooks are currently Claude-Code-specific.

## Testing
- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

### Test report
```
tests/test_server.py::TestHookToolsFromArgs::test_auto_selects_claude_code PASSED                                [ 14%]
tests/test_server.py::TestHookToolsFromArgs::test_empty_defaults_to_auto PASSED                                  [ 28%]
tests/test_server.py::TestHookToolsFromArgs::test_none_selects_nothing PASSED                                    [ 42%]
tests/test_server.py::TestHookToolsFromArgs::test_no_hooks_flag_overrides_to_none PASSED                         [ 57%]
tests/test_server.py::TestHookToolsFromArgs::test_explicit_claude_code PASSED                                    [ 71%]
tests/test_server.py::TestHookToolsFromArgs::test_underscore_alias PASSED                                        [ 85%]
tests/test_server.py::TestHookToolsFromArgs::test_unknown_tool_raises PASSED                                     [100%]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `waggle-mcp setup` CLI now supports configurable automatic memory hook installation through the new `--hooks` option. Choose from `auto` (default), `none` to disable, or specify tools via comma-separated list.

* **Deprecated**
  * The `--no-hooks` option is deprecated; migrate to `--hooks none` for equivalent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->