### PR TITLE
perf(rate_limit): shard limiter locks to cut cross-key contention

### DIFF
--- a/src/waggle/rate_limit.py
+++ b/src/waggle/rate_limit.py
@@ -7,6 +7,14 @@ from contextlib import asynccontextmanager
 
 from waggle.errors import RateLimitExceededError
 
+# Number of lock shards. A fixed-size array of locks keeps the number of lock
+# objects bounded (unlike per-key locks, which would need their own cleanup map
+# and interact badly with the unbounded-map cleanup in the sibling issue) while
+# still splitting contention so that requests for unrelated keys do not queue on
+# a single global lock. 64 shards is plenty for the concurrency a single MCP
+# server instance sees; it can be tuned per instance via the constructor.
+DEFAULT_LOCK_SHARDS = 64
+
 
 class RateLimiter:
     def __init__(
@@ -15,21 +23,39 @@ class RateLimiter:
         requests_per_minute: int,
         max_concurrent_requests: int,
         write_requests_per_minute: int | None = None,
+        lock_shards: int = DEFAULT_LOCK_SHARDS,
     ) -> None:
         self.requests_per_minute = max(requests_per_minute, 1)
         self.max_concurrent_requests = max(max_concurrent_requests, 1)
         self.write_requests_per_minute = write_requests_per_minute or self.requests_per_minute
-        self._lock = asyncio.Lock()
+        # A fixed pool of shard locks. Every operation on a given key always
+        # acquires the *same* shard lock (see `_lock_for`), so all critical
+        # sections that touch one key's state remain mutually exclusive — the
+        # exact serialization guarantee the old single global lock gave, but
+        # scoped to a shard instead of the whole limiter.
+        self._lock_shards = max(lock_shards, 1)
+        self._locks: list[asyncio.Lock] = [asyncio.Lock() for _ in range(self._lock_shards)]
         self._request_windows: dict[str, deque[float]] = defaultdict(deque)
         self._write_windows: dict[str, deque[float]] = defaultdict(deque)
         self._concurrent: dict[str, int] = defaultdict(int)
+
+    def _lock_for(self, key: str) -> asyncio.Lock:
+        """Return the shard lock that guards `key`.
+
+        A key is mapped to a shard by its hash, so the same key always resolves
+        to the same lock for the lifetime of this limiter. That stability is
+        what makes the scheme race-free: two operations on the same key can
+        never run their critical sections concurrently, while two operations on
+        keys in different shards no longer block each other.
+        """
+        return self._locks[hash(key) % self._lock_shards]
 
     async def check_rate(self, key: str, *, is_write: bool) -> None:
         limit = self.write_requests_per_minute if is_write else self.requests_per_minute
         bucket = self._write_windows if is_write else self._request_windows
         now = time.monotonic()
 
-        async with self._lock:
+        async with self._lock_for(key):
             window = bucket[key]
 
             while window and now - window[0] > 60.0:
@@ -45,14 +71,15 @@ class RateLimiter:
 
     @asynccontextmanager
     async def concurrency_slot(self, key: str):
-        async with self._lock:
+        lock = self._lock_for(key)
+        async with lock:
             if self._concurrent[key] >= self.max_concurrent_requests:
                 raise RateLimitExceededError("Too many concurrent requests.")
             self._concurrent[key] += 1
         try:
             yield
         finally:
-            async with self._lock:
+            async with lock:
                 self._concurrent[key] = max(self._concurrent[key] - 1, 0)
                 if self._concurrent[key] == 0:
                     del self._concurrent[key]

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from collections import deque
 
@@ -83,3 +84,106 @@ async def test_expired_request_window_is_cleaned_up():
 
     assert "user1" in limiter._request_windows
     assert len(limiter._request_windows["user1"]) == 1
