### PR TITLE
test(serializer): add regression tests for multi-item serializer output

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -145,3 +145,103 @@ def test_serialize_timeline_nonempty():
     output = serialize_timeline(result)
     assert "2024-06-15" in output
     assert "Decision stored" in output
+
+
+def test_serialize_recent_nodes_multiple_nodes():
+    nodes = [
+        Node(
+            label="Decision A",
+            content="PostgreSQL",
+            node_type=NodeType.DECISION,
+        ),
+        Node(
+            label="Preference B",
+            content="Dark mode",
+            node_type=NodeType.PREFERENCE,
+        ),
+    ]
+
+    output = serialize_recent_nodes(nodes)
+
+    assert "Decision A" in output
+    assert "Preference B" in output
+
+
+def test_serialize_observation_result_multiple_nodes():
+    result = ObservationResult(
+        stored_nodes=[
+            Node(
+                label="Decision A",
+                content="PostgreSQL",
+                node_type=NodeType.DECISION,
+            ),
+            Node(
+                label="Decision B",
+                content="Redis",
+                node_type=NodeType.DECISION,
+            ),
+        ]
+    )
+
+    output = serialize_observation_result(result)
+
+    assert "Decision A" in output
+    assert "Decision B" in output
+
+
+def test_serialize_observation_result_multiple_conflicts():
+    result = ObservationResult(
+        conflicts=[
+            ConflictRecord(
+                other_node_id="1",
+                other_node_label="MySQL",
+                reason="Old decision",
+            ),
+            ConflictRecord(
+                other_node_id="2",
+                other_node_label="SQLite",
+                reason="Legacy",
+            ),
+        ]
+    )
+
+    output = serialize_observation_result(result)
+
+    assert "MySQL" in output
+    assert "SQLite" in output
+
+
+def test_serialize_timeline_multiple_items():
+    result = TimelineResult(
+        items=[
+            ContextTimelineItem(
+                kind="created",
+                timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+                label="Node A",
+                summary="Created",
+            ),
+            ContextTimelineItem(
+                kind="updated",
+                timestamp=datetime(2024, 2, 1, tzinfo=UTC),
+                label="Node B",
+                summary="Updated",
+            ),
+        ]
+    )
+
+    output = serialize_timeline(result)
+
+    assert "Node A" in output
+    assert "Node B" in output
+
+
+def test_serialize_recent_nodes_unicode():
+    node = Node(
+        label="🚀 Launch",
+        content="Unicode test",
+        node_type=NodeType.NOTE,
+    )
+
+    output = serialize_recent_nodes([node])
+
+    assert "🚀 Launch" in output


### PR DESCRIPTION
## Summary

This PR improves the regression coverage of the serializer test suite by adding focused tests for multi-item and edge-case serialization scenarios.

### Changes

* Added tests for serializing multiple recent nodes.
* Added tests for observation results containing multiple stored nodes.
* Added tests for observation results containing multiple conflicts.
* Added tests for timeline serialization with multiple entries.
* Added a regression test for Unicode labels.

### Related Issue

Closes #494

### Testing

The following commands were executed successfully:

```bash
WAGGLE_MODEL=deterministic pytest tests/test_serializer.py -q
WAGGLE_MODEL=deterministic pytest -q
ruff check src/ tests/
ruff format --check src/ tests/
```

### Results

* ✅ Serializer tests passed (`26 passed`)
* ✅ Full test suite passed (`817 passed, 5 skipped`)
* ✅ Ruff lint checks passed
* ✅ Ruff formatting checks passed

### Checklist

* [x] Added regression tests only
* [x] No production code modified
* [x] Existing functionality preserved
* [x] All tests pass
* [x] Lint and formatting checks pass

### tests passed screenshots
<img width="1960" height="1694" alt="Screenshot from 2026-06-28 16-05-00 (Copy)" src="https://github.com/user-attachments/assets/7a899ed3-227f-4264-830d-1b20a7fae606" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests to improve coverage of serializer output formatting for recent nodes, observation results, and timeline items.
  * Confirmed labels render correctly for multiple entries, including Unicode labels and multiple conflict partners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->