### PR TITLE
refactor: clean parsing helper utilities

### DIFF
--- a/src/rlm/utils/parsing.py
+++ b/src/rlm/utils/parsing.py
@@ -95,6 +95,7 @@ def format_iteration(iteration: RLMIteration, max_character_length: int = 20000)
         messages.append(execution_message)
     return messages
 
+
 # REPL formatting helpers
 def format_execution_result(result: REPLResult) -> str:
     """

--- a/src/rlm/utils/parsing.py
+++ b/src/rlm/utils/parsing.py
@@ -154,8 +154,3 @@ def convert_context_for_repl(context):
 
     return context, None
 
-
-
-
-
- 

--- a/src/rlm/utils/parsing.py
+++ b/src/rlm/utils/parsing.py
@@ -96,7 +96,6 @@ def format_iteration(iteration: RLMIteration, max_character_length: int = 20000)
     return messages
 
 # REPL formatting helpers
-
 def format_execution_result(result: REPLResult) -> str:
     """
     Format the execution result as a string for display.
@@ -153,4 +152,3 @@ def convert_context_for_repl(context):
         return context, None
 
     return context, None
-

--- a/src/rlm/utils/parsing.py
+++ b/src/rlm/utils/parsing.py
@@ -95,11 +95,7 @@ def format_iteration(iteration: RLMIteration, max_character_length: int = 20000)
         messages.append(execution_message)
     return messages
 
-
-################
-# TODO: Remove and refactor these soon
-################
-
+# REPL formatting helpers
 
 def format_execution_result(result: REPLResult) -> str:
     """
@@ -117,16 +113,15 @@ def format_execution_result(result: REPLResult) -> str:
         result_parts.append(f"\n{result.stderr}")
 
     # Show some key variables (excluding internal ones)
+    excluded_keys = {"__builtins__", "__name__", "__doc__"}
     important_vars = {}
+
     for key, value in result.locals.items():
-        if not key.startswith("_") and key not in [
-            "__builtins__",
-            "__name__",
-            "__doc__",
-        ]:
-            # Only show simple types or short representations
-            if isinstance(value, (str, int, float, bool, list, dict, tuple)):
-                important_vars[key] = ""
+        if key.startswith("_") or key in excluded_keys:
+            continue
+
+        if isinstance(value, (str, int, float, bool, list, dict, tuple)):
+            important_vars[key] = ""
 
     if important_vars:
         result_parts.append(f"REPL variables: {list(important_vars.keys())}\n")
@@ -142,26 +137,25 @@ def check_for_final_answer(response: str, repl_env, logger) -> str | None:
 
 def convert_context_for_repl(context):
     """
-    Convert REPL context to either some
+    Convert REPL context into structured data and string form.
     """
     if isinstance(context, dict):
-        context_data = context
-        context_str = None
-    elif isinstance(context, str):
-        context_data = None
-        context_str = context
-    elif isinstance(context, list):
-        if len(context) > 0 and isinstance(context[0], dict):
-            if "content" in context[0]:
-                context_data = [msg.get("content", "") for msg in context]
-            else:
-                context_data = context
-            context_str = None
-        else:
-            context_data = context
-            context_str = None
-    else:
-        context_data = context
-        context_str = None
+        return context, None
 
-    return context_data, context_str
+    if isinstance(context, str):
+        return None, context
+
+    if isinstance(context, list):
+        if context and isinstance(context[0], dict):
+            if "content" in context[0]:
+                return [msg.get("content", "") for msg in context], None
+            return context, None
+        return context, None
+
+    return context, None
+
+
+
+
+
+ 


### PR DESCRIPTION
## Summary

### What changed?

* Removed the stale TODO marker from `src/rlm/utils/parsing.py`
* Refactored execution-result formatting helpers for improved readability and maintainability
* Simplified `convert_context_for_repl()` logic without changing existing behavior
* Cleaned variable filtering logic in `format_execution_result()`

### Why was it needed?

The helper section in `src/rlm/utils/parsing.py` contained a stale TODO marker and some logic that was harder to follow. This refactor improves code readability and structure while preserving the existing behavior.

## Testing

* [x] Not applicable (refactor-only change)
* [x] No behavior changes introduced

### Test report

Refactor-only change. Existing behavior preserved, so no additional tests were required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved REPL execution result summarization by using a dedicated set of excluded keys and continuing to include only simple, displayable values.
  * Streamlined REPL context conversion to produce a clearer (data, preview) pairing for output.
* **Documentation**
  * Expanded the REPL context conversion documentation, detailing supported input types and the resulting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->