+
+
+# ── Issue #120: sharded locks must cut cross-key contention while keeping caps ──
+
+
+def test_same_key_maps_to_same_shard_lock():
+    limiter = RateLimiter(requests_per_minute=10, max_concurrent_requests=10, lock_shards=64)
+    assert limiter._lock_for("alpha") is limiter._lock_for("alpha")
+
+
+def test_distinct_keys_spread_across_shards():
+    # The whole point of the change: unrelated keys must not all funnel through
+    # one lock. With 64 shards, 256 keys have to land on more than one shard.
+    limiter = RateLimiter(requests_per_minute=10, max_concurrent_requests=10, lock_shards=64)
+    distinct_locks = {id(limiter._lock_for(f"key-{i}")) for i in range(256)}
+    assert len(distinct_locks) > 1
+
+
+def test_single_shard_degenerates_to_global_lock():
+    # lock_shards=1 is the old behaviour; correctness must not depend on sharding.
+    limiter = RateLimiter(requests_per_minute=10, max_concurrent_requests=10, lock_shards=1)
+    assert limiter._lock_for("a") is limiter._lock_for("b")
+
+
+@pytest.mark.asyncio
+async def test_check_rate_cap_holds_under_concurrent_hammer():
+
+    limit = 50
+    limiter = RateLimiter(requests_per_minute=limit, max_concurrent_requests=10_000)
+    key = "hammer"
+    attempts = 500
+
+    async def attempt() -> bool:
+        try:
+            await limiter.check_rate(key, is_write=False)
+            return True
+        except RateLimitExceededError:
+            return False
+
+    results = await asyncio.gather(*[attempt() for _ in range(attempts)])
+
+    allowed = sum(results)
+    # Exactly `limit` requests get through in a single window — no race lets an
+    # extra one slip past the cap.
+    assert allowed == limit
+    assert len(limiter._request_windows[key]) == limit
+
+
+@pytest.mark.asyncio
+async def test_independent_keys_each_get_full_budget():
+
+    limiter = RateLimiter(requests_per_minute=3, max_concurrent_requests=10)
+    keys = [f"user-{i}" for i in range(20)]
+
+    async def fill(key: str) -> int:
+        allowed = 0
+        for _ in range(5):
+            try:
+                await limiter.check_rate(key, is_write=False)
+                allowed += 1
+            except RateLimitExceededError:
+                pass
+        return allowed
+
+    per_key = await asyncio.gather(*[fill(k) for k in keys])
+    # Every key independently receives exactly its own per-minute budget; one
+    # key exhausting its window never steals from another.
+    assert per_key == [3] * len(keys)
+
+
+@pytest.mark.asyncio
+async def test_concurrency_cap_holds_under_concurrent_hammer():
+
+    cap = 5
+    limiter = RateLimiter(requests_per_minute=10_000, max_concurrent_requests=cap)
+    key = "slots"
+    release = asyncio.Event()
+    tally_lock = asyncio.Lock()
+    peak = current = admitted = rejected = 0
+
+    async def worker() -> None:
+        nonlocal peak, current, admitted, rejected
+        try:
+            async with limiter.concurrency_slot(key):
+                async with tally_lock:
+                    admitted += 1
+                    current += 1
+                    peak = max(peak, current)
+                await release.wait()
+                async with tally_lock:
+                    current -= 1
+        except RateLimitExceededError:
+            async with tally_lock:
+                rejected += 1
+
+    tasks = [asyncio.create_task(worker()) for _ in range(20)]
+    await asyncio.sleep(0.05)  # let every worker reach the slot check
+    release.set()
+    await asyncio.gather(*tasks)
+
+    assert peak <= cap
+    assert admitted == cap
+    assert rejected == 20 - cap

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -99,7 +99,7 @@ def test_distinct_keys_spread_across_shards():
     # one lock. With 64 shards, 256 keys have to land on more than one shard.
     limiter = RateLimiter(requests_per_minute=10, max_concurrent_requests=10, lock_shards=64)
     distinct_locks = {id(limiter._lock_for(f"key-{i}")) for i in range(256)}
-    assert len(distinct_locks) > 1
+    assert len(distinct_locks) >= 32
 
 
 def test_single_shard_degenerates_to_global_lock():


### PR DESCRIPTION
# perf(rate_limit): shard limiter locks to cut cross-key contention

Closes issue #120

## Summary

`RateLimiter` guarded every key's state with one `asyncio.Lock`. Because the lock was global, two requests for completely unrelated keys could not have their rate checked at the same time: under load the limiter became a serialization point in front of an otherwise async server.

This PR replaces the single lock with a **fixed pool of shard locks**. A key is mapped to a shard by `hash(key) modulo N` (`_lock_for`), so:

- Each operation on a given key always takes the **same** shard lock: the same mutual-exclusion guarantee the global lock gave, just scoped to one shard
- Operations on keys in **different** shards no longer wait on each other.

I picked **sharded locks over per-key locks** deliberately. Per-key locks would need their own map of lock objects and a reclamation strategy, which is exactly the unbounded-map growth the sibling cleanup issue is fighting: the two fixes would collide. A fixed array of `N` locks (default `64`, constructor-tunable via `lock_shards`) bounds the number of lock objects no matter how many unique keys appear, so it cuts contention without reintroducing a map to leak. 
The window/concurrency dictionaries are left exactly as they were: thus, existing behaviour and the existing tests that poke `_request_windows` / `_concurrent` are unaffected.

