### PR TITLE
perf(embeddings): reuse model initialization across commands

### DIFF
--- a/src/waggle/embeddings.py
+++ b/src/waggle/embeddings.py
@@ -10,6 +10,12 @@ import numpy as np
 
 LOGGER = logging.getLogger(__name__)
 
+# Shared caches used to avoid repeated sentence-transformers initialization.
+_MODEL_SINGLETONS: dict[tuple[str, str], "EmbeddingModel"] = {}
+_MODEL_SINGLETONS_LOCK = threading.Lock()
+_TRANSFORMER_MODEL_CACHE: dict[tuple[str, str], object] = {}
+_TRANSFORMER_MODEL_CACHE_LOCK = threading.Lock()
+
 # Tools that must NEVER trigger torch/sentence-transformers import.
 # Queries to these tools are answered before the model is ready.
 EMBEDDING_FREE_TOOLS: frozenset[str] = frozenset(
@@ -32,6 +38,27 @@ STATUS_WARMING_UP = "warming_up"
 STATUS_READY = "ready"
 STATUS_FAILED = "failed"
 STATUS_DISABLED = "disabled"  # fast / inspection mode
+
+
+def get_embedding_model(model_name: str = "all-MiniLM-L6-v2", embedding_backend: str = "pytorch") -> "EmbeddingModel":
+    """Return a shared embedding wrapper instance for a given model configuration.
+
+    The SentenceTransformer backend is loaded lazily on first use. Subsequent
+    calls reuse the same wrapper instance for the same model name and backend.
+    """
+    normalized_name = (model_name or "").strip() or "all-MiniLM-L6-v2"
+    cache_key = (normalized_name, embedding_backend)
+    instance = _MODEL_SINGLETONS.get(cache_key)
+    if instance is not None:
+        return instance
+
+    with _MODEL_SINGLETONS_LOCK:
+        instance = _MODEL_SINGLETONS.get(cache_key)
+        if instance is not None:
+            return instance
+        instance = EmbeddingModel(normalized_name, embedding_backend=embedding_backend)
+        _MODEL_SINGLETONS[cache_key] = instance
+        return instance
 
 
 class EmbeddingModel:
@@ -334,13 +361,25 @@ class EmbeddingModel:
     def _load_transformer_model(self) -> Any:
         from sentence_transformers import SentenceTransformer
 
+        cache_key = (self.model_name.strip() or "all-MiniLM-L6-v2", self.embedding_backend)
+        with _TRANSFORMER_MODEL_CACHE_LOCK:
+            existing = _TRANSFORMER_MODEL_CACHE.get(cache_key)
+            if existing is not None:
+                return existing
+
         if self.embedding_backend == "onnx":
-            return SentenceTransformer(
+            loaded = SentenceTransformer(
                 self.model_name,
                 backend="onnx",
             )
+            with _TRANSFORMER_MODEL_CACHE_LOCK:
+                _TRANSFORMER_MODEL_CACHE[cache_key] = loaded
+            return loaded
         try:
-            return SentenceTransformer(self.model_name, local_files_only=True)
+            loaded = SentenceTransformer(self.model_name, local_files_only=True)
+            with _TRANSFORMER_MODEL_CACHE_LOCK:
+                _TRANSFORMER_MODEL_CACHE[cache_key] = loaded
+            return loaded
         except Exception:
             # Model not cached locally - must download from HuggingFace.
             # This can take 30-120 s and requires a network connection.
@@ -358,7 +397,10 @@ class EmbeddingModel:
                     ),
                 },
             )
-            return SentenceTransformer(self.model_name)
+            loaded = SentenceTransformer(self.model_name)
+            with _TRANSFORMER_MODEL_CACHE_LOCK:
+                _TRANSFORMER_MODEL_CACHE[cache_key] = loaded
+            return loaded
 
     def _embed_deterministically(self, text: str) -> np.ndarray:
         vector = np.zeros(256, dtype=np.float32)

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -46,7 +46,7 @@ from waggle.abhi import (
     validate_abhi_document,
 )
 from waggle.config import DEFAULT_DB_PATH, AppConfig
