### PR TITLE
docs(codex): point install docs at v0.1.17 marketplace release

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,15 @@ Claude Code also supports **automatic memory hooks** — see the [Hooks](#automa
 
 ### Codex
 
-Add to `~/.codex/config.toml`:
+The easiest install path is the Codex app plugin via the marketplace bundle
+published on the [`v0.1.17` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.17)
+— download `waggle-codex-marketplace-v0.1.17.zip`, extract it, then run
+`codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.17` and
+install `Waggle` from the added marketplace. `v0.1.16` was a partial release
+and is not a viable Codex marketplace install source. See
+[`docs/install/codex.md`](docs/install/codex.md) for full details.
+
+For direct Codex CLI usage instead, add Waggle to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.waggle]

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -47,17 +47,23 @@ and starts it with `serve --transport stdio`.
 Bundled runtime updates are delivered only through plugin upgrades. If a bundled
 binary is stale or missing, reinstall or upgrade the Waggle Codex plugin.
 
-Tagged Waggle releases now publish two Codex plugin assets:
+Tagged Waggle releases publish two Codex plugin assets. The current Codex
+marketplace artifacts are published on the
+[`v0.1.17` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.17):
 
-- `waggle-codex-marketplace-<tag>.zip`: a complete local marketplace root that
+- `waggle-codex-marketplace-v0.1.17.zip`: a complete local marketplace root that
   can be added with `codex plugin marketplace add`
-- `waggle-codex-plugin-<tag>.zip`: the bare `plugins/waggle` plugin folder
+- `waggle-codex-plugin-v0.1.17.zip`: the bare `plugins/waggle` plugin folder
 
-For the easiest install path, download and extract the marketplace bundle, then
-run:
+> `v0.1.16` was a partial release and should not be used as a Codex
+> marketplace install source. Use `v0.1.17` instead.
+
+For the easiest install path, download and extract the marketplace bundle
+from the [`v0.1.17` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.17),
+then run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-<tag>
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.17
 ```
 
 After that, refresh the plugin directory in Codex and install `Waggle` from the


### PR DESCRIPTION
## Summary
- Updated README Codex section to point at the v0.1.17 marketplace release instead of generic config-only instructions
- Resolved `<tag>` placeholders in `docs/install/codex.md` to `v0.1.17`
- Added explicit note that `v0.1.16` was a partial release and is not a valid Codex marketplace install source
- This is a docs-only change, no code touched

## Why
Codex marketplace artifacts are live on the v0.1.17 release. Docs previously had no concrete version reference (`<tag>` placeholder) and didn't link to the release at all, so users had no clear install path.

Fixes #495

## Testing
- [x] N/A — docs-only change, no code/tests affected
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

### Test report
N/A — no source files changed.

---
Working on this under GSSoC '26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Codex setup instructions to recommend installing the current app plugin marketplace bundle release.
  * Added the exact ZIP asset names for the marketplace bundle and plugin, along with the corresponding install/extract steps and marketplace add command.
  * Clarified that the earlier `v0.1.16` release is a partial release and not a valid marketplace source.
  * Kept/relocated the prior direct config guidance and linked to the full install guide for details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->