### PR TITLE
docs: move doctor --json to completed starter issues

### DIFF
--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -33,8 +33,6 @@ Status:
 - Implemented by the root layout policy in `docs/repository-map.md`, `CONTRIBUTING.md`, and `README.md`
 - Guarded by `tests/test_repository_layout.py`
 
-## Open starter issues
-
 ### 3. Add a `doctor --json` mode
 
 - Problem: `waggle-mcp doctor` is useful for humans, but automation and issue templates benefit from structured output.
@@ -44,6 +42,13 @@ Status:
   - Preserve the current human-friendly output by default.
   - Cover the new mode with tests.
 - Suggested labels: `good first issue`, `enhancement`, `tooling`
+
+Status:
+- Implemented in `src/waggle/server.py` by adding the `--json` flag to `_run_doctor`.
+- Guarded by JSON output tests in `tests/test_server.py`.
+- Documented in `docs/reference.md`.
+
+## Open starter issues
 
 ### 4. Improve Windows troubleshooting coverage
 

--- a/docs/good-first-issues.md
+++ b/docs/good-first-issues.md
@@ -44,7 +44,7 @@ Status:
 - Suggested labels: `good first issue`, `enhancement`, `tooling`
 
 Status:
-- Implemented in `src/waggle/server.py` by adding the `--json` flag to `_run_doctor`.
+- Implemented in `src/waggle/server.py` by adding the `--json` flag to the doctor CLI parser and threading it through `json_output`.
 - Guarded by JSON output tests in `tests/test_server.py`.
 - Documented in `docs/reference.md`.
 


### PR DESCRIPTION
Fixes #372. The \--json\ feature for the doctor command was previously implemented and merged, but the issue remained open in the \good-first-issues.md\ documentation. This PR moves the issue to the 'Completed recently' section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “good-first-issues” guide to include added status details for the `doctor --json` mode (where it was implemented, how to run a local dry-run, related test coverage, and where it’s documented).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->