### PR TITLE
test: cover runtime context lifecycle

### DIFF
--- a/tests/test_runtime_context.py
+++ b/tests/test_runtime_context.py
@@ -48,11 +48,11 @@ def test_runtime_context_resets_when_body_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_runtime_context_is_isolated_between_async_tasks() -> None:
-    async def worker(request_id: str) -> tuple[str, str]:
-        with runtime_context(request_id=request_id):
-            before_sleep = get_runtime_context().request_id
+    async def worker(tenant_id: str) -> tuple[str, str]:
+        with runtime_context(tenant_id=tenant_id):
+            before_sleep = get_runtime_context().tenant_id
             await asyncio.sleep(0)
-            after_sleep = get_runtime_context().request_id
+            after_sleep = get_runtime_context().tenant_id
             return before_sleep, after_sleep
 
     with runtime_context(request_id="parent"):

--- a/tests/test_runtime_context.py
+++ b/tests/test_runtime_context.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from waggle.runtime_context import RuntimeContext, get_runtime_context, runtime_context
+
+
+def test_get_runtime_context_returns_empty_default_context() -> None:
+    context = get_runtime_context()
+
+    assert context == RuntimeContext()
+
+
+def test_runtime_context_sets_values_and_restores_after_exit() -> None:
+    with runtime_context(request_id="req-1", tenant_id="tenant-a", transport="stdio") as context:
+        assert context.request_id == "req-1"
+        assert context.tenant_id == "tenant-a"
+        assert context.transport == "stdio"
+        assert get_runtime_context() is context
+
+    assert get_runtime_context() == RuntimeContext()
+
+
+def test_nested_runtime_context_inherits_unspecified_fields_and_restores_parent() -> None:
+    with runtime_context(request_id="outer", tenant_id="tenant-a", backend="sqlite"):
+        with runtime_context(request_id="inner", tool_name="build_context") as inner:
+            assert inner.request_id == "inner"
+            assert inner.tenant_id == "tenant-a"
+            assert inner.backend == "sqlite"
+            assert inner.tool_name == "build_context"
+
+        restored = get_runtime_context()
+        assert restored.request_id == "outer"
+        assert restored.tenant_id == "tenant-a"
+        assert restored.backend == "sqlite"
+        assert restored.tool_name == ""
+
+
+def test_runtime_context_resets_when_body_raises() -> None:
+    with pytest.raises(RuntimeError, match="boom"), runtime_context(request_id="req-error"):
+        assert get_runtime_context().request_id == "req-error"
+        raise RuntimeError("boom")
+
+    assert get_runtime_context() == RuntimeContext()
+
+
+@pytest.mark.asyncio
+async def test_runtime_context_is_isolated_between_async_tasks() -> None:
+    async def worker(request_id: str) -> tuple[str, str]:
+        with runtime_context(request_id=request_id):
+            before_sleep = get_runtime_context().request_id
+            await asyncio.sleep(0)
+            after_sleep = get_runtime_context().request_id
+            return before_sleep, after_sleep
+
+    with runtime_context(request_id="parent"):
+        first, second = await asyncio.gather(worker("task-a"), worker("task-b"))
+        assert get_runtime_context().request_id == "parent"
+
+    assert first == ("task-a", "task-a")
+    assert second == ("task-b", "task-b")
+    assert get_runtime_context() == RuntimeContext()


### PR DESCRIPTION
## Summary

Adds direct tests for the `waggle.runtime_context` ContextVar lifecycle.

Closes #240

## What changed

- Covers the empty default context returned outside any runtime scope.
- Verifies context values are set inside `runtime_context()` and restored after exit.
- Verifies nested contexts inherit unspecified fields and restore the parent context.
- Verifies context reset still happens when the context body raises.
- Adds an async isolation test so concurrent tasks keep separate runtime context values across awaits.

## Validation

- `python -m pytest tests/test_runtime_context.py tests/test_logging_utils.py -q`
- `python -m ruff check tests/test_runtime_context.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for runtime context behavior, including default/empty values, temporary overrides within a context block, nested context inheritance and field overriding, automatic reset after exceptions, and isolation across concurrent async tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->