### PR TITLE
tooling(labels): reconcile labels.yml with community labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -112,3 +112,16 @@
 - name: mentor:username
   color: "ffedd5"
   description: Replace username with a mentor handle when crediting reviewed PRs.
+- name: SSoC26
+  color: "5319e7"
+  description: Social Summer of Code 2026 program label.
+- name: easy
+  color: "0e8a16"
+  description: Easy difficulty issue for contributors.
+- name: medium
+  color: "fbca04"
+  description: Medium difficulty issue for contributors.
+- name: hard
+  color: "d93f0b"
+  description: Hard difficulty issue for contributors.
+ 

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -90,3 +90,20 @@ Status:
 - Use `good first issue` only for tasks with clear acceptance criteria, a small blast radius, and obvious files to change.
 - Use `help wanted` for larger tasks that are still open to outside contribution but need more codebase context.
 - Pair broad labels with domain labels. Example: `bug` + `graph`, or `documentation` + `windows`.
+
+## Label Source of Truth
+
+Repository labels are managed through `.github/labels.yml`.
+
+This file serves as the canonical source of truth for repository labels,
+including community program labels.
+
+Current community labels include:
+
+- SSoC26
+- easy
+- medium
+- hard
+
+Changes to labels should be made in `.github/labels.yml` and synchronized
+using `scripts/sync_github_labels.py`.

--- a/scripts/sync_github_labels.py
+++ b/scripts/sync_github_labels.py
@@ -156,6 +156,10 @@ def sync_labels(
     delete_missing: bool,
 ) -> list[str]:
     actions: list[str] = []
+    # .github/labels.yml is the canonical source of truth for labels.
+    # Community labels such as SSoC26, easy, medium, and hard should be
+    # defined there so that sync operations remain predictable when
+    # --delete-missing is used.
     desired_names = {label.name.lower() for label in desired}
 
     for label in desired:
@@ -249,3 +253,4 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+


### PR DESCRIPTION
## Summary

* Added missing community program labels (`SSoC26`, `easy`, `medium`, and `hard`) to `.github/labels.yml`.
* Documented `.github/labels.yml` as the canonical source of truth for repository labels.
* Added clarification in `scripts/sync_github_labels.py` regarding management of community labels when using `--delete-missing`.

### Why was it needed?

The live repository label set included community-program labels that were not defined in `.github/labels.yml`, creating drift between the repository configuration, documentation, and label synchronization tooling. This change aligns them and establishes a single source of truth.

Fixes #354

## Testing

* [ ] `WAGGLE_MODEL=deterministic pytest -q`
* [ ] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/`

### Test report

Not run (documentation/configuration-only changes).
