### PR TITLE
test(graph): cover hub_analysis betweenness cap on large graphs

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2361,3 +2361,78 @@ def test_read_to_write_lock_upgrade_raises_runtime_error() -> None:
 
     with lock.read(), pytest.raises(RuntimeError, match="Cannot upgrade a read lock to a write lock"), lock:
         pass
+
+
+# ---------------------------------------------------------------------------
+# hub_analysis - betweenness cap on large graphs
+# ---------------------------------------------------------------------------
+
+_BETWEENNESS_NODE_CAP = 2000
+
+
+def _build_star_graph(graph: MemoryGraph, *, spoke_count: int) -> str:
+    """Add one hub node connected to *spoke_count* leaves; return the hub node id."""
+    hub = graph.add_node(
+        label="hub",
+        content="central hub node",
+        node_type=NodeType.CONCEPT,
+    )
+    for i in range(spoke_count):
+        leaf = graph.add_node(
+            label=f"leaf-{i}",
+            content=f"leaf node {i}",
+            node_type=NodeType.CONCEPT,
+        )
+        graph.add_edge(
+            source_id=hub.node.id,
+            target_id=leaf.node.id,
+            relationship=RelationType.RELATES_TO,
+        )
+    return hub.node.id
+
+
+def test_hub_analysis_large_graph_skips_betweenness(tmp_path: Path) -> None:
+    """hub_analysis returns betweenness_centrality=0.0 for all nodes above the cap."""
+    graph = make_graph(tmp_path)
+    # 1 hub + 2001 spokes = 2002 nodes total, which exceeds the 2000-node cap
+    hub_id = _build_star_graph(graph, spoke_count=_BETWEENNESS_NODE_CAP + 1)
+
+    hubs = graph.hub_analysis(top_n=10, min_degree=1)
+
+    assert hubs, "hub_analysis must return results even on a large graph"
+    for entry in hubs:
+        assert entry["betweenness_centrality"] == 0.0, (
+            f"expected 0.0 for {entry['node_id']} on capped graph, got {entry['betweenness_centrality']}"
+        )
+    # Degree-based ordering must still work: the hub connects to every spoke
+    top = hubs[0]
+    assert top["node_id"] == hub_id
+    assert top["degree"] == _BETWEENNESS_NODE_CAP + 1
+
+
+def test_hub_analysis_small_graph_computes_betweenness(tmp_path: Path) -> None:
+    """hub_analysis computes real betweenness centrality when below the node cap."""
+    graph = make_graph(tmp_path)
+    # Chain A - B - C: B is the only node with positive betweenness
+    node_a = graph.add_node(label="A", content="node A", node_type=NodeType.CONCEPT)
+    node_b = graph.add_node(label="B", content="node B", node_type=NodeType.CONCEPT)
+    node_c = graph.add_node(label="C", content="node C", node_type=NodeType.CONCEPT)
+    graph.add_edge(
+        source_id=node_a.node.id,
+        target_id=node_b.node.id,
+        relationship=RelationType.RELATES_TO,
+    )
+    graph.add_edge(
+        source_id=node_b.node.id,
+        target_id=node_c.node.id,
+        relationship=RelationType.RELATES_TO,
+    )
+
+    hubs = graph.hub_analysis(top_n=10, min_degree=1)
+
+    assert hubs, "hub_analysis must return entries for a small graph"
+    b_entry = next((h for h in hubs if h["node_id"] == node_b.node.id), None)
+    assert b_entry is not None, "node B must appear in results"
+    assert b_entry["betweenness_centrality"] > 0.0, (
+        "node B is the only path between A and C and must have positive betweenness"
+    )


### PR DESCRIPTION
## Summary

**What changed?**
Added two tests in `tests/test_graph.py` covering the betweenness centrality cap behaviour introduced by `hub_analysis()` in #419.

- `test_hub_analysis_large_graph_skips_betweenness` - builds a star topology with 2002 nodes (1 hub + 2001 spokes), exceeding the 2000-node cap. Asserts every returned entry has `betweenness_centrality == 0.0` and that degree-based ordering still places the hub node first.
- `test_hub_analysis_small_graph_computes_betweenness` - builds a 3-node chain (A–B–C) below the cap and asserts node B has positive betweenness centrality, confirming the computation runs normally on small graphs.

**Why was it needed?**
The cap branch in `hub_analysis()` - which skips the O(V·E) betweenness computation for graphs with more than 2000 nodes - was previously untested. These tests exercise that branch deterministically using lightweight fixtures as specified in #453.

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

### Test report

```text
platform win32 -- Python 3.11.7, pytest-8.1.1, pluggy-1.6.0
collected 2 items

tests/test_graph.py::test_hub_analysis_large_graph_skips_betweenness PASSED   [ 50%]
tests/test_graph.py::test_hub_analysis_small_graph_computes_betweenness PASSED [100%]

2 passed in 152.46s (0:02:32)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for hub analysis on both large and small graphs.
  * Verified that very large graphs still return nodes ordered by degree while skipping betweenness calculations.
  * Verified that smaller graphs compute betweenness correctly, with the middle node in a simple chain showing a positive score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->