### PR TITLE
feat(drive): add resumable uploads with retry support

### DIFF
--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 import secrets
 import threading
 import urllib.parse
 import webbrowser
+from collections.abc import Callable
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
@@ -27,6 +29,12 @@ from waggle.models import DrivePushResult, DriveShareResult
 
 DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.file"
 TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+LOGGER = logging.getLogger(__name__)
+
+RESUMABLE_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024
+RESUMABLE_UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024
+DEFAULT_UPLOAD_RETRIES = 3
 
 
 def ensure_drive_credentials(
@@ -59,6 +67,55 @@ def build_drive_service(*, credentials: Credentials) -> Any:
     return build("drive", "v3", credentials=credentials, cache_discovery=False)
 
 
+def should_use_resumable_upload(
+    path: Path,
+    *,
+    threshold_bytes: int = RESUMABLE_UPLOAD_THRESHOLD_BYTES,
+) -> bool:
+    """Return whether an upload should use Google Drive resumable mode."""
+    if threshold_bytes < 0:
+        raise ValueError("threshold_bytes cannot be negative.")
+
+    return path.stat().st_size >= threshold_bytes
+
+
+def _execute_resumable_upload(
+    request: Any,
+    *,
+    max_retries: int,
+    progress_callback: Callable[[int], None] | None = None,
+) -> dict[str, Any]:
+    """Execute a resumable Drive request until its final response is returned."""
+    response: dict[str, Any] | None = None
+    last_progress = -1
+
+    while response is None:
+        status, response = request.next_chunk(num_retries=max_retries)
+
+        if status is None:
+            continue
+
+        progress = max(0, min(100, int(status.progress() * 100)))
+
+        if progress == last_progress:
+            continue
+
+        LOGGER.info("Google Drive upload progress: %s%%", progress)
+
+        if progress_callback is not None:
+            progress_callback(progress)
+
+        last_progress = progress
+
+    if last_progress < 100:
+        LOGGER.info("Google Drive upload progress: 100%%")
+
+        if progress_callback is not None:
+            progress_callback(100)
+
+    return response
+
+
 def push_file_to_drive(
     *,
     local_path: str | Path,
@@ -66,21 +123,69 @@ def push_file_to_drive(
     credentials: Credentials,
     remote_name: str = "",
     encrypted: bool = False,
+    resumable_threshold_bytes: int = RESUMABLE_UPLOAD_THRESHOLD_BYTES,
+    chunk_size: int = RESUMABLE_UPLOAD_CHUNK_SIZE,
+    max_retries: int = DEFAULT_UPLOAD_RETRIES,
+    progress_callback: Callable[[int], None] | None = None,
 ) -> DrivePushResult:
     path = Path(local_path).expanduser()
+
+    if not path.is_file():
+        raise FileNotFoundError(f"Drive upload file not found: {path}")
+
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive.")
+
+    if max_retries < 0:
+        raise ValueError("max_retries cannot be negative.")
+
+    use_resumable = should_use_resumable_upload(
+        path,
+        threshold_bytes=resumable_threshold_bytes,
+    )
+
     service = build_drive_service(credentials=credentials)
-    metadata: dict[str, Any] = {"name": remote_name or path.name}
+
+    metadata: dict[str, Any] = {
+        "name": remote_name or path.name,
+    }
+
     if folder_id.strip():
         metadata["parents"] = [folder_id.strip()]
-    created = (
-        service.files()
-        .create(
-            body=metadata,
-            media_body=MediaFileUpload(str(path), mimetype="application/zip", resumable=False),
-            fields="id,name,webViewLink",
+
+    if use_resumable:
+        media = MediaFileUpload(
+            str(path),
+            mimetype="application/zip",
+            chunksize=chunk_size,
+            resumable=True,
         )
-        .execute()
+    else:
+        media = MediaFileUpload(
+            str(path),
+            mimetype="application/zip",
+            resumable=False,
+        )
+
+    request = service.files().create(
+        body=metadata,
+        media_body=media,
+        fields="id,name,webViewLink",
     )
+
+    try:
+        if use_resumable:
+            created = _execute_resumable_upload(
+                request,
+                max_retries=max_retries,
+                progress_callback=progress_callback,
+            )
+        else:
+            created = request.execute(num_retries=max_retries)
+    except Exception as exc:
+        upload_mode = "resumable" if use_resumable else "simple"
+        raise RuntimeError(f"Google Drive {upload_mode} upload failed for '{path.name}': {exc}") from exc
+
     return DrivePushResult(
         local_path=str(path),
         remote_file_id=str(created.get("id", "")),

--- a/src/waggle/drive_sync.py
+++ b/src/waggle/drive_sync.py
@@ -34,6 +34,7 @@ LOGGER = logging.getLogger(__name__)
 
 RESUMABLE_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024
 RESUMABLE_UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024
+GOOGLE_DRIVE_RESUMABLE_CHUNK_ALIGNMENT_BYTES = 256 * 1024
 DEFAULT_UPLOAD_RETRIES = 3
 
 
@@ -135,6 +136,9 @@ def push_file_to_drive(
 
     if chunk_size <= 0:
         raise ValueError("chunk_size must be positive.")
+
+    if chunk_size % GOOGLE_DRIVE_RESUMABLE_CHUNK_ALIGNMENT_BYTES != 0:
+        raise ValueError("chunk_size must be a multiple of 256 KiB for resumable uploads.")
 
     if max_retries < 0:
         raise ValueError("max_retries cannot be negative.")

--- a/tests/test_drive_sync.py
+++ b/tests/test_drive_sync.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from google.oauth2.credentials import Credentials
 
+import waggle.drive_sync as drive_sync
 from waggle.drive_sync import resolve_drive_file_id, share_drive_file
 from waggle.models import DriveShareResult
 
@@ -69,7 +73,11 @@ def test_resolve_drive_file_id_filename_lookup_with_folder_id(mock_build, mock_c
     mock_files.list.return_value = mock_list_request
     mock_list_request.execute.return_value = {"files": [{"id": "file123", "name": "my file.txt"}]}
 
-    file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials, folder_id="folder-999")
+    file_id, name = resolve_drive_file_id(
+        file_ref=ref,
+        credentials=mock_credentials,
+        folder_id="folder-999",
+    )
 
     assert file_id == "file123"
     assert name == "my file.txt"
@@ -90,7 +98,9 @@ def test_resolve_drive_file_id_escapes_single_quotes(mock_build, mock_credential
     mock_list_request = MagicMock()
     mock_service.files.return_value = mock_files
     mock_files.list.return_value = mock_list_request
-    mock_list_request.execute.return_value = {"files": [{"id": "file456", "name": "O'Connor's File.txt"}]}
+    mock_list_request.execute.return_value = {
+        "files": [{"id": "file456", "name": "O'Connor's File.txt"}],
+    }
 
     file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
 
@@ -153,3 +163,325 @@ def test_share_drive_file(mock_build, mock_credentials):
         fileId="file-xyz", body={"type": "anyone", "role": "reader"}, fields="id"
     )
     mock_files.get.assert_called_once_with(fileId="file-xyz", fields="id,webViewLink")
+
+
+def make_drive_service(
+    *,
+    response: dict[str, str] | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    service = MagicMock()
+    request = MagicMock()
+
+    service.files.return_value.create.return_value = request
+    request.execute.return_value = response or {
+        "id": "drive-file-id",
+        "name": "backup.abhi",
+        "webViewLink": "https://drive.google.com/file/d/drive-file-id/view",
+    }
+
+    return service, request
+
+
+def patch_drive_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    service: MagicMock,
+) -> tuple[MagicMock, object]:
+    build_service = MagicMock(return_value=service)
+    media = object()
+    media_factory = MagicMock(return_value=media)
+
+    monkeypatch.setattr(
+        drive_sync,
+        "build_drive_service",
+        build_service,
+    )
+    monkeypatch.setattr(
+        drive_sync,
+        "MediaFileUpload",
+        media_factory,
+    )
+
+    return media_factory, media
+
+
+def test_small_file_uses_simple_upload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / "small.abhi"
+    upload_path.write_bytes(b"small upload")
+
+    service, request = make_drive_service()
+    media_factory, media = patch_drive_dependencies(
+        monkeypatch,
+        service,
+    )
+
+    result = drive_sync.push_file_to_drive(
+        local_path=upload_path,
+        folder_id="folder-id",
+        credentials=MagicMock(),
+        remote_name="backup.abhi",
+        encrypted=True,
+        resumable_threshold_bytes=1024,
+    )
+
+    media_factory.assert_called_once_with(
+        str(upload_path),
+        mimetype="application/zip",
+        resumable=False,
+    )
+
+    service.files.return_value.create.assert_called_once_with(
+        body={
+            "name": "backup.abhi",
+            "parents": ["folder-id"],
+        },
+        media_body=media,
+        fields="id,name,webViewLink",
+    )
+
+    request.execute.assert_called_once_with(num_retries=3)
+    request.next_chunk.assert_not_called()
+
+    assert result.local_path == str(upload_path)
+    assert result.remote_file_id == "drive-file-id"
+    assert result.remote_name == "backup.abhi"
+    assert result.folder_id == "folder-id"
+    assert result.web_view_link == ("https://drive.google.com/file/d/drive-file-id/view")
+    assert result.encrypted is True
+
+
+def test_large_file_uses_resumable_upload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / "large.abhi"
+    upload_path.write_bytes(b"large")
+
+    service, request = make_drive_service()
+    media_factory, _ = patch_drive_dependencies(
+        monkeypatch,
+        service,
+    )
+
+    complete_status = MagicMock()
+    complete_status.progress.return_value = 1.0
+
+    request.next_chunk.return_value = (
+        complete_status,
+        {
+            "id": "drive-file-id",
+            "name": "large.abhi",
+            "webViewLink": "https://drive.example/large",
+        },
+    )
+
+    drive_sync.push_file_to_drive(
+        local_path=upload_path,
+        folder_id="",
+        credentials=MagicMock(),
+        resumable_threshold_bytes=1,
+        chunk_size=4 * 1024 * 1024,
+    )
+
+    media_factory.assert_called_once_with(
+        str(upload_path),
+        mimetype="application/zip",
+        chunksize=4 * 1024 * 1024,
+        resumable=True,
+    )
+
+    request.next_chunk.assert_called_once_with(num_retries=3)
+    request.execute.assert_not_called()
+
+
+def test_resumable_upload_reports_chunk_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / "progress.abhi"
+    upload_path.write_bytes(b"progress")
+
+    service, request = make_drive_service()
+    patch_drive_dependencies(monkeypatch, service)
+
+    halfway = MagicMock()
+    halfway.progress.return_value = 0.5
+
+    complete = MagicMock()
+    complete.progress.return_value = 1.0
+
+    request.next_chunk.side_effect = [
+        (halfway, None),
+        (
+            complete,
+            {
+                "id": "drive-file-id",
+                "name": "progress.abhi",
+                "webViewLink": "https://drive.example/progress",
+            },
+        ),
+    ]
+
+    progress_updates: list[int] = []
+
+    drive_sync.push_file_to_drive(
+        local_path=upload_path,
+        folder_id="",
+        credentials=MagicMock(),
+        resumable_threshold_bytes=1,
+        progress_callback=progress_updates.append,
+    )
+
+    assert progress_updates == [50, 100]
+    assert request.next_chunk.call_count == 2
+
+    for call in request.next_chunk.call_args_list:
+        assert call.kwargs == {"num_retries": 3}
+
+
+def test_resumable_upload_does_not_repeat_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / "duplicate-progress.abhi"
+    upload_path.write_bytes(b"progress")
+
+    service, request = make_drive_service()
+    patch_drive_dependencies(monkeypatch, service)
+
+    first = MagicMock()
+    first.progress.return_value = 0.25
+
+    duplicate = MagicMock()
+    duplicate.progress.return_value = 0.25
+
+    complete = MagicMock()
+    complete.progress.return_value = 1.0
+
+    request.next_chunk.side_effect = [
+        (first, None),
+        (duplicate, None),
+        (
+            complete,
+            {
+                "id": "drive-file-id",
+                "name": "duplicate-progress.abhi",
+                "webViewLink": "",
+            },
+        ),
+    ]
+
+    updates: list[int] = []
+
+    drive_sync.push_file_to_drive(
+        local_path=upload_path,
+        folder_id="",
+        credentials=MagicMock(),
+        resumable_threshold_bytes=1,
+        progress_callback=updates.append,
+    )
+
+    assert updates == [25, 100]
+
+
+def test_threshold_boundary_uses_resumable_upload(
+    tmp_path: Path,
+) -> None:
+    upload_path = tmp_path / "boundary.abhi"
+    upload_path.write_bytes(b"12345")
+
+    assert drive_sync.should_use_resumable_upload(
+        upload_path,
+        threshold_bytes=5,
+    )
+
+
+def test_missing_file_fails_before_service_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_service = MagicMock()
+
+    monkeypatch.setattr(
+        drive_sync,
+        "build_drive_service",
+        build_service,
+    )
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="Drive upload file not found",
+    ):
+        drive_sync.push_file_to_drive(
+            local_path=tmp_path / "missing.abhi",
+            folder_id="",
+            credentials=MagicMock(),
+        )
+
+    build_service.assert_not_called()
+
+
+def test_resumable_upload_failure_has_useful_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upload_path = tmp_path / "failed.abhi"
+    upload_path.write_bytes(b"failed")
+
+    service, request = make_drive_service()
+    patch_drive_dependencies(monkeypatch, service)
+
+    request.next_chunk.side_effect = OSError("connection reset")
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Google Drive resumable upload failed.*connection reset",
+    ):
+        drive_sync.push_file_to_drive(
+            local_path=upload_path,
+            folder_id="",
+            credentials=MagicMock(),
+            resumable_threshold_bytes=1,
+        )
+
+
+def test_invalid_upload_options_are_rejected(
+    tmp_path: Path,
+) -> None:
+    upload_path = tmp_path / "options.abhi"
+    upload_path.write_bytes(b"options")
+
+    with pytest.raises(
+        ValueError,
+        match="chunk_size must be positive",
+    ):
+        drive_sync.push_file_to_drive(
+            local_path=upload_path,
+            folder_id="",
+            credentials=MagicMock(),
+            chunk_size=0,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="max_retries cannot be negative",
+    ):
+        drive_sync.push_file_to_drive(
+            local_path=upload_path,
+            folder_id="",
+            credentials=MagicMock(),
+            max_retries=-1,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="threshold_bytes cannot be negative",
+    ):
+        drive_sync.push_file_to_drive(
+            local_path=upload_path,
+            folder_id="",
+            credentials=MagicMock(),
+            resumable_threshold_bytes=-1,
+        )

--- a/tests/test_drive_sync.py
+++ b/tests/test_drive_sync.py
@@ -485,3 +485,22 @@ def test_invalid_upload_options_are_rejected(
             credentials=MagicMock(),
             resumable_threshold_bytes=-1,
         )
+
+
+def test_invalid_resumable_chunk_size_alignment_is_rejected(
+    tmp_path: Path,
+) -> None:
+    upload_path = tmp_path / "misaligned.abhi"
+    upload_path.write_bytes(b"misaligned")
+
+    with pytest.raises(
+        ValueError,
+        match="chunk_size must be a multiple of 256 KiB",
+    ):
+        drive_sync.push_file_to_drive(
+            local_path=upload_path,
+            folder_id="",
+            credentials=MagicMock(),
+            chunk_size=1000,
+            resumable_threshold_bytes=1,
+        )


### PR DESCRIPTION
## Summary

### What changed?

* Added automatic upload-mode selection based on `.abhi` file size.
* Preserved the existing simple upload path for smaller files.
* Added resumable chunked uploads for larger files using Google Drive’s `next_chunk()` flow.
* Added retry handling for both simple and resumable upload requests.
* Added upload-progress logging and an optional progress callback.
* Added validation for missing files, invalid chunk sizes, negative retry values, and invalid upload thresholds.
* Added clear error messages identifying whether a simple or resumable upload failed.
* Added focused tests covering upload-mode selection, threshold boundaries, retries, progress reporting, duplicate-progress suppression, metadata preservation, validation, and failure handling.

### Why was it needed?

Drive pushes previously used a single non-resumable request. A connection interruption during a large `.abhi` upload could therefore fail the entire operation and require restarting from the beginning.

This change improves reliability on unstable networks by using retry-aware, resumable chunk uploads for larger files. Smaller files continue using the existing simple upload flow to avoid unnecessary resumable-upload overhead.

Closes #317

## Testing

* [x] `WAGGLE_MODEL=deterministic pytest -q`
* [x] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/`

The repository-wide format check currently reports 114 pre-existing files outside this PR that would be reformatted. The files changed by this PR pass the focused formatting check:

* [x] `ruff format --check src/waggle/drive_sync.py tests/test_drive_sync.py`

### Test report

```text
tests/test_drive_sync.py::test_small_file_uses_simple_upload PASSED
tests/test_drive_sync.py::test_large_file_uses_resumable_upload PASSED
tests/test_drive_sync.py::test_resumable_upload_reports_chunk_progress PASSED
tests/test_drive_sync.py::test_resumable_upload_does_not_repeat_progress PASSED
tests/test_drive_sync.py::test_threshold_boundary_uses_resumable_upload PASSED
tests/test_drive_sync.py::test_missing_file_fails_before_service_creation PASSED
tests/test_drive_sync.py::test_resumable_upload_failure_has_useful_error PASSED
tests/test_drive_sync.py::test_invalid_upload_options_are_rejected PASSED

8 passed in 1.44s
```

### Additional validation

* Full suite: 649 passed, 5 skipped, 1 pre-existing warning
* Drive server subset: 1 passed, 80 deselected
* ABHI merge suite: 19 passed, 4 skipped
* Changed-file Ruff lint and formatting checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Drive uploads can now run in resumable mode for larger files, automatically selected using a configurable size threshold.
  * Added upload-progress reporting via an optional callback.
  * Added configurable upload options for resumable transfers, including chunk size and maximum retry attempts.
* **Bug Fixes**
  * Improved resiliency and clearer error reporting when resumable uploads fail.
* **Tests**
  * Expanded test coverage for resumable vs non-resumable uploads, progress updates (including final completion), option validation (including alignment/threshold rules), and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->