## File changes

- `src/waggle/rate_limit.py`
  - Added `DEFAULT_LOCK_SHARDS = 64` and a `lock_shards` constructor parameter.
  - Replaced `self._lock` with `self._locks: list[asyncio.Lock]` (one per shard).
  - Added `_lock_for(key)` (hash -> shard lock).
  - `check_rate` and both halves of `concurrency_slot` now acquire `_lock_for(key)` instead of the global lock.
- `tests/test_rate_limit.py`
  - Added 6 tests (shard mapping, cross-key spread, single-shard degeneration, the concurrent cap-holds hammer for both `check_rate` and `concurrency_slot`, and per-key budget independence).

## Design decisions and outcomes

- **Same-key serialization is preserved.** A key `k` always resolves to `_locks[hash(k) modulo N]`, a single deterministic lock. Every `check_rate(k, …)` and both halves of `concurrency_slot(k)` acquire that one lock, so all read-modify-write sequences on `k`'s window/counter are mutually exclusive: identical to the old global lock, restricted to `k`. No key can exceed its window or concurrency cap, since the check-and-append (and the check-and-increment) for that key cannot interleave with another op on the same key.
- **Cross-key independence is safe.** Two keys in different shards hold different locks. Their critical sections contain **no `await`**, so under CPython's single-threaded asyncio the event loop never pre-empts one coroutine in the midst of a critical-section; concurrent operations on *different* keys of the shared window/counter dicts cannot interleave their mutations. The only suspension point is lock acquisition itself, and that is what the shard lock serializes.
- **The lock set is bounded.** `N` is set at construction, so this change does not create a per-key lock map and cannot reintroduce unbounded growth.

The hammer test fires 500 concurrent `check_rate` calls at one key with a limit of 50 and asserts **exactly** 50 are admitted (no race lets an extra through); the concurrency hammer fires 20 tasks at a cap of 5 and asserts peak in-flight never exceeds 5 and exactly 5 are admitted.

## Testing

```bash
PS C:\Users\lenovo\Documents\Waggle-mcp> python -m pytest tests/test_rate_limit.py -v
======================================================= test session starts ========================================================
platform win32 -- Python 3.11.9, pytest-7.4.4, pluggy-1.6.0 -- C:\Program Files\Python311\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\lenovo\Documents\Waggle-mcp
configfile: pyproject.toml
plugins: anyio-4.13.0, asyncio-0.23.3, cov-4.1.0
asyncio: mode=Mode.STRICT
collected 11 items

tests/test_rate_limit.py::test_rate_limiter_read_limit PASSED                                                                 [  9%]
tests/test_rate_limit.py::test_rate_limiter_read_write_independence PASSED                                                    [ 18%]
tests/test_rate_limit.py::test_rate_limiter_concurrency_slot PASSED                                                           [ 27%]
tests/test_rate_limit.py::test_concurrency_key_removed_when_count_reaches_zero PASSED                                         [ 36%]
tests/test_rate_limit.py::test_expired_request_window_is_cleaned_up PASSED                                                    [ 45%]
tests/test_rate_limit.py::test_same_key_maps_to_same_shard_lock PASSED                                                        [ 54%]
tests/test_rate_limit.py::test_distinct_keys_spread_across_shards PASSED                                                      [ 63%]
tests/test_rate_limit.py::test_single_shard_degenerates_to_global_lock PASSED                                                 [ 72%]
tests/test_rate_limit.py::test_check_rate_cap_holds_under_concurrent_hammer PASSED                                            [ 81%]
tests/test_rate_limit.py::test_independent_keys_each_get_full_budget PASSED                                                   [ 90%]
tests/test_rate_limit.py::test_concurrency_cap_holds_under_concurrent_hammer PASSED                                           [100%]

======================================================== 11 passed in 0.30s ========================================================
```

## Acceptance criteria

- [x] Independent keys no longer block each other on a single global lock.
- [x] Limits remain correct under concurrent access (hammer test asserts the cap holds).
- [x] PR explains why the new scheme is race-free (above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `RateLimiter` constructor now accepts an optional `lock_shards` parameter (defaults to 64) for fine-tuning concurrent request handling.

* **Improvements**
  * Enhanced rate limiter concurrency performance with improved synchronization strategy.
  * Clearer error messaging when concurrent request limits are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->