### PR TITLE
refactor(abhi): remove not yet implemented log line

### DIFF
--- a/src/waggle/abhi.py
+++ b/src/waggle/abhi.py
@@ -533,7 +533,8 @@ def build_abhi_document(
                 "Use --include-deps or remove --strict-export."
             )
         if include_deps:
-            logger.info("Walking dangling edge targets to include referenced nodes (not yet implemented, continuing)")
+            # TODO: Implement traversal of dangling edge targets to include referenced nodes.
+            pass
         else:
             logger.warning(
                 "Export contains %d dangling edge(s): %s",


### PR DESCRIPTION
## Summary

### What changed?
- Removed the runtime INFO log message containing "not yet implemented" from the dangling-edge walker path.
- Preserved the implementation intent with a TODO comment.

### Why was it needed?
The previous implementation emitted a runtime INFO log for an unimplemented feature while continuing execution. This created unnecessary log noise without changing behavior. The implementation intent is now preserved in source code instead of runtime logs.

## Testing

- [x] WAGGLE_MODEL=deterministic pytest -q
- [x] ruff check src/ tests/
- [x] ruff format --check src/ tests/

### Test report

```text
546 passed, 5 skipped, 1 warning in 92.27s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the way export traversal handles a specific dangling-edge scenario when non-strict exporting is enabled.
  * Cleaned up outdated placeholder messaging in that area.
  * No expected user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->