### PR TITLE
test(drive-sync): add unit tests for Google Drive sync helper layer

### DIFF
--- a/tests/test_drive_sync.py
+++ b/tests/test_drive_sync.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+
 import pytest
 from google.oauth2.credentials import Credentials
 
@@ -15,20 +16,19 @@ def test_resolve_drive_file_id_direct_id(mock_credentials):
     # Length >= 20, no slash, no space, should resolve directly
     ref = "abcdefghijklmnopqrstuvwxyz"
     with patch("waggle.drive_sync.build_drive_service") as mock_build:
-        file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
+        file_id, name = resolve_drive_file_id(
+            file_ref=ref, credentials=mock_credentials
+        )
         assert file_id == ref
         assert name == ""
         mock_build.assert_not_called()
 
 
-
-
-
 def test_resolve_drive_file_id_empty_raises_value_error(mock_credentials):
-    with pytest.raises(ValueError, match="Drive file reference cannot be empty."):
+    with pytest.raises(ValueError, match=r"Drive file reference cannot be empty\."):
         resolve_drive_file_id(file_ref="", credentials=mock_credentials)
 
-    with pytest.raises(ValueError, match="Drive file reference cannot be empty."):
+    with pytest.raises(ValueError, match=r"Drive file reference cannot be empty\."):
         resolve_drive_file_id(file_ref="   ", credentials=mock_credentials)
 
 
@@ -57,12 +57,14 @@ def test_resolve_drive_file_id_filename_lookup(mock_build, mock_credentials):
     mock_files.list.assert_called_once_with(
         q="name = 'my file.txt' and trashed = false",
         pageSize=1,
-        fields="files(id,name)"
+        fields="files(id,name)",
     )
 
 
 @patch("waggle.drive_sync.build_drive_service")
-def test_resolve_drive_file_id_filename_lookup_with_folder_id(mock_build, mock_credentials):
+def test_resolve_drive_file_id_filename_lookup_with_folder_id(
+    mock_build, mock_credentials
+):
     ref = "my file.txt"
     mock_service = MagicMock()
     mock_build.return_value = mock_service
@@ -76,9 +78,7 @@ def test_resolve_drive_file_id_filename_lookup_with_folder_id(mock_build, mock_c
     }
 
     file_id, name = resolve_drive_file_id(
-        file_ref=ref,
-        credentials=mock_credentials,
-        folder_id="folder-999"
+        file_ref=ref, credentials=mock_credentials, folder_id="folder-999"
     )
 
     assert file_id == "file123"
