### PR TITLE
docs(readme): clarify WAGGLE_MODEL=deterministic degradation

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Shared JSON config for clients that accept `mcpServers` JSON:
 ```
 
 > First run takes ~30 s — `all-MiniLM-L6-v2` (~420 MB) downloads on first use.
-> To skip the download: set `"WAGGLE_MODEL": "deterministic"` (offline-safe, instant start, slightly lower retrieval quality).
+> **⚠️ `WAGGLE_MODEL=deterministic` is for CI/testing only.** It replaces semantic embeddings with SHA-256 hash bucketing, completely disabling semantic similarity. Do not use in production — retrieval quality will be fundamentally degraded.
 
 ### Claude Desktop
 


### PR DESCRIPTION
Replace the 'slightly lower retrieval quality' understatement with a prominent warning that deterministic mode replaces semantic embeddings with SHA-256 hash bucketing, completely disabling semantic similarity.

Fixes: #508 

## Summary

- What changed?
- Why was it needed?

## Testing

- [ ] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

### Test report

Paste the output of `pytest -v` for the files you added or changed (not the full suite, just yours):

```text
<paste here>