### PR TITLE
feat: add code-analysis extra, code_extraction module, and CI test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,10 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,36 @@ jobs:
           PYTHONUTF8: "1"   # prevents UnicodeEncodeError on Windows
         run: pytest -v --tb=long
 
-  # â”€â”€ Packaging smoke-test â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  # ── Code-analysis tests ───────────────────────────────────────────────────
+  code-analysis:
+    name: Code-analysis (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install project + dev + code-analysis
+        run: pip install -e ".[dev,code-analysis]"
+
+      - name: Verify critical dependencies
+        run: |
+          python -c "import waggle.code_extraction; print('code_extraction OK')"
+          python -c "import tree_sitter_language_pack; print('tree-sitter OK')"
+
+      - name: Run code-extraction tests
+        run: pytest -v --tb=long tests/test_code_extraction.py
+
+  # ── Packaging smoke-test ───────────────────────────────────────────────────
   package:
     name: Package smoke-test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ dev = [
 neo4j = [
   "neo4j>=5.20.0",
 ]
+code-analysis = [
+  "tree-sitter>=0.21.0",
+  "tree-sitter-language-pack>=0.2.0",
+]
 rlm-ipython = [
   "dill>=0.3.7",
   "ipykernel>=6.0.0",

--- a/src/waggle/code_extraction.py
+++ b/src/waggle/code_extraction.py
@@ -1,0 +1,193 @@
+"""Extract code entities (functions, classes) from conversation text.
+
+When a user pastes code into a conversation, Waggle can pull out the named
+symbols and store them as ENTITY nodes, linking conversation context to code
+structure (and, if a Graphify graph was imported, to the actual codebase graph).
+
+Parsing strategy:
+  1. Locate fenced code blocks (```lang ... ```) in the text.
+  2. For each block, detect the language (from the fence hint or a heuristic).
+  3. Parse with tree-sitter when the optional ``code-analysis`` extra is
+     installed; otherwise fall back to language-aware regular expressions.
+
+The regex fallback is always available, so this module never hard-depends on
+tree-sitter. Install ``waggle-mcp[code-analysis]`` for more accurate parsing.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+
+# Fenced code block: ```lang\n ... \n```  (lang optional)
+_FENCE_RE = re.compile(r"```([\w+-]*)\n(.*?)```", re.DOTALL)
+
+# Language hint normalization
+_LANG_ALIASES = {
+    "py": "python",
+    "python3": "python",
+    "js": "javascript",
+    "jsx": "javascript",
+    "ts": "typescript",
+    "tsx": "typescript",
+    "node": "javascript",
+}
+
+# Regex symbol extractors per language family.
+_PY_FUNC_RE = re.compile(r"^\s*(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(", re.MULTILINE)
+_PY_CLASS_RE = re.compile(r"^\s*class\s+([A-Za-z_]\w*)\s*[:\(]", re.MULTILINE)
+
+_JS_FUNC_RE = re.compile(r"^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(", re.MULTILINE)
+_JS_CLASS_RE = re.compile(r"^\s*(?:export\s+)?(?:default\s+)?class\s+([A-Za-z_$][\w$]*)", re.MULTILINE)
+_JS_CONST_FN_RE = re.compile(
+    r"^\s*(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?(?:function\b|\([^)]*\)\s*=>|[A-Za-z_$][\w$]*\s*=>)",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class CodeEntity:
+    """A named symbol extracted from a code block."""
+
+    name: str
+    entity_type: str  # "function" | "class"
+    language: str
+    snippet: str  # the line(s) the symbol was declared on (best-effort)
+
+
+def _normalize_language(hint: str, code: str) -> str:
+    """Resolve a fence hint (or guess from code) to a canonical language name."""
+    lang = _LANG_ALIASES.get(hint.strip().lower(), hint.strip().lower())
+    if lang in {"python", "javascript", "typescript"}:
+        return lang
+    if re.search(r"^\s*def\s+\w+\s*\(", code, re.MULTILINE) or ("import " in code and ":" in code):
+        return "python"
+    if re.search(r"\bfunction\b|=>|\bconst\b|\blet\b", code):
+        return "javascript"
+    return lang or "unknown"
+
+
+def _snippet_for(code: str, name: str) -> str:
+    """Return the first source line mentioning ``name`` (trimmed), else name."""
+    for line in code.splitlines():
+        if name in line:
+            return line.strip()[:200]
+    return name
+
+
+def _regex_extract(code: str, language: str) -> list[CodeEntity]:
+    entities: list[CodeEntity] = []
+    seen: set[tuple[str, str]] = set()
+
+    def _add(name: str, entity_type: str) -> None:
+        key = (name, entity_type)
+        if key in seen:
+            return
+        seen.add(key)
+        entities.append(
+            CodeEntity(name=name, entity_type=entity_type, language=language, snippet=_snippet_for(code, name))
+        )
+
+    if language == "python":
+        for m in _PY_CLASS_RE.finditer(code):
+            _add(m.group(1), "class")
+        for m in _PY_FUNC_RE.finditer(code):
+            _add(m.group(1), "function")
+    elif language in {"javascript", "typescript"}:
+        for m in _JS_CLASS_RE.finditer(code):
+            _add(m.group(1), "class")
+        for m in _JS_FUNC_RE.finditer(code):
+            _add(m.group(1), "function")
+        for m in _JS_CONST_FN_RE.finditer(code):
+            _add(m.group(1), "function")
+    else:
+        # Generic best-effort: try both families
+        for m in _PY_CLASS_RE.finditer(code):
+            _add(m.group(1), "class")
+        for m in _PY_FUNC_RE.finditer(code):
+            _add(m.group(1), "function")
+        for m in _JS_FUNC_RE.finditer(code):
+            _add(m.group(1), "function")
+
+    return entities
+
+
+@lru_cache(maxsize=1)
+def _tree_sitter_available() -> bool:
+    try:
+        import tree_sitter_language_pack  # type: ignore[import-not-found]  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _tree_sitter_extract(code: str, language: str) -> list[CodeEntity] | None:
+    """Parse with tree-sitter if installed. Returns None to signal fallback."""
+    if not _tree_sitter_available():
+        return None
+    try:
+        from tree_sitter_language_pack import get_parser  # type: ignore[import-not-found]
+
+        parser = get_parser(language)
+        tree = parser.parse(code.encode("utf-8"))
+    except Exception:
+        return None
+
+    entities: list[CodeEntity] = []
+    seen: set[tuple[str, str]] = set()
+    func_types = {"function_definition", "function_declaration", "method_definition", "arrow_function"}
+    class_types = {"class_definition", "class_declaration"}
+
+    def _walk(node: object) -> None:
+        node_type = getattr(node, "type", "")
+        if node_type in func_types or node_type in class_types:
+            name_node = node.child_by_field_name("name") if hasattr(node, "child_by_field_name") else None
+            if name_node is not None:
+                name = code[name_node.start_byte : name_node.end_byte]
+                entity_type = "class" if node_type in class_types else "function"
+                key = (name, entity_type)
+                if name and key not in seen:
+                    seen.add(key)
+                    entities.append(
+                        CodeEntity(
+                            name=name,
+                            entity_type=entity_type,
+                            language=language,
+                            snippet=_snippet_for(code, name),
+                        )
+                    )
+        for child in getattr(node, "children", []):
+            _walk(child)
+
+    _walk(tree.root_node)
+    return entities
+
+
+def extract_code_entities(text: str) -> list[CodeEntity]:
+    """Extract named code symbols from all fenced code blocks in ``text``.
+
+    Returns a de-duplicated list of :class:`CodeEntity`. If no fenced code
+    blocks are present, returns an empty list. Never raises on malformed code.
+    """
+    if not text or "```" not in text:
+        return []
+
+    results: list[CodeEntity] = []
+    seen: set[tuple[str, str]] = set()
+    for match in _FENCE_RE.finditer(text):
+        hint, code = match.group(1), match.group(2)
+        if not code.strip():
+            continue
+        language = _normalize_language(hint, code)
+        entities = _tree_sitter_extract(code, language)
+        if entities is None:
+            entities = _regex_extract(code, language)
+        for entity in entities:
+            key = (entity.name, entity.entity_type)
+            if key in seen:
+                continue
+            seen.add(key)
+            results.append(entity)
+    return results

--- a/src/waggle/code_extraction.py
+++ b/src/waggle/code_extraction.py
@@ -137,11 +137,32 @@ def _tree_sitter_extract(code: str, language: str) -> list[CodeEntity] | None:
 
     entities: list[CodeEntity] = []
     seen: set[tuple[str, str]] = set()
-    func_types = {"function_definition", "function_declaration", "method_definition", "arrow_function"}
+    func_types = {"function_definition", "function_declaration", "function", "method_definition", "arrow_function"}
     class_types = {"class_definition", "class_declaration"}
 
     def _walk(node: object) -> None:
         node_type = getattr(node, "type", "")
+
+        # Variable-bound functions: const handleClick = () => {}
+        if node_type == "variable_declarator":
+            value_node = node.child_by_field_name("value") if hasattr(node, "child_by_field_name") else None
+            name_node = node.child_by_field_name("name") if hasattr(node, "child_by_field_name") else None
+            if value_node is not None and name_node is not None:
+                value_type = getattr(value_node, "type", "")
+                if value_type in func_types:
+                    name = code[name_node.start_byte : name_node.end_byte]
+                    key = (name, "function")
+                    if name and key not in seen:
+                        seen.add(key)
+                        entities.append(
+                            CodeEntity(
+                                name=name,
+                                entity_type="function",
+                                language=language,
+                                snippet=_snippet_for(code, name),
+                            )
+                        )
+
         if node_type in func_types or node_type in class_types:
             name_node = node.child_by_field_name("name") if hasattr(node, "child_by_field_name") else None
             if name_node is not None:
@@ -182,7 +203,7 @@ def extract_code_entities(text: str) -> list[CodeEntity]:
             continue
         language = _normalize_language(hint, code)
         entities = _tree_sitter_extract(code, language)
-        if entities is None:
+        if not entities:
             entities = _regex_extract(code, language)
         for entity in entities:
             key = (entity.name, entity.entity_type)

--- a/tests/test_code_extraction.py
+++ b/tests/test_code_extraction.py
@@ -1,0 +1,55 @@
+"""Tests for code_extraction module: tree-sitter and regex parse paths."""
+
+from __future__ import annotations
+
+from waggle.code_extraction import CodeEntity, extract_code_entities
+
+
+class TestCodeExtraction:
+    def test_no_code_blocks_returns_empty(self) -> None:
+        assert extract_code_entities("just a plain sentence with no code") == []
+
+    def test_python_function_and_class(self) -> None:
+        text = "Here:\n```python\nclass UserService:\n    def authenticate(self, user):\n        return True\n```"
+        entities = extract_code_entities(text)
+        names = {(e.name, e.entity_type) for e in entities}
+        assert ("UserService", "class") in names
+        assert ("authenticate", "function") in names
+
+    def test_python_async_function(self) -> None:
+        text = "```py\nasync def fetch_data(url):\n    pass\n```"
+        entities = extract_code_entities(text)
+        assert ("fetch_data", "function") in {(e.name, e.entity_type) for e in entities}
+
+    def test_javascript_function_and_class(self) -> None:
+        text = "```js\nexport class Widget {}\nfunction render(props) { return null; }\n```"
+        entities = extract_code_entities(text)
+        names = {(e.name, e.entity_type) for e in entities}
+        assert ("Widget", "class") in names
+        assert ("render", "function") in names
+
+    def test_javascript_arrow_const(self) -> None:
+        text = "```javascript\nconst handleClick = (e) => { console.log(e); };\n```"
+        entities = extract_code_entities(text)
+        assert ("handleClick", "function") in {(e.name, e.entity_type) for e in entities}
+
+    def test_multiple_blocks_deduped(self) -> None:
+        text = "```python\ndef foo():\n    pass\n```\nand\n```python\ndef foo():\n    pass\n```"
+        entities = extract_code_entities(text)
+        assert sum(1 for e in entities if e.name == "foo") == 1
+
+    def test_language_detected_without_hint(self) -> None:
+        text = "```\ndef compute_total(items):\n    return sum(items)\n```"
+        entities = extract_code_entities(text)
+        assert any(e.name == "compute_total" for e in entities)
+
+    def test_malformed_code_does_not_raise(self) -> None:
+        text = "```python\ndef broken(:\n  ???\n```"
+        extract_code_entities(text)
+
+    def test_entity_carries_language_and_snippet(self) -> None:
+        text = "```python\ndef greet(name):\n    pass\n```"
+        entity = next(e for e in extract_code_entities(text) if e.name == "greet")
+        assert isinstance(entity, CodeEntity)
+        assert entity.language == "python"
+        assert "greet" in entity.snippet


### PR DESCRIPTION
### Problem
Waggle needs to detect code entities (functions, classes) embedded in user conversation messages so they can be stored as `ENTITY` nodes in the graph. This PR provides the extraction infrastructure and a CI lane to keep it reliable.

### Changes

**`pyproject.toml`**
- Added `[code-analysis]` optional-dependencies extra:
  - `tree-sitter>=0.21.0`
  - `tree-sitter-language-pack>=0.2.0`

**`src/waggle/code_extraction.py`** (new)
- Dual-parse-path module:
  - **Tree-sitter path** — uses AST-based parsing when `code-analysis` extra is installed (accurate, language-aware).
  - **Regex fallback** — always available with zero additional dependencies (covers Python, JavaScript/TypeScript functions, classes, arrow functions, async functions).
- Extracts `CodeEntity` dataclass instances (name, entity_type, language, snippet) from fenced code blocks in conversation text.
- Language detection from fence hints (`py`, `js`, `ts`) or code heuristics.

**`tests/test_code_extraction.py`** (new, 9 tests)
| Test | What it covers |
|------|----------------|
| `test_no_code_blocks_returns_empty` | No ``` fence → empty list |
| `test_python_function_and_class` | Python `def` + `class` extraction |
| `test_python_async_function` | `async def` extraction |
| `test_javascript_function_and_class` | JS `function` + `class` extraction |
| `test_javascript_arrow_const` | `const fn = (...) => ...` extraction |
| `test_multiple_blocks_deduped` | Same symbol across blocks → deduped |
| `test_language_detected_without_hint` | No language hint → heuristic detection |
| `test_malformed_code_does_not_raise` | Syntax errors → no exception |
| `test_entity_carries_language_and_snippet` | Entity metadata correctness |

**`.github/workflows/ci.yml`**
- New `code-analysis` job:
  - Matrix: Python 3.11, 3.12, 3.13 on `ubuntu-latest`
  - `pip install -e ".[dev,code-analysis]"`
  - Verifies `waggle.code_extraction` and `tree_sitter_language_pack` imports
  - Runs `pytest -v --tb=long tests/test_code_extraction.py`

### Testing

```bash
# Without tree-sitter (regex fallback)
pip install -e ".[dev]"
pytest -v tests/test_code_extraction.py

# With tree-sitter (AST-based)
pip install -e ".[dev,code-analysis]"
pytest -v tests/test_code_extraction.py
```

Closes #461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic extraction of named functions and classes from fenced code blocks, including support for multiple languages and unlabeled fences.
  * Results now include the entity name, type, detected language, and a best-effort snippet.

* **Bug Fixes**
  * Extraction is now resilient to malformed or partially invalid code, avoiding unexpected failures.
  * Prevents duplicate entities when the same symbol appears across multiple blocks.

* **Tests**
  * Added unit tests covering empty inputs, language detection, deduplication, malformed fences, and returned metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->