### PR TITLE
Tooling/docs link check v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run ruff format check
         run: ruff format --check src/ tests/
 
+      - name: Check markdown links
+        run: python scripts/check_markdown_links.py
+
   # ── Tests ─────────────────────────────────────────────────────────────────
   test:
     name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,9 +259,6 @@ python scripts/check_markdown_links.py
 
 The script checks internal Markdown links across the repository and reports the source file and broken path when an invalid link is found.
 
-External URLs and section anchors are ignored to keep the check deterministic and CI-safe.
-```
-
 ## Code Style
 
 This project uses [ruff](https://docs.astral.sh/ruff/) for both linting and formatting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ Thank you for your interest in improving Waggle. This document covers everything
 - [First Contribution Paths](#first-contribution-paths)
 - [Project Architecture](#project-architecture)
 - [Running Tests](#running-tests)
-- [Writing Tests](#writing-tests)      <-- ADD THIS LINE
+- [Documentation Link Checks](#documentation-link-checks)
+- [Writing Tests](#writing-tests)
 - [Code Style](#code-style)
 - [Key Concepts](#key-concepts)
 - [How to Submit a PR](#how-to-submit-a-pr)
@@ -247,6 +248,20 @@ Follow these rules when adding tests to the repository:
 * **One function per behavior:** Do not bundle multiple unrelated assertions into a single test function. Keeping tests isolated ensures failure logs remain specific and actionable.
 
 ---
+
+## Documentation Link Checks
+
+To validate repository-local Markdown links:
+
+```bash
+python scripts/check_markdown_links.py
+```
+
+The script checks internal Markdown links across the repository and reports the source file and broken path when an invalid link is found.
+
+External URLs and section anchors are ignored to keep the check deterministic and CI-safe.
+```
+
 ## Code Style
 
 This project uses [ruff](https://docs.astral.sh/ruff/) for both linting and formatting.

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import re
 import sys
+from urllib.parse import urlsplit
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -32,7 +33,8 @@ for md_file in markdown_files:
             continue
 
         # Remove anchor part
-        link_path = link.split("#")[0]
+        parsed = urlsplit(link)
+        link_path = parsed.path
 
         if not link_path:
             continue

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -5,6 +5,9 @@ from urllib.parse import urlsplit
 
 ROOT = Path(__file__).resolve().parent.parent
 
+FENCED_CODE_PATTERN = re.compile(r"```.*?```", re.DOTALL)
+INLINE_CODE_PATTERN = re.compile(r"`[^`\n]+`")
+
 LINK_PATTERN = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
 IGNORED_DIRS = {".venv", ".git", "node_modules"}
@@ -19,6 +22,10 @@ broken_links = []
 
 for md_file in markdown_files:
     text = md_file.read_text(encoding="utf-8")
+    
+    # Ignore Markdown examples inside code blocks and inline code spans.
+    text = FENCED_CODE_PATTERN.sub("", text)
+    text = INLINE_CODE_PATTERN.sub("", text)
 
     for match in LINK_PATTERN.finditer(text):
         link = match.group(1).strip()

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -6,7 +6,13 @@ ROOT = Path(__file__).resolve().parent.parent
 
 LINK_PATTERN = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
-markdown_files = ROOT.rglob("*.md")
+IGNORED_DIRS = {".venv", ".git", "node_modules"}
+
+markdown_files = sorted(
+    path
+    for path in ROOT.rglob("*.md")
+    if not any(part in IGNORED_DIRS for part in path.parts)
+)
 
 broken_links = []
 
@@ -33,12 +39,19 @@ for md_file in markdown_files:
 
         resolved_path = (md_file.parent / link_path).resolve()
 
-        if not resolved_path.exists():
-            try:
-                relative_path = resolved_path.relative_to(ROOT)
-            except ValueError:
-                relative_path = resolved_path
+        try:
+            relative_path = resolved_path.relative_to(ROOT)
+        except ValueError:
+            broken_links.append(
+                (
+                    md_file.relative_to(ROOT),
+                    link,
+                    resolved_path,
+                )
+            )
+            continue
 
+        if not resolved_path.exists():
             broken_links.append(
                 (
                     md_file.relative_to(ROOT),

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+
+LINK_PATTERN = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+markdown_files = ROOT.rglob("*.md")
+
+broken_links = []
+
+for md_file in markdown_files:
+    text = md_file.read_text(encoding="utf-8")
+
+    for match in LINK_PATTERN.finditer(text):
+        link = match.group(1).strip()
+
+        # Ignore external URLs
+        if (
+            link.startswith("http://")
+            or link.startswith("https://")
+            or link.startswith("mailto:")
+            or link.startswith("#")
+        ):
+            continue
+
+        # Remove anchor part
+        link_path = link.split("#")[0]
+
+        if not link_path:
+            continue
+
+        resolved_path = (md_file.parent / link_path).resolve()
+
+        if not resolved_path.exists():
+            try:
+                relative_path = resolved_path.relative_to(ROOT)
+            except ValueError:
+                relative_path = resolved_path
+
+            broken_links.append(
+                (
+                    md_file.relative_to(ROOT),
+                    link,
+                    relative_path,
+                )
+            )
+
+if broken_links:
+    print("\nBroken markdown links found:\n")
+
+    for source_file, link, resolved in broken_links:
+        print(f"{source_file}")
+        print(f"  Link: {link}")
+        print(f"  Resolved path: {resolved}")
+        print()
+
+    sys.exit(1)
+
+print("All markdown links are valid.")


### PR DESCRIPTION
## Summary

### What changed?

* Added a deterministic repository-local Markdown link checker under `scripts/check_markdown_links.py`.
* Added a CI step to run the checker as part of the lint workflow.
* Documented how contributors can run the check locally in `CONTRIBUTING.md`.
* Normalized links using `urllib.parse.urlsplit` so both query strings (`?v=1`) and fragments (`#section`) are ignored when resolving repository-local paths.
* Enforced repository-root boundaries and excluded `.venv`, `.git`, and `node_modules` from the scan.

### Why was it needed?

Broken internal Markdown links are easy to introduce and difficult to notice until contributors encounter them. This adds a deterministic, CI-safe validation step that catches broken repository-local links early and provides actionable output while avoiding false positives from external URLs, fragments, and query strings.

## Testing

* [ ] `WAGGLE_MODEL=deterministic pytest -q` *(1 unrelated pre-existing failure in `tests/test_neo4j_stubs.py`)*
* [x] `ruff check src/ tests/`
* [ ] `ruff format --check src/ tests/` *(repository currently contains pre-existing formatting differences unrelated to this change)*

### Test report

No pytest tests were added or modified in this change.

```text
python scripts/check_markdown_links.py
All markdown links are valid.

python -m compileall scripts/check_markdown_links.py
Compiling 'scripts/check_markdown_links.py'...

python -m ruff check src/ tests/
All checks passed!

pytest -q
628 passed, 4 skipped, 1 failed

FAILED tests/test_neo4j_stubs.py::test_neo4j_for_tenant_returns_new_instance
TypeError: fromisoformat: argument must be str
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic validation for repository-local Markdown links during CI.
  * Introduced a new check that reports broken internal documentation links with clear file and path details.

* **Documentation**
  * Updated contributor guidance with instructions for running the Markdown link check locally.
  * Added a new section to the table of contents for documentation link validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->