-from waggle.embeddings import EMBEDDING_FREE_TOOLS, STATUS_DISABLED, STATUS_READY, EmbeddingModel
+from waggle.embeddings import EMBEDDING_FREE_TOOLS, STATUS_DISABLED, STATUS_READY, get_embedding_model
 from waggle.errors import (
     AuthenticationError,
     PayloadTooLargeError,
@@ -483,7 +483,7 @@ def _assert_runtime_feature_parity() -> None:
 
 
 def _build_backend(config: AppConfig) -> Any:
-    embedding_model = EmbeddingModel(
+    embedding_model = get_embedding_model(
         config.model_name,
         embedding_backend=config.embedding_backend,
     )
@@ -4757,7 +4757,7 @@ def _run_admin_command(config: AppConfig, args: argparse.Namespace) -> int:
             raise ValidationFailure("migrate-sqlite requires WAGGLE_BACKEND=neo4j for the target environment.")
         source = MemoryGraph(
             args.db_path,
-            EmbeddingModel(
+            get_embedding_model(
                 config.model_name,
                 embedding_backend=config.embedding_backend,
             ),
@@ -6024,7 +6024,7 @@ def _run_demo(args: argparse.Namespace) -> int:
 
     try:
         # Import the demo graph
-        embedding_model = EmbeddingModel(model_name)
+        embedding_model = get_embedding_model(model_name)
         graph = MemoryGraph(
             str(demo_db),
             embedding_model,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import builtins
+import threading
+from typing import Any
+
 import numpy as np
 import pytest
 
-from waggle.embeddings import EmbeddingModel
+from waggle.embeddings import EmbeddingModel, get_embedding_model
 
 
 def test_embedding_bytes_round_trip() -> None:
@@ -135,3 +139,87 @@ def test_embedding_cache_isolates_different_models(
 
     assert vec_a.shape == (3,)
     assert vec_b.shape == (2,)
+
+
+def test_get_embedding_model_returns_shared_instance() -> None:
+    model_a = get_embedding_model("shared-loader-model")
+    model_b = get_embedding_model("shared-loader-model")
+
+    assert model_a is model_b
+    assert model_a.model_name == model_b.model_name
+
+
+def test_embedding_model_loads_once_per_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    load_calls: list[str] = []
+
+    def fake_load(self) -> Any:
+        load_calls.append("loaded")
+
+        class DummyModel:
+            def encode(self, text, normalize_embeddings=True, convert_to_numpy=True):
+                return np.array([1.0, 1.0, 1.0], dtype=np.float32)
+
+        return DummyModel()
+
+    monkeypatch.setattr(EmbeddingModel, "_load_transformer_model", fake_load)
+
+    model = get_embedding_model("singleton-init-model")
+    model.embed("first")
+    model.embed("second")
+
+    assert len(load_calls) == 1
+
+
+def test_deterministic_mode_does_not_import_sentence_transformers(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+            raise AssertionError("sentence-transformers must not be imported in deterministic mode")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    model = get_embedding_model("deterministic")
+    vector = model.embed("offline-safe request")
+
+    assert model.uses_deterministic_mode is True
+    assert vector.shape == (256,)
+    assert np.isclose(np.linalg.norm(vector), 1.0)
+
+
+def test_get_embedding_model_thread_safe_initialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    load_count = 0
+    started = threading.Event()
+    proceed = threading.Event()
+
+    def fake_load(self) -> Any:
+        nonlocal load_count
+        load_count += 1
+        started.set()
+        proceed.wait(timeout=5)
+
+        class DummyModel:
+            def encode(self, text, normalize_embeddings=True, convert_to_numpy=True):
+                return np.array([1.0, 1.0, 1.0], dtype=np.float32)
+
+        return DummyModel()
+
+    monkeypatch.setattr(EmbeddingModel, "_load_transformer_model", fake_load)
+
+    model = get_embedding_model("thread-safe-model")
+
+    def worker() -> None:
+        model.embed("race")
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+
+    assert started.wait(timeout=5)
+    proceed.set()
+
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert load_count == 1


### PR DESCRIPTION
## Summary

This PR introduces a reusable embedding model-loading strategy to prevent repeated sentence-transformer initialization across CLI, server, and retrieval paths.

### Changes

* Added a centralized lazy-loaded model reuse mechanism in `src/waggle/embeddings.py`
* Ensured process-wide model caching for embedding models
* Preserved deterministic fallback behavior
* Updated retrieval and server paths to use the shared loader
* Added regression tests covering:

  * Model reuse
  * Single initialization behavior
  * Deterministic fallback
  * Thread-safe access

## Why

Embedding model initialization is one of the heaviest startup costs in Waggle. Reusing a single loaded instance improves latency and reduces unnecessary resource consumption while maintaining existing functionality.

## Testing

* [x] Existing tests pass
* [x] Added model reuse tests
* [x] Verified deterministic mode behavior
* [x] Verified initialization occurs only once

## Expected Impact

* Faster repeated embedding operations
* Reduced startup overhead within long-running processes
* No behavior changes for deterministic mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized model initialization through shared caching, reducing repeated load overhead.
  * Enhanced thread-safe model management for concurrent access across multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->