### PR TITLE
ci(labels): add label catalog drift checker script, test, and workflow

### DIFF
--- a/.github/workflows/check-label-refs.yml
+++ b/.github/workflows/check-label-refs.yml
@@ -1,0 +1,39 @@
+name: Check Label Catalog Drift
+
+on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/labels.yml"
+      - "CONTRIBUTING.md"
+      - "docs/good-first-issues.md"
+      - "scripts/check_label_refs.py"
+      - ".github/workflows/check-label-refs.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/labels.yml"
+      - "CONTRIBUTING.md"
+      - "docs/good-first-issues.md"
+      - "scripts/check_label_refs.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-label-refs:
+    name: Label catalog drift check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check for label drift
+        run: python3 scripts/check_label_refs.py --verbose

--- a/.github/workflows/check-label-refs.yml
+++ b/.github/workflows/check-label-refs.yml
@@ -28,10 +28,12 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,15 @@ Quick checklist:
 
 Repository labels are defined in [`.github/labels.yml`](./.github/labels.yml) and synced with [`scripts/sync_github_labels.py`](./scripts/sync_github_labels.py). Use `--dry-run` first before changing live labels.
 
+To prevent contributor docs from referencing renamed or deleted labels, the repository has an automated drift checker:
+```bash
+python scripts/check_label_refs.py
+```
+If you rename or remove a label:
+1. Run the script to detect mismatching references in `CONTRIBUTING.md` and `docs/good-first-issues.md`.
+2. Update the document references to match the new label names.
+3. Commit and push the changes. The check runs automatically on pull requests.
+
 ---
 
 ## Project Architecture

--- a/scripts/check_label_refs.py
+++ b/scripts/check_label_refs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 check_label_refs.py -- Label catalog drift checker.
 
@@ -105,25 +104,23 @@ _SUGGESTED_RE = re.compile(
     r"(?i)(?:suggested|recommended)\s+labels?\s*:\s*(.*)",
 )
 
-# Pattern B: list context following "such as", "example", or "like"
+# Pattern B: list context following "such as", "for example", "example:", "e.g.", or "like"
 # Captures every backtick token on that line after the trigger keyword.
 _LIST_CONTEXT_RE = re.compile(
-    r"(?i)\b(?:such\s+as|example|like)\b\s*[:\s]*(.*)",
+    r"(?i)\b(?:such\s+as|for\s+example|example|e\.g\.|like)\b[,:]?\s*(.*)",
 )
 
 # Pattern C: specific use/add/start-as guidance (singular backtick tokens)
-_SPECIFIC_LABEL_RE = re.compile(
-    r"(?i)(?:use|add|start\s+as|start\s+with)\s+`([^`]+)`"
-)
+_SPECIFIC_LABEL_RE = re.compile(r"(?i)(?:use|add|start\s+as|start\s+with)\s+`([^`]+)`")
 
 _CODE_TOKEN_RE = re.compile(
     r"^(?:"
-    r"--[\w-]+"                    # CLI flags: --dry-run
-    r"|[A-Z][A-Z0-9_]+=\S+"       # env assignments: WAGGLE_MODEL=deterministic
-    r"|[A-Z][A-Z0-9_]{2,}"        # ALL_CAPS env var names (3+ chars)
-    r"|\w*_\w+"                    # snake_case identifiers: tmp_path, agent_id
-    r"|.*[()/{\\=<>].*"            # contains code chars
-    r"|.*\d+\.\d+.*"               # version numbers
+    r"--[\w-]+"  # CLI flags: --dry-run
+    r"|[A-Z][A-Z0-9_]+=\S+"  # env assignments: WAGGLE_MODEL=deterministic
+    r"|[A-Z][A-Z0-9_]{2,}"  # ALL_CAPS env var names (3+ chars)
+    r"|\w*_\w+"  # snake_case identifiers: tmp_path, agent_id
+    r"|.*[()/{\\=<>].*"  # contains code chars
+    r"|.*\d+\.\d+.*"  # version numbers
     r")$"
 )
 

