### PR TITLE
feat: support configurable merge strategy for Google Drive pull

### DIFF
--- a/src/waggle/abhi.py
+++ b/src/waggle/abhi.py
@@ -1282,6 +1282,11 @@ def merge_abhi_documents(
     - ``prefer_right``: retain the right/remote value during a conflict.
     """
     merge_strategy = _validate_abhi_merge_strategy(merge_strategy)
+    if strategy_config is not None:
+        for override in strategy_config.type_overrides:
+            _validate_abhi_merge_strategy(override.strategy)
+        for override in strategy_config.field_overrides:
+            _validate_abhi_merge_strategy(override.strategy)
 
     import time
 

--- a/src/waggle/abhi.py
+++ b/src/waggle/abhi.py
@@ -69,6 +69,27 @@ ABHI_SIGNATURE_MEMBER = "signatures/content.ed25519"
 ABHI_PUBLIC_KEY_MEMBER = "signatures/public_key.pem"
 ABHI_DETERMINISTIC_ZIP_TIMESTAMP = (2000, 1, 1, 0, 0, 0)
 
+ABHI_MERGE_STRATEGIES = (
+    "contradict",
+    "last_write_wins",
+    "prefer_left",
+    "prefer_right",
+)
+DEFAULT_ABHI_MERGE_STRATEGY = "last_write_wins"
+
+
+def _validate_abhi_merge_strategy(merge_strategy: str) -> str:
+    """Validate and return a supported .abhi merge strategy."""
+    normalized = str(merge_strategy).strip()
+
+    if normalized not in ABHI_MERGE_STRATEGIES:
+        raise ValidationFailure(
+            f"Invalid merge_strategy '{merge_strategy}'. Supported strategies: {', '.join(ABHI_MERGE_STRATEGIES)}."
+        )
+
+    return normalized
+
+
 DIFFED_FIELDS: frozenset[str] = frozenset(
     {
         "label",
@@ -1251,6 +1272,17 @@ def merge_abhi_documents(
     passphrase: str = "",
     dry_run: bool = False,
 ) -> AbhiMergeResult:
+    """Merge left and right .abhi documents against a common base.
+
+    Supported strategies:
+
+    - ``contradict``: retain the right value and create a CONTRADICTS edge.
+    - ``last_write_wins``: retain the value with the newest timestamp.
+    - ``prefer_left``: retain the left/local value during a conflict.
+    - ``prefer_right``: retain the right/remote value during a conflict.
+    """
+    merge_strategy = _validate_abhi_merge_strategy(merge_strategy)
+
     import time
 
     _t0 = time.monotonic()

--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -169,7 +169,8 @@ def merge_downloaded_abhi(
     Raises:
         ValidationFailure: If merge_strategy is unsupported.
     """
-    if merge_strategy not in ABHI_MERGE_STRATEGIES:
+    normalized_merge_strategy = str(merge_strategy).strip()
+    if normalized_merge_strategy not in ABHI_MERGE_STRATEGIES:
         supported = ", ".join(ABHI_MERGE_STRATEGIES)
         raise ValidationFailure(f"Invalid merge_strategy {merge_strategy!r}. Expected one of: {supported}.")
 
@@ -195,7 +196,7 @@ def merge_downloaded_abhi(
         left_input_path="local://current",
         right_input_path="local://remote",
         output_path=output_path,
-        merge_strategy=merge_strategy,
+        merge_strategy=normalized_merge_strategy,
     )
 
     return merged.output_path

--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -17,7 +17,12 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 
-from waggle.abhi import merge_abhi_documents
+from waggle.abhi import (
+    ABHI_MERGE_STRATEGIES,
+    DEFAULT_ABHI_MERGE_STRATEGY,
+    merge_abhi_documents,
+)
+from waggle.errors import ValidationFailure
 from waggle.models import DrivePushResult, DriveShareResult
 
 DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.file"
@@ -146,7 +151,28 @@ def merge_downloaded_abhi(
     local_document: dict[str, Any],
     remote_document: dict[str, Any],
     output_path: str | Path,
+    merge_strategy: str = DEFAULT_ABHI_MERGE_STRATEGY,
 ) -> str:
+    """Merge a downloaded remote .abhi document with the local document.
+
+    Args:
+        local_document: The current local .abhi document.
+        remote_document: The downloaded remote .abhi document.
+        output_path: Destination path for the merged .abhi file.
+        merge_strategy: Conflict-resolution strategy used when both documents
+            modify the same object. Supported values are contradict,
+            last_write_wins, prefer_left, and prefer_right.
+
+    Returns:
+        The path to the written merged .abhi file.
+
+    Raises:
+        ValidationFailure: If merge_strategy is unsupported.
+    """
+    if merge_strategy not in ABHI_MERGE_STRATEGIES:
+        supported = ", ".join(ABHI_MERGE_STRATEGIES)
+        raise ValidationFailure(f"Invalid merge_strategy {merge_strategy!r}. Expected one of: {supported}.")
+
     merged = merge_abhi_documents(
         {
             "graph": {"nodes": [], "edges": []},
@@ -169,8 +195,9 @@ def merge_downloaded_abhi(
         left_input_path="local://current",
         right_input_path="local://remote",
         output_path=output_path,
-        merge_strategy="last_write_wins",
+        merge_strategy=merge_strategy,
     )
+
     return merged.output_path
 
 

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -13,6 +13,7 @@ import tempfile
 import threading
 import time
 import uuid
+import warnings
 import webbrowser
 from contextlib import asynccontextmanager, suppress
 from copy import deepcopy
@@ -38,6 +39,8 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from waggle import __version__
 from waggle.abhi import (
+    ABHI_MERGE_STRATEGIES,
+    DEFAULT_ABHI_MERGE_STRATEGY,
     abhi_to_snapshot,
     build_abhi_document,
     execute_abhi_query,
@@ -135,6 +138,12 @@ except Exception as exc:  # pragma: no cover - depends on optional Google libs
     resolve_drive_file_id = None
     share_drive_file = None
     _DRIVE_SYNC_IMPORT_ERROR = exc
+
+_ABHI_IMPORT_STRATEGIES = (
+    "skip-existing",
+    "overwrite",
+    "branch",
+)
 
 WRITE_HEAVY_TOOLS = {
     "store_node",
@@ -4420,12 +4429,37 @@ def _build_parser() -> argparse.ArgumentParser:
     pull_abhi.add_argument("--download-path", default="")
     pull_abhi.add_argument("--merged-output", default="")
     pull_abhi.add_argument("--passphrase-env", default="")
-    pull_abhi.add_argument("--client-secret-path", default="~/.waggle/google-client-secret.json")
+    pull_abhi.add_argument(
+        "--client-secret-path",
+        default="~/.waggle/google-client-secret.json",
+    )
     pull_abhi.add_argument("--token-path", default="")
-    pull_abhi.add_argument("--open-browser", action=argparse.BooleanOptionalAction, default=True)
+    pull_abhi.add_argument(
+        "--open-browser",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
     pull_abhi.add_argument("--namespace", default="")
     pull_abhi.add_argument(
-        "--merge-strategy", choices=["skip-existing", "overwrite", "branch"], default="skip-existing"
+        "--merge-strategy",
+        choices=[
+            *ABHI_MERGE_STRATEGIES,
+            "skip-existing",
+            "overwrite",
+            "branch",
+        ],
+        default=None,
+        help=(
+            "Conflict strategy used when merging local memory with the "
+            "downloaded Drive document. Legacy import values are deprecated; "
+            "use --import-strategy for those."
+        ),
+    )
+    pull_abhi.add_argument(
+        "--import-strategy",
+        choices=["skip-existing", "overwrite", "branch"],
+        default=None,
+        help="Strategy used to import the merged document into the active graph.",
     )
     pull_abhi.add_argument("--verify-signature", action="store_true")
     pull_abhi.add_argument("--read-only", action="store_true")
@@ -4627,6 +4661,45 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     return parser
+
+
+def _normalize_pull_strategy_args(
+    args: argparse.Namespace,
+) -> argparse.Namespace:
+    """Normalize current and legacy strategy arguments for Drive pull."""
+    if getattr(args, "command", "") != "pull":
+        return args
+
+    raw_merge_strategy = getattr(args, "merge_strategy", None)
+    explicit_import_strategy = getattr(args, "import_strategy", None)
+
+    if raw_merge_strategy in _ABHI_IMPORT_STRATEGIES:
+        if explicit_import_strategy is None:
+            args.import_strategy = raw_merge_strategy
+            warning_message = (
+                f"`--merge-strategy {raw_merge_strategy}` is deprecated for "
+                "selecting the graph import strategy. Use "
+                f"`--import-strategy {raw_merge_strategy}` instead."
+            )
+        else:
+            warning_message = (
+                f"Legacy `--merge-strategy {raw_merge_strategy}` is deprecated "
+                "and has been ignored because `--import-strategy` was also "
+                "supplied."
+            )
+
+        args.merge_strategy = DEFAULT_ABHI_MERGE_STRATEGY
+        warnings.warn(
+            warning_message,
+            FutureWarning,
+            stacklevel=2,
+        )
+    else:
+        args.merge_strategy = raw_merge_strategy or DEFAULT_ABHI_MERGE_STRATEGY
+        if explicit_import_strategy is None:
+            args.import_strategy = "skip-existing"
+
+    return args
 
 
 def _run_admin_command(config: AppConfig, args: argparse.Namespace) -> int:
@@ -4999,16 +5072,21 @@ def _run_admin_command(config: AppConfig, args: argparse.Namespace) -> int:
         local_document = build_abhi_document(backend.get_graph_snapshot())
         remote_document = load_abhi_document(download_path, passphrase=passphrase)
         merged_output = Path(getattr(args, "merged_output", "") or backend.export_dir / f"merged-{remote_file_id}.abhi")
+        selected_merge_strategy = getattr(args, "merge_strategy", None) or DEFAULT_ABHI_MERGE_STRATEGY
+        selected_import_strategy = getattr(args, "import_strategy", None) or "skip-existing"
+
         merged_path = merge_downloaded_abhi(
             local_document=local_document,
             remote_document=remote_document,
             output_path=merged_output,
+            merge_strategy=selected_merge_strategy,
         )
+
         imported = backend.import_abhi(
             input_path=merged_path,
             passphrase=passphrase,
             namespace=getattr(args, "namespace", ""),
-            merge_strategy=getattr(args, "merge_strategy", "skip-existing"),
+            merge_strategy=selected_import_strategy,
             verify_signature=bool(getattr(args, "verify_signature", False)),
             read_only=bool(getattr(args, "read_only", False)),
             reembed_on_mismatch=bool(getattr(args, "reembed_on_mismatch", False)),
@@ -5018,7 +5096,7 @@ def _run_admin_command(config: AppConfig, args: argparse.Namespace) -> int:
             remote_name=resolved_name or remote_name,
             downloaded_path=str(download_path),
             merged_output_path=merged_path,
-            merge_strategy="last_write_wins",
+            merge_strategy=selected_merge_strategy,
             nodes_created=imported.nodes_created,
             nodes_updated=imported.nodes_updated,
             edges_created=imported.edges_created,
@@ -6440,7 +6518,7 @@ def main() -> None:
             pass  # best-effort; don't break startup over encoding
     _assert_runtime_feature_parity()
     parser = _build_parser()
-    args = parser.parse_args()
+    args = _normalize_pull_strategy_args(parser.parse_args())
     command = args.command or "serve"
 
     # Commands that should work before full backend/app initialization.

--- a/tests/test_abhi_diff_merge.py
+++ b/tests/test_abhi_diff_merge.py
@@ -31,10 +31,12 @@ from waggle.abhi import (
     validate_abhi_document,
     write_abhi_document,
 )
+from waggle.drive_sync import merge_downloaded_abhi
 from waggle.errors import (
     ConflictResolutionError,
     DanglingEdgeError,
     SchemaVersionError,
+    ValidationFailure,
 )
 from waggle.models import (
     FieldDelta,
@@ -51,7 +53,27 @@ except ImportError:
     cli_app = None  # type: ignore[assignment]
     _CLI_AVAILABLE = False
 
-_skip_cli = pytest.mark.skipif(not _CLI_AVAILABLE, reason="waggle.server requires mcp package")
+_skip_cli = pytest.mark.skipif(
+    not _CLI_AVAILABLE,
+    reason="waggle.server requires mcp package",
+)
+
+try:
+    from waggle.server import (
+        _build_parser,
+        _normalize_pull_strategy_args,
+    )
+
+    _PARSER_AVAILABLE = True
+except ImportError:
+    _build_parser = None  # type: ignore[assignment]
+    _normalize_pull_strategy_args = None  # type: ignore[assignment]
+    _PARSER_AVAILABLE = False
+
+_skip_parser = pytest.mark.skipif(
+    not _PARSER_AVAILABLE,
+    reason="waggle.server requires MCP dependencies",
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -112,6 +134,79 @@ def _edge(source_id, target_id, relationship="relates_to", **kwargs):
 # ---------------------------------------------------------------------------
 # 16.1  Fixture-based tests
 # ---------------------------------------------------------------------------
+
+
+def test_drive_merge_respects_prefer_left_strategy(tmp_path):
+    local_document = build_abhi_document(
+        {
+            "tenant_id": "test-tenant",
+            "nodes": [
+                {
+                    "id": "shared-node",
+                    "label": "Local label",
+                    "content": "Local content",
+                    "node_type": "note",
+                    "tags": [],
+                    "metadata": {},
+                    "updated_at": "2026-06-10T10:00:00+00:00",
+                }
+            ],
+            "edges": [],
+            "transcripts": [],
+            "context_windows": [],
+        }
+    )
+
+    remote_document = build_abhi_document(
+        {
+            "tenant_id": "test-tenant",
+            "nodes": [
+                {
+                    "id": "shared-node",
+                    "label": "Remote label",
+                    "content": "Remote content",
+                    "node_type": "note",
+                    "tags": [],
+                    "metadata": {},
+                    "updated_at": "2026-06-11T10:00:00+00:00",
+                }
+            ],
+            "edges": [],
+            "transcripts": [],
+            "context_windows": [],
+        }
+    )
+
+    output_path = tmp_path / "merged.abhi"
+
+    merge_downloaded_abhi(
+        local_document=local_document,
+        remote_document=remote_document,
+        output_path=output_path,
+        merge_strategy="prefer_left",
+    )
+
+    merged_document = load_abhi_document(output_path)
+    merged_nodes = [node for node in merged_document["nodes"] if node["id"] == "shared-node"]
+
+    assert len(merged_nodes) == 1, f"Expected exactly one node with id 'shared-node', found {len(merged_nodes)}"
+
+    merged_node = merged_nodes[0]
+
+    assert merged_node["label"] == "Local label"
+    assert merged_node["content"] == "Local content"
+
+
+def test_drive_merge_rejects_invalid_strategy(tmp_path):
+    document = build_abhi_document(_make_snapshot())
+
+    with pytest.raises(ValidationFailure, match="Invalid merge_strategy"):
+        merge_downloaded_abhi(
+            local_document=document,
+            remote_document=document,
+            output_path=tmp_path / "merged.abhi",
+            merge_strategy="invalid-strategy",
+        )
 
 
 def test_diff_empty_abhi():
@@ -366,6 +461,85 @@ def test_upgrade_unsupported_path():
                 target_version="99.0.0",
                 output_path=path,
             )
+
+
+@_skip_parser
+def test_pull_parser_accepts_drive_merge_strategy():
+    assert _build_parser is not None
+    assert _normalize_pull_strategy_args is not None
+
+    parser = _build_parser()
+    args = _normalize_pull_strategy_args(
+        parser.parse_args(
+            [
+                "pull",
+                "remote-file-id",
+                "--merge-strategy",
+                "prefer_left",
+            ]
+        )
+    )
+
+    assert args.merge_strategy == "prefer_left"
+    assert args.import_strategy == "skip-existing"
+
+
+@_skip_parser
+def test_pull_parser_defaults_to_last_write_wins():
+    assert _build_parser is not None
+    assert _normalize_pull_strategy_args is not None
+
+    parser = _build_parser()
+    args = _normalize_pull_strategy_args(parser.parse_args(["pull", "remote-file-id"]))
+
+    assert args.merge_strategy == "last_write_wins"
+    assert args.import_strategy == "skip-existing"
+
+
+@_skip_parser
+def test_pull_parser_maps_legacy_merge_strategy_to_import_strategy():
+    assert _build_parser is not None
+    assert _normalize_pull_strategy_args is not None
+
+    parser = _build_parser()
+    parsed_args = parser.parse_args(
+        [
+            "pull",
+            "remote-file-id",
+            "--merge-strategy",
+            "overwrite",
+        ]
+    )
+
+    with pytest.warns(FutureWarning, match="deprecated"):
+        args = _normalize_pull_strategy_args(parsed_args)
+
+    assert args.merge_strategy == "last_write_wins"
+    assert args.import_strategy == "overwrite"
+
+
+@_skip_parser
+def test_explicit_import_strategy_overrides_legacy_merge_value():
+    assert _build_parser is not None
+    assert _normalize_pull_strategy_args is not None
+
+    parser = _build_parser()
+    parsed_args = parser.parse_args(
+        [
+            "pull",
+            "remote-file-id",
+            "--merge-strategy",
+            "overwrite",
+            "--import-strategy",
+            "branch",
+        ]
+    )
+
+    with pytest.warns(FutureWarning, match="ignored"):
+        args = _normalize_pull_strategy_args(parsed_args)
+
+    assert args.merge_strategy == "last_write_wins"
+    assert args.import_strategy == "branch"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_abhi_diff_merge.py
+++ b/tests/test_abhi_diff_merge.py
@@ -24,6 +24,7 @@ from waggle.abhi import (
     build_abhi_document,
     diff_abhi_files,
     load_abhi_document,
+    merge_abhi_documents,
     merge_abhi_files,
     resolve_abhi_conflict,
     serialize_abhi_diff,
@@ -206,6 +207,62 @@ def test_drive_merge_rejects_invalid_strategy(tmp_path):
             remote_document=document,
             output_path=tmp_path / "merged.abhi",
             merge_strategy="invalid-strategy",
+        )
+
+
+def test_drive_merge_normalizes_strategy_whitespace(tmp_path):
+    document = build_abhi_document(_make_snapshot())
+    output_path = tmp_path / "normalized-strategy.abhi"
+
+    merge_downloaded_abhi(
+        local_document=document,
+        remote_document=document,
+        output_path=output_path,
+        merge_strategy=" prefer_left ",
+    )
+
+    assert output_path.exists()
+
+
+@pytest.mark.parametrize(
+    "strategy_config",
+    [
+        MergeStrategyConfig(
+            type_overrides=[
+                {
+                    "node_type": "fact",
+                    "strategy": "invalid-strategy",
+                }
+            ]
+        ),
+        MergeStrategyConfig(
+            field_overrides=[
+                {
+                    "field": "content",
+                    "strategy": "invalid-strategy",
+                }
+            ]
+        ),
+    ],
+)
+def test_merge_rejects_invalid_override_strategies(
+    tmp_path,
+    strategy_config,
+):
+    document = build_abhi_document(_make_snapshot())
+
+    with pytest.raises(ValidationFailure, match="Invalid merge_strategy"):
+        merge_abhi_documents(
+            document,
+            document,
+            document,
+            base_input_path="local://base",
+            left_input_path="local://left",
+            right_input_path="local://right",
+            output_path=tmp_path / "merged.abhi",
+            merge_strategy="prefer_left",
+            strategy_config=strategy_config,
+            dry_run=True,
         )
 
 


### PR DESCRIPTION
## Summary

Closes #320

### What changed?

* Added shared `.abhi` merge strategy constants:

  * `contradict`
  * `last_write_wins`
  * `prefer_left`
  * `prefer_right`
* Added `DEFAULT_ABHI_MERGE_STRATEGY`, set to `last_write_wins`.
* Updated `merge_downloaded_abhi()` to accept and forward a configurable merge strategy instead of always using `last_write_wins`.
* Updated the Google Drive `pull` command so `--merge-strategy` controls how the local and downloaded `.abhi` documents are merged.
* Added a separate `--import-strategy` option for controlling how the merged document is imported into the active graph.
* Included the selected merge strategy in the `DrivePullResult`.
* Added tests covering:

  * `prefer_left` behaviour during a Drive merge.
  * Explicit `--merge-strategy prefer_left` parsing.
  * The default `last_write_wins` merge strategy.
  * The default `skip-existing` import strategy.

### Why was it needed?

The Drive pull flow previously hard-coded `last_write_wins` when merging the local and downloaded `.abhi` documents.

Additionally, the existing `--merge-strategy` option represented the later graph-import behaviour through values such as `skip-existing`, `overwrite`, and `branch`. This made it impossible for users to choose an actual `.abhi` conflict-resolution strategy during the Drive merge.

This change separates the two operations:

* `--merge-strategy` controls `.abhi` document conflict resolution.
* `--import-strategy` controls how the merged document is imported into the graph.

The existing behaviour remains backward-compatible through the defaults:

* Merge strategy: `last_write_wins`
* Import strategy: `skip-existing`

## Testing

* [x] `WAGGLE_MODEL=deterministic pytest -q`
* [x] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/`

The repository-wide Ruff format check reports 111 pre-existing formatting differences in files unrelated to this PR. All four files modified by this PR pass the scoped formatting check:

```text
python -m ruff format --check src/waggle/abhi.py src/waggle/drive_sync.py src/waggle/server.py tests/test_abhi_diff_merge.py
4 files already formatted
```

Additional verification:

```text
python -m py_compile src/waggle/server.py src/waggle/abhi.py src/waggle/drive_sync.py tests/test_abhi_diff_merge.py
```

Completed successfully without syntax errors.

```text
git diff --check
```

Completed without whitespace errors. The displayed LF-to-CRLF messages are Windows line-ending warnings only.

### Test report

```text
python -m pytest tests/test_abhi_diff_merge.py -v

collected 26 items

test_drive_merge_respects_prefer_left_strategy PASSED
test_diff_empty_abhi PASSED
test_diff_single_node_abhi PASSED
test_diff_linear_history PASSED
test_merge_empty_abhi PASSED
test_validate_all_fixtures PASSED
test_validate_dangling_edges_fixture PASSED
test_schema_version_mismatch_minor PASSED
test_schema_version_mismatch_major PASSED
test_import_dangling_edges_rejected PASSED
test_import_dangling_edges_allow_dangling PASSED
test_import_dangling_edges_force PASSED
test_export_strict_export_rejected PASSED
test_export_strict_export_allowed PASSED
test_resolve_unknown_conflict_id PASSED
test_upgrade_already_at_version PASSED
test_upgrade_unsupported_path PASSED
test_pull_parser_accepts_drive_merge_strategy PASSED
test_pull_parser_defaults_to_last_write_wins PASSED
test_cli_diff_format_patch_error SKIPPED
test_cli_merge_clean_exit_0 SKIPPED
test_cli_merge_conflicts_exit_1 SKIPPED
test_cli_diff_exit_0 SKIPPED
test_serialize_abhi_diff_truncation PASSED
test_serialize_abhi_diff_json_format PASSED
test_merge_strategy_config_load_missing_file PASSED

22 passed, 4 skipped in 2.55s
```

Full test suite:

```text
631 passed, 5 skipped, 1 warning in 222.36s
```

The warning is an existing Starlette deprecation warning from `tests/test_platform.py` and is unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made ABHI merge strategy configurable end-to-end (default remains **last_write_wins**), with supported options such as **contradict** and **prefer_left**.
  * Added a dedicated **import strategy** option (**skip-existing** by default) to control how merged content is applied.
  * Improved CLI handling for legacy strategy usage, including deprecation warnings and clearer defaulting.

* **Tests**
  * Expanded drive-side merge tests for **prefer_left** and added checks for rejecting invalid strategies (including whitespace-normalized inputs).
  * Added CLI parsing/normalization and legacy-warning coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
