### PR TITLE
docs(codex): document unsigned macOS and Windows binary warnings for Codex plugin installs

### DIFF
--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -36,6 +36,40 @@ For more details on how these rules govern agent behavior, see the [Automatic Me
 
 ## Codex app plugin
 
+## First-run OS warnings (unsigned binary)
+
+The bundled Waggle runtime binary is currently unsigned. This means macOS and Windows will show a security warning on first launch. This is expected — it does not mean the binary is malicious.
+
+### macOS (Gatekeeper)
+
+You may see: *"waggle-runtime cannot be opened because it is from an unidentified developer."*
+
+To approve:
+
+1. Open **System Settings → Privacy & Security**
+2. Scroll to the bottom — you'll see a message about the blocked binary
+3. Click **Allow Anyway**
+4. Re-launch Codex — macOS will ask once more; click **Open**
+
+Or via terminal:
+
+```bash
+xattr -dr com.apple.quarantine /path/to/waggle-runtime
+```
+
+### Windows (SmartScreen)
+
+You may see: *"Windows protected your PC"*
+
+To approve:
+
+1. Click **More info**
+2. Click **Run anyway**
+
+Then retry the Codex plugin install.
+
+> These warnings appear only on first run. Once approved, the binary launches without prompting.
+
 This repository also ships a Codex app plugin manifest at `.codex-plugin/plugin.json`
 with its MCP companion config in `.mcp.json`.
 

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -75,7 +75,7 @@ with its MCP companion config in `.mcp.json`.
 
 For the Codex app plugin, Waggle bundles its own plugin-local MCP server runtime.
 Users do not need to install `waggle-mcp` from PyPI separately. The plugin
-launcher resolves a signed executable under `plugins/waggle/runtime/<target>/`
+launcher resolves a bundled executable under `plugins/waggle/runtime/<target>/`
 and starts it with `serve --transport stdio`.
 
 Bundled runtime updates are delivered only through plugin upgrades. If a bundled

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -114,3 +114,33 @@ $env:WAGGLE_DB_PATH = "$env:APPDATA\waggle\waggle.db"
 $env:WAGGLE_LOG_LEVEL = "DEBUG"
 waggle-mcp serve --transport stdio
 ```
+
+---
+
+## Codex plugin binary blocked by OS
+
+The bundled Waggle runtime shipped with the Codex plugin is unsigned. macOS and Windows will block it on first run. This is expected behavior, not a broken install.
+
+### macOS — approve and retry
+
+1. Open **System Settings → Privacy & Security**
+2. Find the blocked binary entry and click **Allow Anyway**
+3. Restart Codex
+
+Or remove the quarantine flag manually:
+
+```bash
+xattr -dr com.apple.quarantine /path/to/waggle-runtime
+```
+
+### Windows — approve and retry
+
+1. When SmartScreen appears, click **More info**
+2. Click **Run anyway**
+3. Restart Codex
+
+If the plugin still fails after approval, run:
+
+```bash
+waggle-mcp doctor
+```


### PR DESCRIPTION
Fixes #499

## Changes
- `docs/install/codex.md`: added "First-run OS warnings (unsigned binary)" section covering macOS Gatekeeper and Windows SmartScreen warnings with manual approve steps
- `docs/install/troubleshooting.md`: added "Codex plugin binary blocked by OS" section with approve-and-retry flow for both platforms; fixed unclosed code fence in Windows verbose logs block

## Why
Bundled runtime binaries are unsigned. Users hitting first-run OS warnings had no docs explaining expected behavior or how to proceed.

## Testing
- [ ] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

> Docs-only change. No source files modified; pytest and ruff not applicable. Markdown rendering verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clearer first-run guidance for signed/unsigned app warnings on macOS and Windows, including approval steps and a macOS terminal workaround.
  * Updated marketplace installation instructions with the latest recommended plugin release and corrected download details.
  * Expanded troubleshooting with steps for cases where the plugin is blocked by the operating system, plus a follow-up check if it still won’t run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->