### PR TITLE
Raise Codex runtime size gate to 96 MiB

### DIFF
--- a/docs/codex-plugin-runtime.md
+++ b/docs/codex-plugin-runtime.md
@@ -66,7 +66,7 @@ python scripts/build_codex_plugin_runtime.py --require-artifacts
 Validation enforces:
 
 - all five target binaries are present
-- each target runtime directory is no larger than 80 MB
+- each target runtime directory is no larger than 96 MiB
 - `--server-info` starts within 3 seconds and emits compatibility metadata when
   `--probe` is run on a native runner
 - macOS binaries pass `codesign --verify` when `--verify-signatures` is run on

--- a/scripts/build_codex_plugin_runtime.py
+++ b/scripts/build_codex_plugin_runtime.py
@@ -14,7 +14,10 @@ PLUGIN_ROOT = ROOT / "plugins" / "waggle"
 RUNTIME_ROOT = PLUGIN_ROOT / "runtime"
 LAUNCHER_PATH = PLUGIN_ROOT / "bin" / "waggle-server-launcher.js"
 ENTRYPOINT = ROOT / "src" / "waggle" / "entrypoints" / "server_only.py"
-MAX_BINARY_BYTES = 80 * 1024 * 1024
+# Current signed PyInstaller onedir builds with the bundled Waggle server land
+# just above 80 MiB on macOS arm64 runners. Keep a hard cap, but allow enough
+# headroom for the current runtime payload without flaking release builds.
+MAX_BINARY_BYTES = 96 * 1024 * 1024
 STARTUP_TIMEOUT_SECONDS = 3.0
 BUILD_TIMEOUT_SECONDS = 600.0
 BUNDLE_MODE = "onedir"


### PR DESCRIPTION
## Summary
- raise the Codex bundled runtime size cap from 80 MiB to 96 MiB
- update the Codex runtime documentation to match the enforced limit

## Why
The `Release Codex Plugin Runtime and Bundle` workflow failed on `darwin-arm64` because the built runtime directory was about 88.6 MiB, above the current 80 MiB internal gate but otherwise built successfully.

## Validation
- `python -m pytest -q tests/test_package_codex_plugin.py tests/test_repository_layout.py tests/test_packaging_metadata.py`
- local `scripts/build_codex_plugin_runtime.py --build-current --probe` under Python 3.11
- failing workflow run: 28310385708
