### PR TITLE
fix(recursive_context): deduplicate random ablation subqueries

### DIFF
--- a/src/waggle/recursive_context.py
+++ b/src/waggle/recursive_context.py
@@ -229,6 +229,7 @@ class RecursiveContextController:
             rng = random.Random(ablation.random_seed)
             words = query.split()
             subqueries: list[RecursiveSubquery] = []
+            seen_substrings: set[str] = set()
             attempts = 0
             while len(subqueries) < max_subqueries and attempts < max_subqueries * 10:
                 attempts += 1
@@ -237,6 +238,9 @@ class RecursiveContextController:
                 slice_len = rng.randint(2, min(4, len(words)))
                 start = rng.randint(0, len(words) - slice_len)
                 substring = " ".join(words[start : start + slice_len])
+                if substring in seen_substrings:
+                    continue
+                seen_substrings.add(substring)
                 subqueries.append(
                     RecursiveSubquery(
                         query=substring,


### PR DESCRIPTION
Track seen substrings in a set so that the random slicer only appends distinct subqueries.  For short queries (e.g. 2 words) this prevents N identical graph retrieval calls when only 1 unique slice exists. The existing attempts guard still bounds total iterations.

Fixes: #507 
## Summary

- What changed?
- Why was it needed?

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

### Test report

Paste the output of `pytest -v` for the files you added or changed (not the full suite, just yours):

```text
<paste here>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recursive context generation so random-substring decomposition avoids adding duplicate substring variants, reducing repeated material in generated context.
  * Resulting generated contexts are cleaner and more consistent, with fewer duplicate query substrings appearing across decomposition steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->