--- a/scripts/check_label_refs.py
+++ b/scripts/check_label_refs.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+check_label_refs.py -- Label catalog drift checker.
+
+Parses the label catalog defined in .github/labels.yml and scans a
+configurable list of contributor-facing docs for label references.
+Exits non-zero with a clear mismatch report when any referenced label
+name is absent from the catalog.
+
+Detection strategy
+------------------
+Rather than scanning all backtick tokens (which produces many false
+positives from code snippets), this script uses targeted patterns that
+match how labels are actually referenced in contributor docs:
+
+  Pattern A -- "Suggested labels:" lines (good-first-issues.md style):
+      - Suggested labels: `good first issue`, `help wanted`, `tooling`
+
+  Pattern B -- "Use/Add ... label" sentences (CONTRIBUTING.md style):
+      Use `good first issue` for small, well-scoped tasks.
+      Add one domain label such as `graph`, `retrieval`, or `tooling`.
+      New issues should usually start as `needs-triage` ...
+
+  Pattern C -- "label(s):" inline list pattern:
+      Every accepted program PR should receive one difficulty label such
+      as `level:beginner`, one type label such as `type:docs`, and a
+      validation label such as `gssoc:approved` ...
+
+Any backtick-quoted string resolved by these patterns that is NOT in
+the current catalog is reported as a mismatch.
+
+Usage
+-----
+    # From the repository root:
+    python3 scripts/check_label_refs.py
+
+    # Explicit paths (override defaults):
+    python3 scripts/check_label_refs.py \\
+        --catalog .github/labels.yml \\
+        --docs CONTRIBUTING.md docs/good-first-issues.md
+
+    # Verbose: show all catalog labels before scanning
+    python3 scripts/check_label_refs.py --verbose
+
+Exit codes
+----------
+    0  All label references found in the catalog -- no drift.
+    1  One or more label references are missing from the catalog.
+    2  The catalog file could not be parsed (bad YAML / missing file).
+
+Maintainer guide: keeping labels and docs in sync
+--------------------------------------------------
+When you rename or remove a label from .github/labels.yml:
+
+  1. Search the scanned docs for the old label name:
+       grep -rn "old-label-name" CONTRIBUTING.md docs/good-first-issues.md
+
+  2. Replace every reference with the new name (or remove the reference
+     if the label was deleted with no replacement).
+
+  3. Run this script to confirm no drift remains:
+       python3 scripts/check_label_refs.py
+
+  4. Sync the live GitHub labels:
+       python3 scripts/sync_github_labels.py --dry-run   # preview
+       python3 scripts/sync_github_labels.py             # apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Ensure UTF-8 output on Windows (avoids cp1252 encode errors in CI)
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+# ---------------------------------------------------------------------------
+# Defaults -- paths relative to the repository root
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_CATALOG = REPO_ROOT / ".github" / "labels.yml"
+
+DEFAULT_DOCS = [
+    REPO_ROOT / "CONTRIBUTING.md",
+    REPO_ROOT / "docs" / "good-first-issues.md",
+]
+
+# ---------------------------------------------------------------------------
+# Label-reference detection patterns
+# ---------------------------------------------------------------------------
+# Each pattern captures one backtick-quoted token that is an intentional
+# label reference. All are applied per line.
+
+# Pattern A: "Suggested labels:" / "Recommended labels:" lines
+# Captures every backtick token on that line after the prefix.
+_SUGGESTED_RE = re.compile(
+    r"(?i)(?:suggested|recommended)\s+labels?\s*:\s*(.*)",
+)
+
+# Pattern B: list context following "such as", "example", or "like"
+# Captures every backtick token on that line after the trigger keyword.
+_LIST_CONTEXT_RE = re.compile(
+    r"(?i)\b(?:such\s+as|example|like)\b\s*[:\s]*(.*)",
+)
+
+# Pattern C: specific use/add/start-as guidance (singular backtick tokens)
+_SPECIFIC_LABEL_RE = re.compile(
+    r"(?i)(?:use|add|start\s+as|start\s+with)\s+`([^`]+)`"
+)
+
+_CODE_TOKEN_RE = re.compile(
+    r"^(?:"
+    r"--[\w-]+"                    # CLI flags: --dry-run
+    r"|[A-Z][A-Z0-9_]+=\S+"       # env assignments: WAGGLE_MODEL=deterministic
+    r"|[A-Z][A-Z0-9_]{2,}"        # ALL_CAPS env var names (3+ chars)
+    r"|\w*_\w+"                    # snake_case identifiers: tmp_path, agent_id
+    r"|.*[()/{\\=<>].*"            # contains code chars
+    r"|.*\d+\.\d+.*"               # version numbers
+    r")$"
+)
+
+# Pattern D: bare comma-separated backtick list after "Suggested labels:" or
+# on lines inside a "Suggested labels" block (covers multi-column list forms)
+_BACKTICK_TOKEN_RE = re.compile(r"`([^`]+)`")
+
+
+def _extract_label_refs_from_line(line: str) -> list[str]:
+    """Return all label references found on a single doc line."""
+    refs: list[str] = []
+
+    # Pattern A -- "Suggested/Recommended labels: ..." -- extract ALL backtick tokens after it
+    m = _SUGGESTED_RE.search(line)
+    if m:
+        for token in _BACKTICK_TOKEN_RE.findall(m.group(1)):
+            if not _CODE_TOKEN_RE.match(token):
+                refs.append(token)
+        return list(dict.fromkeys(refs))
+
+    # Pattern B -- list following such as / example / like -- extract ALL backtick tokens after it
+    m = _LIST_CONTEXT_RE.search(line)
+    if m:
+        for token in _BACKTICK_TOKEN_RE.findall(m.group(1)):
+            if not _CODE_TOKEN_RE.match(token):
+                refs.append(token)
+        return list(dict.fromkeys(refs))
+
+    # Pattern C -- specific Use/Add/start as references
+    for m in _SPECIFIC_LABEL_RE.finditer(line):
+        token = m.group(1)
+        if not _CODE_TOKEN_RE.match(token):
+            refs.append(token)
+
+    # Deduplicate while preserving order
+    return list(dict.fromkeys(refs))
+
+
+# ---------------------------------------------------------------------------
+# Catalog loader
+# ---------------------------------------------------------------------------
+
+
+def load_catalog(catalog_path: Path) -> set[str]:
+    """Return the set of label names defined in *catalog_path* (labels.yml).
+
+    Parses without a YAML dependency by matching "- name: <value>" lines.
+    """
+    if not catalog_path.exists():
+        print(f"ERROR: catalog file not found: {catalog_path}", file=sys.stderr)
+        sys.exit(2)
+
+    names: set[str] = set()
+    name_re = re.compile(r"^\s*-?\s*name:\s*[\"']?(.+?)[\"']?\s*$")
+    try:
+        for line in catalog_path.read_text(encoding="utf-8").splitlines():
+            m = name_re.match(line)
+            if m:
+                names.add(m.group(1).strip())
+    except OSError as exc:
+        print(f"ERROR: cannot read catalog: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    if not names:
+        print(f"ERROR: no label names found in {catalog_path}", file=sys.stderr)
+        sys.exit(2)
+
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Doc scanner
+# ---------------------------------------------------------------------------
+
+
+def scan_doc(doc_path: Path, catalog: set[str]) -> list[tuple[int, str]]:
+    """Scan *doc_path* and return (line_number, label_name) mismatches."""
+    if not doc_path.exists():
+        print(f"WARNING: doc file not found, skipping: {doc_path}", file=sys.stderr)
+        return []
+
+    try:
+        lines = doc_path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        print(f"WARNING: cannot read {doc_path}: {exc}", file=sys.stderr)
+        return []
+
+    mismatches: list[tuple[int, str]] = []
+    seen: set[tuple[int, str]] = set()
+
+    for lineno, line in enumerate(lines, start=1):
+        for ref in _extract_label_refs_from_line(line):
+            ref = ref.strip()
+            if ref and ref not in catalog:
+                key = (lineno, ref)
+                if key not in seen:
+                    mismatches.append(key)
+                    seen.add(key)
+
+    return mismatches
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect drift between the label catalog (.github/labels.yml) "
+            "and label names referenced in contributor docs."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--catalog",
+        default=str(DEFAULT_CATALOG),
+        help="Path to the label catalog YAML file (default: .github/labels.yml)",
+    )
+    parser.add_argument(
+        "--docs",
+        nargs="+",
+        default=[str(p) for p in DEFAULT_DOCS],
+        help="Markdown files to scan for label references (default: CONTRIBUTING.md, docs/good-first-issues.md)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print the full label catalog before scanning.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    catalog_path = Path(args.catalog)
+    doc_paths = [Path(p) for p in args.docs]
+
+    # -- Load catalog --------------------------------------------------------
+    catalog = load_catalog(catalog_path)
+
+    if args.verbose:
+        print(f"Catalog ({len(catalog)} labels) loaded from: {catalog_path}")
+        for name in sorted(catalog):
+            print(f"  - {name}")
+        print()
+
+    # -- Scan docs -----------------------------------------------------------
+    all_mismatches: dict[str, list[tuple[int, str]]] = {}
+    for doc_path in doc_paths:
+        mismatches = scan_doc(doc_path, catalog)
+        if mismatches:
+            all_mismatches[str(doc_path)] = mismatches
+
+    # -- Report --------------------------------------------------------------
+    if not all_mismatches:
+        print("[OK] No label drift detected. All referenced labels exist in the catalog.")
+        return 0
+
+    print("[FAIL] Label drift detected -- the following label names are referenced")
+    print("       in contributor docs but are MISSING from the catalog:\n")
+    print(f"  Catalog: {catalog_path}\n")
+
+    for doc_file, mismatches in all_mismatches.items():
+        try:
+            display = str(Path(doc_file).relative_to(REPO_ROOT))
+        except ValueError:
+            display = doc_file
+        print(f"  File: {display}")
+        for lineno, label in mismatches:
+            print(f"    line {lineno:>4}: `{label}`")
+        print()
+
+    sep = "-" * 70
+    print(sep)
+    print("How to fix")
+    print(sep)
+    print("""
+  Option A -- Add the missing label to the catalog:
+    Edit .github/labels.yml and add an entry:
+      - name: <missing-label>
+        color: "<hex-colour>"
+        description: <short description>
+    Then sync live labels:
+      python3 scripts/sync_github_labels.py --dry-run   # preview
+      python3 scripts/sync_github_labels.py             # apply
+
+  Option B -- Update the doc to use the current label name:
+    Replace the stale label reference with the renamed/current equivalent.
+
+  Option C -- The label was intentionally removed:
+    Remove all references to it from contributor-facing docs.
+
+  After fixing, re-run to confirm:
+    python3 scripts/check_label_refs.py
+""")
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_label_drift.py
+++ b/tests/test_label_drift.py
@@ -46,7 +46,7 @@ def test_extract_pattern_c() -> None:
 def test_code_token_exclusions() -> None:
     # CLI flags
     assert MODULE._extract_label_refs_from_line("Use `--dry-run` to preview changes.") == []
-    
+
     # Env variables
     assert MODULE._extract_label_refs_from_line("Ensure `WAGGLE_MODEL=deterministic` is set.") == []
     assert MODULE._extract_label_refs_from_line("Configure `WAGGLE_EMBEDDING_BACKEND` appropriately.") == []

--- a/tests/test_label_drift.py
+++ b/tests/test_label_drift.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Load check_label_refs script dynamically
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_label_refs.py"
+SPEC = importlib.util.spec_from_file_location("check_label_refs", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def test_extract_pattern_a() -> None:
+    # Pattern A: Suggested / Recommended labels
+    line1 = "- Suggested labels: `good first issue`, `help wanted`, `documentation`"
+    assert MODULE._extract_label_refs_from_line(line1) == ["good first issue", "help wanted", "documentation"]
+
+    line2 = "- Recommended labels: `bug`, `testing`"
+    assert MODULE._extract_label_refs_from_line(line2) == ["bug", "testing"]
+
+
+def test_extract_pattern_b() -> None:
+    # Pattern B: Use `x` or such as `x` or start as `x`
+    line1 = "Use `good first issue` for small tasks."
+    assert MODULE._extract_label_refs_from_line(line1) == ["good first issue"]
+
+    line2 = "Add one domain label such as `graph` or `retrieval`."
+    assert MODULE._extract_label_refs_from_line(line2) == ["graph", "retrieval"]
+
+    line3 = "New issues should usually start as `needs-triage` until approved."
+    assert MODULE._extract_label_refs_from_line(line3) == ["needs-triage"]
+
+
+def test_extract_pattern_c() -> None:
+    # Pattern C: label such as / label: `x`
+    line1 = "Every accepted PR should receive one difficulty label such as `level:beginner`."
+    assert MODULE._extract_label_refs_from_line(line1) == ["level:beginner"]
+
+    line2 = "one type label such as `type:docs` and a validation label: `gssoc:approved`"
+    assert MODULE._extract_label_refs_from_line(line2) == ["type:docs", "gssoc:approved"]
+
+
+def test_code_token_exclusions() -> None:
+    # CLI flags
+    assert MODULE._extract_label_refs_from_line("Use `--dry-run` to preview changes.") == []
+    
+    # Env variables
+    assert MODULE._extract_label_refs_from_line("Ensure `WAGGLE_MODEL=deterministic` is set.") == []
+    assert MODULE._extract_label_refs_from_line("Configure `WAGGLE_EMBEDDING_BACKEND` appropriately.") == []
+
+    # Snake case / functions / paths
+    assert MODULE._extract_label_refs_from_line("Use `tmp_path` fixture for testing.") == []
+    assert MODULE._extract_label_refs_from_line("Verify with `agent_id` parameter.") == []
+    assert MODULE._extract_label_refs_from_line("The file resides in `src/waggle/models.py` path.") == []
+
+    # Multi-word commands
+    assert MODULE._extract_label_refs_from_line("Run `waggle-mcp fsck <file.abhi>` to validate.") == []
+
+
+def test_load_catalog(tmp_path: Path) -> None:
+    catalog_file = tmp_path / "labels.yml"
+    catalog_file.write_text(
+        """
+- name: good first issue
+  color: "7057ff"
+- name: "help wanted"
+  color: "008672"
+- name: 'documentation'
+  color: "0075ca"
+""",
+        encoding="utf-8",
+    )
+    catalog = MODULE.load_catalog(catalog_file)
+    assert catalog == {"good first issue", "help wanted", "documentation"}
+
+
+def test_scan_doc(tmp_path: Path) -> None:
+    doc_file = tmp_path / "test_doc.md"
+    doc_file.write_text(
+        """
+# Testing Label Check
+Use `good first issue` for starter tasks.
+Also use `missing-label` which is not in the catalog.
+Ensure `tmp_path` is not caught as a mismatch.
+""",
+        encoding="utf-8",
+    )
+    catalog = {"good first issue", "help wanted"}
+    mismatches = MODULE.scan_doc(doc_file, catalog)
+    assert mismatches == [(4, "missing-label")]
+
+
+def test_main_success(tmp_path: Path) -> None:
+    catalog_file = tmp_path / "labels.yml"
+    catalog_file.write_text(
+        """
+- name: good first issue
+- name: help wanted
+""",
+        encoding="utf-8",
+    )
+    doc_file = tmp_path / "test_doc.md"
+    doc_file.write_text(
+        """
+Use `good first issue`.
+""",
+        encoding="utf-8",
+    )
+
+    exit_code = MODULE.main(["--catalog", str(catalog_file), "--docs", str(doc_file)])
+    assert exit_code == 0
+
+
+def test_main_mismatch(tmp_path: Path) -> None:
+    catalog_file = tmp_path / "labels.yml"
+    catalog_file.write_text(
+        """
+- name: good first issue
+""",
+        encoding="utf-8",
+    )
+    doc_file = tmp_path / "test_doc.md"
+    doc_file.write_text(
+        """
+Use `help wanted`.
+""",
+        encoding="utf-8",
+    )
+
+    exit_code = MODULE.main(["--catalog", str(catalog_file), "--docs", str(doc_file)])
+    assert exit_code == 1


### PR DESCRIPTION
## Summary

- **What changed?**
  - Added `scripts/check_label_refs.py` to parse the label catalog (`.github/labels.yml`) and check for drift against contributor-facing docs (`CONTRIBUTING.md` and `docs/good-first-issues.md`).
  - Implemented pattern-based label extraction covering lists following keywords (`such as`, `example:`, `like`) and singular label usages (`Use`, `Add`, `start as`), combined with strict code token filtering (`_CODE_TOKEN_RE`) to eliminate false positives.
  - Added a GitHub Actions CI workflow `.github/workflows/check-label-refs.yml` to run label drift checks on PRs and pushes to `main`.
  - Updated `CONTRIBUTING.md` to guide maintainers on running the checker script and keeping documentation references in sync when modifying catalog labels.
  - Added unit tests in `tests/test_label_drift.py` to verify pattern extraction, code token exclusions, catalog loading, and mismatch detection.

- **Why was it needed?**
  - To prevent drift between `.github/labels.yml` and documentation so that new contributors do not receive conflicting or broken label guidance.

Fixes Issue #312 

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

### Test report

Paste the output of `pytest -v` for the files you added or changed (not the full suite, just yours):

```text
============================= test session starts =============================
platform win32 -- Python 3.14.0, pytest-9.0.3, pluggy-1.6.0 -- C:\Program Files\Python314\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\KIRTAN\Downloads\Waggle-mcp
configfile: pyproject.toml
plugins: anyio-4.12.0, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 8 items

tests/test_label_drift.py::test_extract_pattern_a PASSED                 [ 12%]
tests/test_label_drift.py::test_extract_pattern_b PASSED                 [ 25%]
tests/test_label_drift.py::test_extract_pattern_c PASSED                 [ 37%]
tests/test_label_drift.py::test_code_token_exclusions PASSED             [ 50%]
tests/test_label_drift.py::test_load_catalog PASSED                      [ 62%]
tests/test_label_drift.py::test_scan_doc PASSED                          [ 75%]
tests/test_label_drift.py::test_main_success PASSED                      [ 87%]
tests/test_label_drift.py::test_main_mismatch PASSED                     [100%]

============================== 8 passed in 0.06s ==============================
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated label-catalog drift checker to prevent contributor docs from referencing invalid or renamed labels.
  * Runs automatically on pull requests and on pushes to the main branch when relevant files change.
  * Provides remediation guidance when mismatches are detected.

* **Documentation**
  * Updated contribution guidelines with instructions to run the drift checker and what to do after label updates.

* **Tests**
  * Added unit/integration coverage for label-reference extraction, drift scanning, and CLI exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->