### PR TITLE
testing(graph-ui): add browser-level coverage for view-mode versus edit-mode mutation gating (#368)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,3 +141,9 @@ jobs:
 
       - name: Build Graph Studio
         run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser tests
+        run: npm run test:browser

--- a/apps/mcp/graph-ui/package-lock.json
+++ b/apps/mcp/graph-ui/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@vitejs/plugin-react": "^5.1.0",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
@@ -466,6 +467,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1861,6 +1878,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/apps/mcp/graph-ui/package.json
+++ b/apps/mcp/graph-ui/package.json
@@ -4,7 +4,9 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "build": "vite build"
+    "dev": "vite",
+    "build": "vite build",
+    "test:browser": "playwright test"
   },
   "dependencies": {
     "cytoscape": "^3.30.4",
@@ -14,6 +16,7 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vitejs/plugin-react": "^5.1.0",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",

--- a/apps/mcp/graph-ui/playwright.config.js
+++ b/apps/mcp/graph-ui/playwright.config.js
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "line",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+    headless: true,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -588,7 +588,15 @@ export function App() {
   };
 
   const mergeNode = async (sourceId) => {
-    if (!selectedNodeId || selectedNodeId === sourceId || boot.sampleMode || readOnly) {
+    if (readOnly) {
+      setToast("Cannot modify graph in view mode.");
+      return;
+    }
+    if (boot.sampleMode) {
+      setToast("Cannot modify sample data.");
+      return;
+    }
+    if (!selectedNodeId || selectedNodeId === sourceId) {
       setToast("Select a destination graph node first.");
       return;
     }

--- a/apps/mcp/graph-ui/src/App.jsx
+++ b/apps/mcp/graph-ui/src/App.jsx
@@ -147,11 +147,15 @@ function EdgeDialog({ edge, onCancel, onSave }) {
   );
 }
 
-function FileInputButton({ label, accept, onChange }) {
+function FileInputButton({ label, accept, onChange, disabled }) {
   return (
-    <label className="cursor-pointer rounded-xl border border-white/10 px-3 py-2 text-sm text-white">
+    <label
+      className={`rounded-xl border border-white/10 px-3 py-2 text-sm text-white ${
+        disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+      }`}
+    >
       {label}
-      <input className="hidden" type="file" accept={accept} onChange={onChange} />
+      <input className="hidden" type="file" accept={accept} onChange={onChange} disabled={disabled} />
     </label>
   );
 }
@@ -560,7 +564,7 @@ export function App() {
   };
 
   const deleteNode = async (nodeId) => {
-    if (boot.sampleMode) {
+    if (boot.sampleMode || readOnly) {
       return;
     }
     await pushHistory();
@@ -584,7 +588,7 @@ export function App() {
   };
 
   const mergeNode = async (sourceId) => {
-    if (!selectedNodeId || selectedNodeId === sourceId || boot.sampleMode) {
+    if (!selectedNodeId || selectedNodeId === sourceId || boot.sampleMode || readOnly) {
       setToast("Select a destination graph node first.");
       return;
     }
@@ -658,7 +662,7 @@ export function App() {
   };
 
   const saveEdgeDialog = async (relationship) => {
-    if (!edgeDialog || boot.sampleMode) {
+    if (!edgeDialog || boot.sampleMode || readOnly) {
       return;
     }
     await pushHistory();
@@ -772,7 +776,7 @@ export function App() {
   };
 
   const commitImport = async () => {
-    if (!importPreview || boot.sampleMode) {
+    if (!importPreview || boot.sampleMode || readOnly) {
       return;
     }
     const payload = await apiRequest("/api/graph/import", {
@@ -790,6 +794,9 @@ export function App() {
   };
 
   const loadImportFile = async (event) => {
+    if (readOnly) {
+      return;
+    }
     const file = event.target.files?.[0];
     if (!file) {
       return;
@@ -1281,7 +1288,7 @@ export function App() {
               <button className="rounded-xl border border-white/10 px-3 py-2 text-sm" onClick={() => exportGraph("abhi")} type="button">
                 Export
               </button>
-              <FileInputButton label="Import preview" accept=".abhi,.json" onChange={(event) => loadImportFile(event).catch((error) => setToast(error.message))} />
+              <FileInputButton label="Import preview" accept=".abhi,.json" onChange={(event) => loadImportFile(event).catch((error) => setToast(error.message))} disabled={readOnly || boot.sampleMode} />
               <button className="rounded-xl border border-white/10 px-3 py-2 text-sm text-graph-muted" type="button">
                 Sync to Drive
               </button>
@@ -1301,7 +1308,7 @@ export function App() {
                   ))}
                 </div>
                 {!boot.sampleMode ? (
-                  <button className="mt-3 w-full rounded-xl bg-white px-3 py-2 text-sm font-medium text-black" onClick={() => commitImport().catch((error) => setToast(error.message))} type="button">
+                  <button className="mt-3 w-full rounded-xl bg-white px-3 py-2 text-sm font-medium text-black" onClick={() => commitImport().catch((error) => setToast(error.message))} disabled={readOnly} type="button">
                     Commit import
                   </button>
                 ) : null}

--- a/apps/mcp/graph-ui/tests/gating.spec.js
+++ b/apps/mcp/graph-ui/tests/gating.spec.js
@@ -1,0 +1,159 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  // Mock the API calls so the tests are 100% deterministic and do not depend on a running server
+  await page.route("**/api/graph**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/transcripts")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          records: [
+            {
+              id: "t-1",
+              session_id: "test-session",
+              project: "test-project",
+              agent_id: "test-agent",
+              turn_index: 0,
+              role: "user",
+              transcript_text: "Help me write a document.",
+              observed_at: "2026-06-13T08:00:00Z"
+            },
+            {
+              id: "t-2",
+              session_id: "test-session",
+              project: "test-project",
+              agent_id: "test-agent",
+              turn_index: 1,
+              role: "assistant",
+              transcript_text: "Document created successfully.",
+              observed_at: "2026-06-13T08:01:00Z"
+            }
+          ],
+          pagination: {
+            offset: 0,
+            total_count: 2
+          }
+        })
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          tenant_id: "test-tenant",
+          nodes: [
+            {
+              id: "node-1",
+              label: "Test Node 1",
+              content: "This is a test node content",
+              node_type: "decision",
+              tags: ["test"],
+              source_prompt: "user: Help me write a document.",
+              evidence_records: [
+                {
+                  evidence_id: "ev-1",
+                  session_id: "test-session",
+                  turn_index: 1,
+                  source_role: "assistant",
+                  source_text: "Document created successfully.",
+                  observed_at: "2026-06-13T08:01:00Z"
+                }
+              ],
+              project: "test-project",
+              agent_id: "test-agent",
+              session_id: "test-session",
+              updated_at: "2026-06-13T08:01:00Z",
+              created_at: "2026-06-13T08:01:00Z"
+            }
+          ],
+          edges: [],
+          ui: {}
+        })
+      });
+    }
+  });
+});
+
+test.describe("Graph UI - Gating in View Mode", () => {
+  test.beforeEach(async ({ page }) => {
+    // Set the boot config to view mode
+    await page.addInitScript(() => {
+      window.__WAGGLE_GRAPH_CONFIG__ = {
+        mode: "view",
+        sampleMode: false,
+        project: "test-project",
+        agent_id: "test-agent",
+        session_id: "test-session"
+      };
+    });
+    await page.goto("/");
+  });
+
+  test("should display view mode indicator and disable graph mutations", async ({ page }) => {
+    // Verify view mode header text
+    await expect(page.locator("text=View mode")).toBeVisible();
+
+    // Verify canvas action buttons are disabled
+    await expect(page.locator('button:has-text("New node")')).toBeDisabled();
+    await expect(page.locator('button:has-text("Undo")')).toBeDisabled();
+    await expect(page.locator('button:has-text("Redo")')).toBeDisabled();
+
+    // Verify import button is disabled
+    await expect(page.locator('label:has-text("Import preview") input')).toBeDisabled();
+
+    // Switch to transcripts tab to select a node and verify inspector
+    await page.click('button:has-text("Transcripts")');
+    await page.click('button:has-text("Show in graph")');
+
+    // Inspector should now open for node-1
+    await expect(page.locator('input[name="label"]')).toBeDisabled();
+    await expect(page.locator('textarea[name="content"]')).toBeDisabled();
+    await expect(page.locator('input[name="tags"]')).toBeDisabled();
+
+    // Inspector buttons should be disabled
+    await expect(page.locator('button:has-text("Save node")')).toBeDisabled();
+    await expect(page.locator('button:has-text("Delete")')).toBeDisabled();
+  });
+});
+
+test.describe("Graph UI - Allowed Actions in Edit Mode", () => {
+  test.beforeEach(async ({ page }) => {
+    // Set the boot config to edit mode
+    await page.addInitScript(() => {
+      window.__WAGGLE_GRAPH_CONFIG__ = {
+        mode: "edit",
+        sampleMode: false,
+        project: "test-project",
+        agent_id: "test-agent",
+        session_id: "test-session"
+      };
+    });
+    await page.goto("/");
+  });
+
+  test("should display edit mode indicator and allow graph mutations", async ({ page }) => {
+    // Verify edit mode header text
+    await expect(page.locator("text=Edit mode")).toBeVisible();
+
+    // Verify canvas action buttons are enabled
+    await expect(page.locator('button:has-text("New node")')).toBeEnabled();
+
+    // Verify import button is enabled
+    await expect(page.locator('label:has-text("Import preview") input')).toBeEnabled();
+
+    // Switch to transcripts tab to select a node and verify inspector
+    await page.click('button:has-text("Transcripts")');
+    await page.click('button:has-text("Show in graph")');
+
+    // Inspector should now open for node-1
+    await expect(page.locator('input[name="label"]')).toBeEnabled();
+    await expect(page.locator('textarea[name="content"]')).toBeEnabled();
+    await expect(page.locator('input[name="tags"]')).toBeEnabled();
+
+    // Inspector buttons should be enabled
+    await expect(page.locator('button:has-text("Save node")')).toBeEnabled();
+    await expect(page.locator('button:has-text("Delete")')).toBeEnabled();
+  });
+});


### PR DESCRIPTION
Description
Introduces Playwright browser-level testing for the Graph Studio UI to ensure that read-only/view mode cannot trigger destructive actions or bypass mutation blocks.

Proposed Changes
Mutation Gating Safeguards: Hardened handler-level checks in apps/mcp/graph-ui/src/App.jsx for:
deleteNode
mergeNode
saveEdgeDialog
commitImport
loadImportFile Additionally, disabled the "Import preview" and "Commit import" buttons when readOnly is active.
Testing Setup: Installed @playwright/test devDependencies in apps/mcp/graph-ui and created apps/mcp/graph-ui/playwright.config.js.
Browser Gating Tests: Created apps/mcp/graph-ui/tests/gating.spec.js using page initialization scripts and mocked API endpoints (/api/graph and /api/graph/transcripts) to verify that:
View Mode: Edit-only actions, sidebar buttons (Save Node, Delete), file import button, and canvas-level mutations are fully disabled/blocked.
Edit Mode: Edit actions and dialogs are fully interactive and enabled.
CI Integration: Configured Playwright browser installation and run steps inside the graph-studio job of .github/workflows/ci.yml.
Verification / How to Test
Run browser tests locally:
```
cd apps/mcp/graph-ui
npm run test:browser

```
closes #368
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented view mode (read-only) that disables graph editing, import functionality, and inspector controls when activated.
  * Edit mode enables full editing capabilities with all controls available.

* **Tests**
  * Added browser-based end-to-end tests validating view and edit mode behavior.
  * Integrated Playwright testing framework into CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->