@@ -86,7 +86,7 @@ def test_resolve_drive_file_id_filename_lookup_with_folder_id(mock_build, mock_c
     mock_files.list.assert_called_once_with(
         q="name = 'my file.txt' and trashed = false and 'folder-999' in parents",
         pageSize=1,
-        fields="files(id,name)"
+        fields="files(id,name)",
     )
 
 
@@ -112,12 +112,14 @@ def test_resolve_drive_file_id_escapes_single_quotes(mock_build, mock_credential
     mock_files.list.assert_called_once_with(
         q="name = 'O\\'Connor\\'s File.txt' and trashed = false",
         pageSize=1,
-        fields="files(id,name)"
+        fields="files(id,name)",
     )
 
 
 @patch("waggle.drive_sync.build_drive_service")
-def test_resolve_drive_file_id_not_found_raises_value_error(mock_build, mock_credentials):
+def test_resolve_drive_file_id_not_found_raises_value_error(
+    mock_build, mock_credentials
+):
     ref = "nonexistent.txt"
     mock_service = MagicMock()
     mock_build.return_value = mock_service
@@ -128,7 +130,9 @@ def test_resolve_drive_file_id_not_found_raises_value_error(mock_build, mock_cre
     mock_files.list.return_value = mock_list_request
     mock_list_request.execute.return_value = {"files": []}
 
-    with pytest.raises(ValueError, match="No Drive file found for 'nonexistent.txt'."):
+    with pytest.raises(
+        ValueError, match=r"No Drive file found for 'nonexistent\.txt'\."
+    ):
         resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
 
 
@@ -151,7 +155,7 @@ def test_share_drive_file(mock_build, mock_credentials):
     mock_files.get.return_value = mock_get_request
     mock_get_request.execute.return_value = {
         "id": "file-xyz",
-        "webViewLink": "https://drive.google.com/file/xyz/view"
+        "webViewLink": "https://drive.google.com/file/xyz/view",
     }
 
     result = share_drive_file(file_id="file-xyz", credentials=mock_credentials)
@@ -162,11 +166,6 @@ def test_share_drive_file(mock_build, mock_credentials):
     assert result.web_view_link == "https://drive.google.com/file/xyz/view"
 
     mock_permissions.create.assert_called_once_with(
-        fileId="file-xyz",
-        body={"type": "anyone", "role": "reader"},
-        fields="id"
+        fileId="file-xyz", body={"type": "anyone", "role": "reader"}, fields="id"
     )
-    mock_files.get.assert_called_once_with(
-        fileId="file-xyz",
-        fields="id,webViewLink"
-    )
+    mock_files.get.assert_called_once_with(fileId="file-xyz", fields="id,webViewLink")

--- a/tests/test_drive_sync.py
+++ b/tests/test_drive_sync.py
@@ -1,0 +1,172 @@
+from unittest.mock import MagicMock, patch
+import pytest
+from google.oauth2.credentials import Credentials
+
+from waggle.drive_sync import resolve_drive_file_id, share_drive_file
+from waggle.models import DriveShareResult
+
+
+@pytest.fixture
+def mock_credentials():
+    return MagicMock(spec=Credentials)
+
+
+def test_resolve_drive_file_id_direct_id(mock_credentials):
+    # Length >= 20, no slash, no space, should resolve directly
+    ref = "abcdefghijklmnopqrstuvwxyz"
+    with patch("waggle.drive_sync.build_drive_service") as mock_build:
+        file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
+        assert file_id == ref
+        assert name == ""
+        mock_build.assert_not_called()
+
+
+
+
+
+def test_resolve_drive_file_id_empty_raises_value_error(mock_credentials):
+    with pytest.raises(ValueError, match="Drive file reference cannot be empty."):
+        resolve_drive_file_id(file_ref="", credentials=mock_credentials)
+
+    with pytest.raises(ValueError, match="Drive file reference cannot be empty."):
+        resolve_drive_file_id(file_ref="   ", credentials=mock_credentials)
+
+
+@patch("waggle.drive_sync.build_drive_service")
+def test_resolve_drive_file_id_filename_lookup(mock_build, mock_credentials):
+    # A short ref or ref with spaces should trigger API lookup
+    ref = "my file.txt"
+    mock_service = MagicMock()
+    mock_build.return_value = mock_service
+
+    # Setup the mock API response hierarchy
+    # service.files().list(q=...).execute() -> {"files": [{"id": "file123", "name": "my file.txt"}]}
+    mock_files = MagicMock()
+    mock_list_request = MagicMock()
+    mock_service.files.return_value = mock_files
+    mock_files.list.return_value = mock_list_request
+    mock_list_request.execute.return_value = {
+        "files": [{"id": "file123", "name": "my file.txt"}]
+    }
+
+    file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
+
+    assert file_id == "file123"
+    assert name == "my file.txt"
+    mock_build.assert_called_once_with(credentials=mock_credentials)
+    mock_files.list.assert_called_once_with(
+        q="name = 'my file.txt' and trashed = false",
+        pageSize=1,
+        fields="files(id,name)"
+    )
+
+
+@patch("waggle.drive_sync.build_drive_service")
+def test_resolve_drive_file_id_filename_lookup_with_folder_id(mock_build, mock_credentials):
+    ref = "my file.txt"
+    mock_service = MagicMock()
+    mock_build.return_value = mock_service
+
+    mock_files = MagicMock()
+    mock_list_request = MagicMock()
+    mock_service.files.return_value = mock_files
+    mock_files.list.return_value = mock_list_request
+    mock_list_request.execute.return_value = {
+        "files": [{"id": "file123", "name": "my file.txt"}]
+    }
+
+    file_id, name = resolve_drive_file_id(
+        file_ref=ref,
+        credentials=mock_credentials,
+        folder_id="folder-999"
+    )
+
+    assert file_id == "file123"
+    assert name == "my file.txt"
+    mock_files.list.assert_called_once_with(
+        q="name = 'my file.txt' and trashed = false and 'folder-999' in parents",
+        pageSize=1,
+        fields="files(id,name)"
+    )
+
+
+@patch("waggle.drive_sync.build_drive_service")
+def test_resolve_drive_file_id_escapes_single_quotes(mock_build, mock_credentials):
+    ref = "O'Connor's File.txt"
+    mock_service = MagicMock()
+    mock_build.return_value = mock_service
+
+    mock_files = MagicMock()
+    mock_list_request = MagicMock()
+    mock_service.files.return_value = mock_files
+    mock_files.list.return_value = mock_list_request
+    mock_list_request.execute.return_value = {
+        "files": [{"id": "file456", "name": "O'Connor's File.txt"}]
+    }
+
+    file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
+
+    assert file_id == "file456"
+    assert name == "O'Connor's File.txt"
+    # Verify escaping: O'Connor's -> O\'Connor\'s
+    mock_files.list.assert_called_once_with(
+        q="name = 'O\\'Connor\\'s File.txt' and trashed = false",
+        pageSize=1,
+        fields="files(id,name)"
+    )
+
+
+@patch("waggle.drive_sync.build_drive_service")
+def test_resolve_drive_file_id_not_found_raises_value_error(mock_build, mock_credentials):
+    ref = "nonexistent.txt"
+    mock_service = MagicMock()
+    mock_build.return_value = mock_service
+
+    mock_files = MagicMock()
+    mock_list_request = MagicMock()
+    mock_service.files.return_value = mock_files
+    mock_files.list.return_value = mock_list_request
+    mock_list_request.execute.return_value = {"files": []}
+
+    with pytest.raises(ValueError, match="No Drive file found for 'nonexistent.txt'."):
+        resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
+
+
+@patch("waggle.drive_sync.build_drive_service")
+def test_share_drive_file(mock_build, mock_credentials):
+    mock_service = MagicMock()
+    mock_build.return_value = mock_service
+
+    # Setup permissions create mock
+    mock_permissions = MagicMock()
+    mock_perm_request = MagicMock()
+    mock_service.permissions.return_value = mock_permissions
+    mock_permissions.create.return_value = mock_perm_request
+    mock_perm_request.execute.return_value = {"id": "permission-abc"}
+
+    # Setup files get mock
+    mock_files = MagicMock()
+    mock_get_request = MagicMock()
+    mock_service.files.return_value = mock_files
+    mock_files.get.return_value = mock_get_request
+    mock_get_request.execute.return_value = {
+        "id": "file-xyz",
+        "webViewLink": "https://drive.google.com/file/xyz/view"
+    }
+
+    result = share_drive_file(file_id="file-xyz", credentials=mock_credentials)
+
+    assert isinstance(result, DriveShareResult)
+    assert result.remote_file_id == "file-xyz"
+    assert result.permission_id == "permission-abc"
+    assert result.web_view_link == "https://drive.google.com/file/xyz/view"
+
+    mock_permissions.create.assert_called_once_with(
+        fileId="file-xyz",
+        body={"type": "anyone", "role": "reader"},
+        fields="id"
+    )
+    mock_files.get.assert_called_once_with(
+        fileId="file-xyz",
+        fields="id,webViewLink"
+    )

--- a/tests/test_drive_sync.py
+++ b/tests/test_drive_sync.py
@@ -16,9 +16,7 @@ def test_resolve_drive_file_id_direct_id(mock_credentials):
     # Length >= 20, no slash, no space, should resolve directly
     ref = "abcdefghijklmnopqrstuvwxyz"
     with patch("waggle.drive_sync.build_drive_service") as mock_build:
-        file_id, name = resolve_drive_file_id(
-            file_ref=ref, credentials=mock_credentials
-        )
+        file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
         assert file_id == ref
         assert name == ""
         mock_build.assert_not_called()
@@ -45,9 +43,7 @@ def test_resolve_drive_file_id_filename_lookup(mock_build, mock_credentials):
     mock_list_request = MagicMock()
     mock_service.files.return_value = mock_files
     mock_files.list.return_value = mock_list_request
-    mock_list_request.execute.return_value = {
-        "files": [{"id": "file123", "name": "my file.txt"}]
-    }
+    mock_list_request.execute.return_value = {"files": [{"id": "file123", "name": "my file.txt"}]}
 
     file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
 
@@ -62,9 +58,7 @@ def test_resolve_drive_file_id_filename_lookup(mock_build, mock_credentials):
 
 
 @patch("waggle.drive_sync.build_drive_service")
-def test_resolve_drive_file_id_filename_lookup_with_folder_id(
-    mock_build, mock_credentials
-):
+def test_resolve_drive_file_id_filename_lookup_with_folder_id(mock_build, mock_credentials):
     ref = "my file.txt"
     mock_service = MagicMock()
     mock_build.return_value = mock_service
@@ -73,13 +67,9 @@ def test_resolve_drive_file_id_filename_lookup_with_folder_id(
     mock_list_request = MagicMock()
     mock_service.files.return_value = mock_files
     mock_files.list.return_value = mock_list_request
-    mock_list_request.execute.return_value = {
-        "files": [{"id": "file123", "name": "my file.txt"}]
-    }
+    mock_list_request.execute.return_value = {"files": [{"id": "file123", "name": "my file.txt"}]}
 
-    file_id, name = resolve_drive_file_id(
-        file_ref=ref, credentials=mock_credentials, folder_id="folder-999"
-    )
+    file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials, folder_id="folder-999")
 
     assert file_id == "file123"
     assert name == "my file.txt"
@@ -100,9 +90,7 @@ def test_resolve_drive_file_id_escapes_single_quotes(mock_build, mock_credential
     mock_list_request = MagicMock()
     mock_service.files.return_value = mock_files
     mock_files.list.return_value = mock_list_request
-    mock_list_request.execute.return_value = {
-        "files": [{"id": "file456", "name": "O'Connor's File.txt"}]
-    }
+    mock_list_request.execute.return_value = {"files": [{"id": "file456", "name": "O'Connor's File.txt"}]}
 
     file_id, name = resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
 
@@ -117,9 +105,7 @@ def test_resolve_drive_file_id_escapes_single_quotes(mock_build, mock_credential
 
 
 @patch("waggle.drive_sync.build_drive_service")
-def test_resolve_drive_file_id_not_found_raises_value_error(
-    mock_build, mock_credentials
-):
+def test_resolve_drive_file_id_not_found_raises_value_error(mock_build, mock_credentials):
     ref = "nonexistent.txt"
     mock_service = MagicMock()
     mock_build.return_value = mock_service
@@ -130,9 +116,7 @@ def test_resolve_drive_file_id_not_found_raises_value_error(
     mock_files.list.return_value = mock_list_request
     mock_list_request.execute.return_value = {"files": []}
 
-    with pytest.raises(
-        ValueError, match=r"No Drive file found for 'nonexistent\.txt'\."
-    ):
+    with pytest.raises(ValueError, match=r"No Drive file found for 'nonexistent\.txt'\."):
         resolve_drive_file_id(file_ref=ref, credentials=mock_credentials)
 
 


### PR DESCRIPTION
## Summary

- **Created Unit Test Suite**: Added a new test file [test_drive_sync.py](file:///c:/Users/KIRTAN/Downloads/Waggle-mcp/tests/test_drive_sync.py) to cover Google Drive helper functionality in [drive_sync.py](file:///c:/Users/KIRTAN/Downloads/Waggle-mcp/src/waggle/drive_sync.py) using mock/stubbed Google API clients.
- **Covered File ID Resolution**: Wrote tests validating that direct IDs bypass API requests, while filenames trigger query-based lookups.
- **Covered Query Escaping & Query-Safety**: Verified that query parameters containing single quotes are properly escaped to prevent syntax issues.
- **Covered File Sharing & Result Mapping**: Wrote test coverage ensuring the permissions creation and details retrieval map correctly to `DriveShareResult`.
- **Zero Live Traffic**: Mocked the `build_drive_service` constructor to isolate tests from any live Google API endpoints.

Fixes Issue #305 

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -v tests/test_drive_sync.py`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

### Test report

Paste the output of `pytest -v` for the files you added or changed (not the full suite, just yours):

```text
============================= test session starts =============================
platform win32 -- Python 3.14.0, pytest-9.0.3, pluggy-1.6.0 -- C:\Program Files\Python314\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\KIRTAN\Downloads\Waggle-mcp
configfile: pyproject.toml
plugins: anyio-4.12.0, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 7 items

tests/test_drive_sync.py::test_resolve_drive_file_id_direct_id PASSED    [ 14%]
tests/test_drive_sync.py::test_resolve_drive_file_id_empty_raises_value_error PASSED [ 28%]
tests/test_drive_sync.py::test_resolve_drive_file_id_filename_lookup PASSED [ 42%]
tests/test_drive_sync.py::test_resolve_drive_file_id_filename_lookup_with_folder_id PASSED [ 57%]
tests/test_drive_sync.py::test_resolve_drive_file_id_escapes_single_quotes PASSED [ 71%]
tests/test_drive_sync.py::test_resolve_drive_file_id_not_found_raises_value_error PASSED [ 85%]
tests/test_drive_sync.py::test_share_drive_file PASSED                   [100%]

============================== 7 passed in 0.48s ==============================


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for drive file synchronization operations, including file ID resolution and sharing functionality, with proper mocking to ensure reliable testing without external API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->