### PR TITLE
fix(neo4j): implement winner support in resolve_conflict

### DIFF
--- a/src/waggle/neo4j_graph.py
+++ b/src/waggle/neo4j_graph.py
@@ -2994,6 +2994,7 @@ def update_node(
         *,
         edge_id: str,
         resolution_note: str = "",
+        winner: str | None = None,
     ) -> ConflictEntry:
         with self._lock, self._session() as session:
             record = session.run(
@@ -3022,11 +3023,19 @@ def update_node(
             if edge.relationship not in {RelationType.CONTRADICTS.value, RelationType.UPDATES.value}:
                 raise ValueError("Only contradicts or updates edges can be resolved.")
 
+            if winner is not None and winner not in {edge.source_id, edge.target_id}:
+                raise ValueError(
+                    f"winner '{winner}' is not an endpoint of edge '{edge_id}'. "
+                    f"Must be one of: '{edge.source_id}' (source) or '{edge.target_id}' (target)."
+                )
+
             metadata = dict(edge.metadata)
             metadata["resolved"] = True
             metadata["resolved_at"] = utc_now().isoformat()
             if resolution_note.strip():
                 metadata["resolution_note"] = resolution_note.strip()
+            if winner is not None:
+                metadata["winner"] = winner
 
             session.run(
                 """
@@ -3037,6 +3046,16 @@ def update_node(
                 edge_id=edge_id,
                 metadata=_encode_metadata(metadata),
             ).consume()
+
+            if winner is not None:
+                losing_id = edge.target_id if winner == edge.source_id else edge.source_id
+                self._mark_node_superseded(
+                    session,
+                    losing_id=losing_id,
+                    winner_id=winner,
+                    relationship=edge.relationship,
+                )
+
             updated_edge = Edge(
                 id=edge.id,
                 tenant_id=edge.tenant_id,
@@ -3859,6 +3878,47 @@ def update_node(
         resolved_at_raw = metadata.get("resolved_at")
         resolved_at = _parse_datetime(resolved_at_raw) if resolved_at_raw else None
         return resolved, resolution_note, resolved_at
+
+    def _mark_node_superseded(
+        self,
+        session: Any,
+        *,
+        losing_id: str,
+        winner_id: str,
+        relationship: str,
+    ) -> None:
+        now = utc_now()
+
+        record = session.run(
+            """
+            MATCH (n:MemoryNode {tenant_id: $tenant_id, id: $id})
+            RETURN n.metadata AS metadata
+            LIMIT 1
+            """,
+            tenant_id=self.tenant_id,
+            id=losing_id,
+        ).single()
+        if record is None:
+            raise ValueError(f"Node not found: {losing_id}")
+
+        metadata = _decode_metadata(record.get("metadata"))
+        metadata["superseded_by"] = winner_id
+        metadata["superseded_at"] = now.isoformat()
+        metadata["superseded_relationship"] = relationship
+
+        session.run(
+            """
+            MATCH (n:MemoryNode {tenant_id: $tenant_id, id: $id})
+            SET n.valid_to = $valid_to,
+                n.updated_at = $updated_at,
+                n.metadata = $metadata
+            """,
+            tenant_id=self.tenant_id,
+            id=losing_id,
+            valid_to=now.isoformat(),
+            updated_at=now.isoformat(),
+            metadata=_encode_metadata(metadata),
+        ).consume()
 
     def _temporal_sort_value(self, node: Node, hints: Any) -> float:
         if hints.recency_mode == "latest":

--- a/src/waggle/neo4j_graph.py
+++ b/src/waggle/neo4j_graph.py
@@ -3364,6 +3364,7 @@ def update_node(
             tags=list(props.get("tags") or []),
             source_prompt=props.get("source_prompt") or "",
             evidence_records=_decode_evidence_records(props.get("evidence_records")),
+            metadata=_decode_metadata(props.get("metadata")),
             valid_from=_parse_datetime(props["valid_from"]) if props.get("valid_from") else None,
             valid_to=_parse_datetime(props["valid_to"]) if props.get("valid_to") else None,
             created_at=_parse_datetime(props["created_at"]),


### PR DESCRIPTION
## Summary

This PR brings the Neo4j implementation of `resolve_conflict()` into behavioral parity with the SQLite backend by adding support for winner-based conflict resolution.

### Changes

- Added support for the optional `winner` parameter in the Neo4j `resolve_conflict()` implementation.
- Validated that `winner` is one of the conflict edge endpoints, matching the SQLite backend's validation behavior.
- Stored the selected `winner` in the conflict edge metadata.
- Added Neo4j loser-node supersession logic that:
  - sets `valid_to`
  - sets `updated_at`
  - records `superseded_by`
  - records `superseded_at`
  - records `superseded_relationship`
- Preserved the existing behavior when `winner` is not provided.

Fixes #393.

## Testing

Executed:

```bash
pytest -k conflict -v
```

Result:

```
28 passed
1 skipped
0 failed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced conflict resolution now supports an optional “winner” node designation for clearer, explicitly targeted outcomes.
  * When a winner is specified, the non-winning endpoint is automatically marked as superseded, including updated validity, timestamps, and supersession metadata.
* **Improvements**
  * Improved graph node construction by ensuring persisted node metadata is correctly loaded and reflected in returned node objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->