### PR TITLE
docs: document WAGGLE_EMBEDDING_BACKEND

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ waggle-mcp doctor
 
 These steps are intended to work on a clean macOS, Linux, or Windows checkout with Python 3.11+ and Git installed:
 
+For a complete list of supported environment variables and configuration options, see [docs/environment-variables.md](docs/environment-variables.md).
+
 ```bash
 git clone https://github.com/Abhigyan-Shekhar/Waggle-mcp.git
 cd Waggle-mcp

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -11,9 +11,42 @@ Boolean values are enabled only when set to the lowercase string `true`. Integer
 | `WAGGLE_BACKEND` | `sqlite` | string enum: `sqlite`, `neo4j` | Always. Selects the storage backend. | `neo4j` |
 | `WAGGLE_TRANSPORT` | `stdio` | string enum: `stdio`, `http` | Always. HTTP transport requires `WAGGLE_BACKEND=neo4j`. | `http` |
 | `WAGGLE_MODEL` | `all-MiniLM-L6-v2` | string | Always. Names the sentence-transformers embedding model. | `BAAI/bge-small-en-v1.5` |
+| `WAGGLE_EMBEDDING_BACKEND` | `pytorch` | string enum: `pytorch`, `onnx` | Always. Controls which backend Sentence Transformers uses for embedding inference. | `onnx` |
 | `WAGGLE_DEFAULT_TENANT_ID` | `local-default` | string | Always. Used when a request does not provide a tenant. Must not be empty. | `workspace-default` |
 | `WAGGLE_LOG_LEVEL` | `INFO` | string | Always. Configures application logging verbosity. | `DEBUG` |
 | `WAGGLE_STARTUP_MODE` | `normal` | string enum: `fast`, `normal`, `strict` | Always. Controls startup/warmup behavior. | `strict` |
+
+## Embedding backend
+
+`WAGGLE_EMBEDDING_BACKEND` controls which backend Sentence Transformers uses for embedding inference.
+
+**Default:** `pytorch`
+
+**Allowed values:**
+
+* `pytorch`
+* `onnx`
+
+Example:
+
+```bash
+export WAGGLE_EMBEDDING_BACKEND=onnx
+```
+
+### ONNX Runtime requirements
+
+Using `WAGGLE_EMBEDDING_BACKEND=onnx` requires additional ONNX Runtime dependencies:
+
+```bash
+pip install onnxruntime optimum
+```
+
+### Backend tradeoffs
+
+* **pytorch** (default): Recommended for most deployments. Simpler setup and works out of the box.
+* **onnx**: Can improve inference performance and reduce latency on some hardware configurations, but requires additional ONNX Runtime dependencies.
+
+If ONNX dependencies are unavailable, model initialization may fail and Waggle will fall back to deterministic embeddings.
 
 ## SQLite storage
 


### PR DESCRIPTION
## Summary

* Added documentation for `WAGGLE_EMBEDDING_BACKEND` in `docs/environment-variables.md`
* Documented supported values (`pytorch`, `onnx`), default behavior, and ONNX runtime requirements
* Added a README cross-reference to the environment variable documentation
* Explained tradeoffs between the PyTorch and ONNX backends

### Why was it needed?

`WAGGLE_EMBEDDING_BACKEND` was already supported in the codebase and documented in `CONTRIBUTING.md`, but it was missing from the main environment variable reference. This change makes the configuration discoverable for users and operators.

## Testing

* [ ] `WAGGLE_MODEL=deterministic pytest -q`
* [ ] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/`

### Test report

Documentation-only change. No code or runtime behavior was modified, so no additional tests were required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration documentation with details on embedding backend options, including ONNX runtime dependencies and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->