### PR TITLE
ci: cache pip dependencies in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Install ruff
         run: pip install ruff>=0.4.0
@@ -53,7 +55,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Install project + dev dependencies
         run: pip install -e ".[dev]"
@@ -83,6 +86,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Install build
         run: pip install build


### PR DESCRIPTION
## Summary

* Added pip dependency caching to all `actions/setup-python@v5` steps in `.github/workflows/ci.yml`.
* Added `cache-dependency-path: 'pyproject.toml'` to ensure cache invalidation when dependencies change.
* Left npm-based workflows unchanged.

## Why was it needed?

Each CI job was installing Python dependencies from scratch. Since the dependency tree includes large packages such as `torch` and `sentence-transformers`, installation time was significant across the matrix.

Using GitHub Actions pip caching allows dependency downloads to be reused between runs, reducing setup time and improving CI performance.

## Testing

* [x] Verified all `actions/setup-python@v5` invocations in `ci.yml` use `cache: 'pip'`
* [x] Verified `cache-dependency-path` points to `pyproject.toml`
* [x] Verified npm-based workflows were left unchanged

### Test report

Configuration-only workflow change. No Python source files or tests were modified.

### Benchmark / Verification

The first CI run will populate the cache. Subsequent CI runs should show cache restoration in the `actions/setup-python` step (for example, "Cache restored from key"), reducing dependency installation time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD pipeline efficiency through dependency caching, reducing build and test times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->