### PR TITLE
tooling(docs): add CI check for broken internal Markdown links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run ruff format check
         run: ruff format --check src/ tests/
 
+      - name: Check markdown links
+        run: python scripts/check_markdown_links.py
+
   # ── Tests ─────────────────────────────────────────────────────────────────
   test:
     name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ Thank you for your interest in improving Waggle. This document covers everything
 - [First Contribution Paths](#first-contribution-paths)
 - [Project Architecture](#project-architecture)
 - [Running Tests](#running-tests)
-- [Writing Tests](#writing-tests)      <-- ADD THIS LINE
+- [Documentation Link Checks](#documentation-link-checks)
+- [Writing Tests](#writing-tests)
 - [Code Style](#code-style)
 - [Key Concepts](#key-concepts)
 - [How to Submit a PR](#how-to-submit-a-pr)
@@ -179,6 +180,20 @@ Follow these rules when adding tests to the repository:
 * **One function per behavior:** Do not bundle multiple unrelated assertions into a single test function. Keeping tests isolated ensures failure logs remain specific and actionable.
 
 ---
+
+## Documentation Link Checks
+
+To validate repository-local Markdown links:
+
+```bash
+python scripts/check_markdown_links.py
+```
+
+The script checks internal Markdown links across the repository and reports the source file and broken path when an invalid link is found.
+
+External URLs and section anchors are ignored to keep the check deterministic and CI-safe.
+```
+
 ## Code Style
 
 This project uses [ruff](https://docs.astral.sh/ruff/) for both linting and formatting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,9 +191,6 @@ python scripts/check_markdown_links.py
 
 The script checks internal Markdown links across the repository and reports the source file and broken path when an invalid link is found.
 
-External URLs and section anchors are ignored to keep the check deterministic and CI-safe.
-```
-
 ## Code Style
 
 This project uses [ruff](https://docs.astral.sh/ruff/) for both linting and formatting.

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import re
 import sys
+from urllib.parse import urlsplit
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -32,7 +33,8 @@ for md_file in markdown_files:
             continue
 
         # Remove anchor part
-        link_path = link.split("#")[0]
+        parsed = urlsplit(link)
+        link_path = parsed.path
 
         if not link_path:
             continue

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -6,7 +6,13 @@ ROOT = Path(__file__).resolve().parent.parent
 
 LINK_PATTERN = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
-markdown_files = ROOT.rglob("*.md")
+IGNORED_DIRS = {".venv", ".git", "node_modules"}
+
+markdown_files = sorted(
+    path
+    for path in ROOT.rglob("*.md")
+    if not any(part in IGNORED_DIRS for part in path.parts)
+)
 
 broken_links = []
 
@@ -33,12 +39,19 @@ for md_file in markdown_files:
 
         resolved_path = (md_file.parent / link_path).resolve()
 
-        if not resolved_path.exists():
-            try:
-                relative_path = resolved_path.relative_to(ROOT)
-            except ValueError:
-                relative_path = resolved_path
+        try:
+            relative_path = resolved_path.relative_to(ROOT)
+        except ValueError:
+            broken_links.append(
+                (
+                    md_file.relative_to(ROOT),
+                    link,
+                    resolved_path,
+                )
+            )
+            continue
 
+        if not resolved_path.exists():
             broken_links.append(
                 (
                     md_file.relative_to(ROOT),

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+
+LINK_PATTERN = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+markdown_files = ROOT.rglob("*.md")
+
+broken_links = []
+
+for md_file in markdown_files:
+    text = md_file.read_text(encoding="utf-8")
+
+    for match in LINK_PATTERN.finditer(text):
+        link = match.group(1).strip()
+
+        # Ignore external URLs
+        if (
+            link.startswith("http://")
+            or link.startswith("https://")
+            or link.startswith("mailto:")
+            or link.startswith("#")
+        ):
+            continue
+
+        # Remove anchor part
+        link_path = link.split("#")[0]
+
+        if not link_path:
+            continue
+
+        resolved_path = (md_file.parent / link_path).resolve()
+
+        if not resolved_path.exists():
+            try:
+                relative_path = resolved_path.relative_to(ROOT)
+            except ValueError:
+                relative_path = resolved_path
+
+            broken_links.append(
+                (
+                    md_file.relative_to(ROOT),
+                    link,
+                    relative_path,
+                )
+            )
+
+if broken_links:
+    print("\nBroken markdown links found:\n")
+
+    for source_file, link, resolved in broken_links:
+        print(f"{source_file}")
+        print(f"  Link: {link}")
+        print(f"  Resolved path: {resolved}")
+        print()
+
+    sys.exit(1)
+
+print("All markdown links are valid.")


### PR DESCRIPTION
## Summary

* Added a deterministic repository-local Markdown link checker script under `scripts/check_markdown_links.py`.
* Added a CI step to run the checker as part of the lint workflow.
* Documented how contributors can run the check locally in `CONTRIBUTING.md`.

### Why was it needed?

Broken relative Markdown links are easy to introduce and difficult to notice until contributors encounter them. This change adds a CI-safe validation step that catches broken repository-local links early and provides actionable output.

## Testing

* [ ] `WAGGLE_MODEL=deterministic pytest -q`
* [x] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/` *(repository currently has pre-existing formatting differences unrelated to this change)*

Additional verification performed:

* [x] `python scripts/check_markdown_links.py`
* [x] `python -m compileall scripts/check_markdown_links.py`

### Test report

No pytest tests were added or modified in this change.

Verified locally with:

```text
> python -m ruff check src/ tests/
All checks passed!

> python scripts/check_markdown_links.py
All markdown links are valid.

> python -m compileall scripts/check_markdown_links.py
Compiling 'scripts/check_markdown_links.py'...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated repository Markdown link validation and wired it into the continuous integration lint process.

* **Documentation**
  * Updated contribution guidelines with a new section explaining the markdown link check, including how to run it and what it reports when links are broken.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->