### PR TITLE
Improve headless Google Drive OAuth workflow

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -449,6 +449,24 @@ When an API key is presented:
 - `/api/admin/*` read routes require `admin:read`
 - `/api/admin/*` write routes require `admin:write`
 
+## Headless Google Drive Authentication
+
+When running Waggle from a remote server, SSH session, container, or environment without a graphical browser, use the `--no-open-browser` option:
+
+```bash
+waggle-mcp push --no-open-browser
+```
+Instead of launching a browser automatically, Waggle prints the Google OAuth authorization URL to the terminal.
+
+Open the URL in a browser, complete authorization flow, and return to the terminal. Waggle will continue waiting for authorization.
+
+The same option is available for:
+
+```bash
+waggle-mcp pull --no-open-browser
+waggle-mcp share --no-open-browser
+```
+
 ## Full tool surface
 
 | Tool | What it does |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -458,7 +458,7 @@ waggle-mcp push --no-open-browser
 ```
 Instead of launching a browser automatically, Waggle prints the Google OAuth authorization URL to the terminal.
 
-Open the URL in a browser, complete authorization flow, and return to the terminal. Waggle will continue waiting for authorization.
+Open the URL in a browser and complete authorization flow. The OAuth callback must still be able to reach the machine running Waggle. Waggle waits up to 300 seconds for authorization before timing out.
 
 The same option is available for:
 

--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -215,7 +215,8 @@ def _run_local_oauth_flow(
     if open_browser:
         webbrowser.open(auth_url)
     else:
-        print("\nAuthorize Waggle Drive access by visiting this URL:\n" + auth_url)
+        print("\nAuthorize Waggle Drive access by visiting this URL:\n")
+        print(auth_url)
         print("\nWaiting for authorization...\n")
     thread.join(timeout=300)
     code = code_holder.get("code", "")

--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -11,6 +11,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
 
+import sys
+
 import requests
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
@@ -215,9 +217,9 @@ def _run_local_oauth_flow(
     if open_browser:
         webbrowser.open(auth_url)
     else:
-        print("\nAuthorize Waggle Drive access by visiting this URL:\n")
-        print(auth_url)
-        print("\nWaiting for authorization...\n")
+        print("\nAuthorize Waggle Drive access by visiting this URL:\n", file=sys.stderr,flush=True)
+        print(auth_url, file=sys.stderr,flush=True)
+        print("\nWaiting for authorization...\n",file=sys.stderr,flush=True)
     thread.join(timeout=300)
     code = code_holder.get("code", "")
     if not code:

--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -217,9 +217,15 @@ def _run_local_oauth_flow(
     if open_browser:
         webbrowser.open(auth_url)
     else:
-        print("\nAuthorize Waggle Drive access by visiting this URL:\n", file=sys.stderr,flush=True)
-        print(auth_url, file=sys.stderr,flush=True)
-        print("\nWaiting for authorization...\n",file=sys.stderr,flush=True)
+        print("\nAuthorize Waggle Drive access by visiting this URL:\n", 
+              file=sys.stderr,
+              flush=True)
+        print(auth_url, 
+              file=sys.stderr,
+              flush=True)
+        print("\nWaiting for authorization...\n",
+              file=sys.stderr,
+              flush=True)
     thread.join(timeout=300)
     code = code_holder.get("code", "")
     if not code:

--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -217,15 +217,14 @@ def _run_local_oauth_flow(
     if open_browser:
         webbrowser.open(auth_url)
     else:
-        print("\nAuthorize Waggle Drive access by visiting this URL:\n", 
-              file=sys.stderr,
-              flush=True)
-        print(auth_url, 
-              file=sys.stderr,
-              flush=True)
-        print("\nWaiting for authorization...\n",
-              file=sys.stderr,
-              flush=True)
+        print(
+        "\nAuthorize Waggle Drive access by visiting this URL:\n",
+        file=sys.stderr,
+        flush=True,
+        )
+        print(auth_url, file=sys.stderr, flush=True)
+        print("\nWaiting for authorization...\n", file=sys.stderr, flush=True)
+
     thread.join(timeout=300)
     code = code_holder.get("code", "")
     if not code:

--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -215,7 +215,8 @@ def _run_local_oauth_flow(
     if open_browser:
         webbrowser.open(auth_url)
     else:
-        raise RuntimeError(f"Open this URL to authorize Waggle Drive access: {auth_url}")
+        print("\nAuthorize Waggle Drive access by visiting this URL:\n" + auth_url)
+        print("\nWaiting for authorization...\n")
     thread.join(timeout=300)
     code = code_holder.get("code", "")
     if not code:


### PR DESCRIPTION
## Summary

- **What changed?**

- Added a headless Google Drive authentication workflow for users running Waggle in remote or non-graphical environments.
- When "--no-open-browser" is used, the OAuth consent URL is printed to the terminal instead of raising a "RuntimeError".
- Added documentation for the headless authentication flow in "docs/reference.md".

- **Why was it needed?**

The existing implementation exposed a "--no-open-browser" path but did not provide a user-friendly workflow for SSH sessions, remote servers, containers, or other environments without a graphical browser. This change allows users to manually open the OAuth consent URL and complete authentication without requiring automatic browser launch.

## Testing

- [ ] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

### Test report

Manually verified the CLI workflow.

- Confirmed that --open-browser / --no-open-browser options are available.
- Confirmed that the Drive authentication flow reaches the OAuth setup path.
- Confirmed that the previous RuntimeError path was replaced with user-facing URL output.
- Documentation updated for the headless workflow.

Automated tests and Ruff checks were not run in the local environment.

Closes #313 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * **Headless Google Drive authentication:** the `--no-open-browser` option now prints step-by-step authorization instructions and the authorization URL to the terminal, then waits (up to 300s) for completion instead of failing. Works for push, pull, and share; the OAuth callback must reach the machine running the tool.

* **Documentation**
  * Added reference documentation describing the headless authentication workflow and key usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->