### PR TITLE
test(config): cover _discover_codex_waggle_db_path fallback and blank-value cases

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
+
 from pathlib import Path
+
 import pytest
+
 from waggle.config import (
+    DEFAULT_DB_PATH,
     AppConfig,
     _discover_codex_waggle_db_path,
     resolve_default_db_path,
-    DEFAULT_DB_PATH,
 )
 from waggle.errors import ValidationFailure
+
 
 def test_embedding_backend_defaults_to_pytorch(monkeypatch):
     monkeypatch.delenv("WAGGLE_EMBEDDING_BACKEND", raising=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
-
+from pathlib import Path
 import pytest
-
-from waggle.config import AppConfig
+from waggle.config import (
+    AppConfig,
+    _discover_codex_waggle_db_path,
+    resolve_default_db_path,
+    DEFAULT_DB_PATH,
+)
 from waggle.errors import ValidationFailure
-
 
 def test_embedding_backend_defaults_to_pytorch(monkeypatch):
     monkeypatch.delenv("WAGGLE_EMBEDDING_BACKEND", raising=False)
@@ -95,3 +98,58 @@ def test_zero_hybrid_weights_are_allowed() -> None:
     )
 
     config.validate()
+
+
+def test_discover_db_path_missing_config(tmp_path):
+    assert _discover_codex_waggle_db_path(home=tmp_path) is None
+
+
+def test_discover_db_path_invalid_toml(tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    config_file = codex_dir / "config.toml"
+    config_file.write_text("invalid = { toml = [", encoding="utf-8")
+    assert _discover_codex_waggle_db_path(home=tmp_path) is None
+
+
+def test_discover_db_path_blank_value(tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    config_file = codex_dir / "config.toml"
+    config_file.write_text('[mcp_servers.waggle.env]\nWAGGLE_DB_PATH = ""', encoding="utf-8")
+    assert _discover_codex_waggle_db_path(home=tmp_path) is None
+
+
+def test_discover_db_path_missing_env_key(tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    config_file = codex_dir / "config.toml"
+    config_file.write_text("[mcp_servers.waggle]\nenv = {}", encoding="utf-8")
+    assert _discover_codex_waggle_db_path(home=tmp_path) is None
+
+
+def test_discover_db_path_valid_path(tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    config_file = codex_dir / "config.toml"
+    target_path = tmp_path / "custom" / "waggle.db"
+    config_content = f'[mcp_servers.waggle.env]\nWAGGLE_DB_PATH = "{target_path.as_posix()}"'
+    config_file.write_text(config_content, encoding="utf-8")
+    result = _discover_codex_waggle_db_path(home=tmp_path)
+    assert result == str(target_path)
+
+
+def test_resolve_default_db_path_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert resolve_default_db_path() == DEFAULT_DB_PATH
+
+
+def test_resolve_default_db_path_configured(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    config_file = codex_dir / "config.toml"
+    target_path = tmp_path / "custom" / "waggle.db"
+    config_content = f'[mcp_servers.waggle.env]\nWAGGLE_DB_PATH = "{target_path.as_posix()}"'
+    config_file.write_text(config_content, encoding="utf-8")
+    assert resolve_default_db_path() == str(target_path)


### PR DESCRIPTION
Fixes #343

Added hermetic unit tests for `_discover_codex_waggle_db_path()` and `resolve_default_db_path()`:

- Missing ~/.codex/config.toml
- Invalid TOML in config file
- Blank WAGGLE_DB_PATH value
- Missing WAGGLE_DB_PATH env key
- Valid configured path override
- resolve_default_db_path() fallback to DEFAULT_DB_PATH
- resolve_default_db_path() returns configured path when available

All 15 tests pass. Tests use tmp_path fixtures and monkeypatch to avoid depending on the real home directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded database configuration testing to cover default DB path discovery and resolution, including edge cases such as missing/invalid config files, blank environment variable values, and missing expected config keys.
  * Added coverage for the configured path scenario when the environment variable is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->