### PR TITLE
docs(vscode-extension): explain mcpConfigScope and merge behavior

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -41,6 +41,68 @@ Use Waggle when you want coding agents in VS Code to remember:
 4. Reload VS Code if your MCP consumer requires it
 5. Waggle runs `doctor` as part of setup
 
+## Settings
+
+| Setting                 | Default   | Description                                    |
+| ----------------------- | --------- | ---------------------------------------------- |
+| `waggle.mcpConfigScope` | `servers` | Root key used when creating `.vscode/mcp.json` |
+
+### `waggle.mcpConfigScope`
+
+Controls which root key the extension uses when creating a new `.vscode/mcp.json`.
+
+Supported values:
+
+* `servers` (default) — Use the VS Code MCP configuration format.
+* `mcpServers` — Use the legacy MCP configuration format expected by some tools.
+
+If `.vscode/mcp.json` already contains a `servers` or `mcpServers` object, the extension follows
+
+the existing file and ignores this setting.
+
+This setting is mainly used when creating a new `.vscode/mcp.json` file.
+
+### `.vscode/mcp.json` merge behavior
+
+When you run **Waggle: Enable for this Workspace**, the extension merges the Waggle configuration into the existing `.vscode/mcp.json` file instead of overwriting unrelated MCP servers.
+
+Process:
+
+1. Read the existing `.vscode/mcp.json`.
+2. Determine whether `servers` or `mcpServers` should be used.
+3. Preserve existing server entries.
+4. Add or update only the `waggle` entry.
+5. Write the updated configuration back to disk.
+
+Example:
+
+Before:
+
+```json
+{
+  "servers": {
+    "github": {
+      "type": "http"
+    }
+  }
+}
+```
+
+After:
+
+```json
+{
+  "servers": {
+    "github": {
+      "type": "http"
+    },
+    "waggle": {
+      "type": "stdio"
+    }
+  }
+}
+```
+
 ## Commands
 
 - `Waggle: Enable for this Workspace`

--- a/docs/install/vscode.md
+++ b/docs/install/vscode.md
@@ -34,6 +34,61 @@ VS Code MCP examples commonly use `.vscode/mcp.json` with a `servers` root:
 }
 ```
 
+## `waggle.mcpConfigScope`
+
+The `waggle.mcpConfigScope` setting controls which root key the extension uses when creating a new `.vscode/mcp.json`.
+
+| Value               | When to use                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `servers` (default) | Recommended for new VS Code MCP configurations                    |
+| `mcpServers`        | Use when your tooling expects the legacy MCP configuration format |
+
+If `.vscode/mcp.json` already contains a `servers` or `mcpServers` object, the extension follows
+
+the existing file structure and ignores this setting.
+
+This setting is mainly used when creating a new `.vscode/mcp.json` file.
+
+## How `.vscode/mcp.json` is merged
+
+The extension does not overwrite your existing MCP configuration.
+
+When you run **Waggle: Enable for this Workspace**, it:
+
+1. Reads the existing `.vscode/mcp.json`.
+2. Preserves existing MCP servers.
+3. Adds or updates only the `waggle` entry.
+4. Writes the updated configuration back to disk.
+
+### Example
+
+Before:
+
+```json
+{
+  "servers": {
+    "github": {
+      "type": "http"
+    }
+  }
+}
+```
+
+After:
+
+```json
+{
+  "servers": {
+    "github": {
+      "type": "http"
+    },
+    "waggle": {
+      "type": "stdio"
+    }
+  }
+}
+```
+
 ## Verify
 
 ```bash


### PR DESCRIPTION
## Summary

### What changed?

* Added documentation for `waggle.mcpConfigScope`.
* Documented when to use `servers` and `mcpServers`.
* Explained how `.vscode/mcp.json` merge behavior preserves existing MCP servers.
* Added before/after examples showing how the Waggle configuration is merged.

### Why was it needed?

Issue #347 requested documentation explaining:

* The purpose of `waggle.mcpConfigScope`
* When each configuration mode should be used
* How the extension merges Waggle into an existing `.vscode/mcp.json` without overwriting unrelated servers

Fixes #347

## Testing

* [ ] `WAGGLE_MODEL=deterministic pytest -q`
* [ ] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/`

### Test report

Documentation-only change. No code or tests were modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VS Code extension and installation guides with comprehensive documentation of the new `waggle.mcpConfigScope` setting.
  * Added detailed examples showing how workspace configuration merges with existing MCP server entries, preserving unrelated settings during the "Enable for this Workspace" operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->