### PR TITLE
feat(server): print a startup banner on serve confirming configured settings (#253)

### DIFF
--- a/src/waggle/entrypoints/server_only.py
+++ b/src/waggle/entrypoints/server_only.py
@@ -25,6 +25,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Only stdio transport is available in the bundled runtime.",
     )
     parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress startup banners and messages.",
+    )
+    parser.add_argument(
         "--server-info",
         action="store_true",
         help="Print bundled runtime compatibility metadata as JSON and exit.",
@@ -43,11 +48,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     from waggle.config import AppConfig
-    from waggle.server import run_stdio
+    from waggle.server import _print_startup_banner, run_stdio
 
     os.environ.setdefault("WAGGLE_TRANSPORT", "stdio")
     config = AppConfig.from_env()
     config.transport = "stdio"
+    _print_startup_banner(config, args)
     asyncio.run(run_stdio(config))
     return 0
 

--- a/src/waggle/entrypoints/server_only.py
+++ b/src/waggle/entrypoints/server_only.py
@@ -48,12 +48,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     from waggle.config import AppConfig
-    from waggle.server import _print_startup_banner, run_stdio
+    from waggle.server import print_startup_banner, run_stdio
 
     os.environ.setdefault("WAGGLE_TRANSPORT", "stdio")
     config = AppConfig.from_env()
     config.transport = "stdio"
-    _print_startup_banner(config, args)
+    print_startup_banner(config, args)
     asyncio.run(run_stdio(config))
     return 0
 

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -4077,6 +4077,7 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument("--quiet", action="store_true", help="Suppress startup banners and messages.")
     subparsers = parser.add_subparsers(dest="command")
     serve = subparsers.add_parser("serve", help="Run the MCP server using the configured stdio or HTTP transport.")
     serve.add_argument(
@@ -6504,6 +6505,25 @@ def _run_init() -> int:
     return 0
 
 
+def _print_startup_banner(config: AppConfig, args: argparse.Namespace | None = None) -> None:
+    if os.environ.get("WAGGLE_BANNER", "").lower() == "false":
+        return
+    if args is not None and getattr(args, "quiet", False):
+        return
+    if not sys.stdout.isatty():
+        return
+
+    banner = (
+        f"Waggle MCP {__version__}\n"
+        f"  Backend:    {config.backend}\n"
+        f"  Model:      {config.model_name} ({config.embedding_backend})\n"
+        f"  DB path:    {config.db_path}\n"
+        f"  Transport:  {config.transport}\n"
+        f"  Tenant:     {config.default_tenant_id}"
+    )
+    print(banner)
+
+
 def main() -> None:
     # ── Windows UTF-8 guard (Error 3 from field bug log) ────────────────────
     # Windows consoles default to cp1252. Unicode log lines / emoji cause
@@ -6550,6 +6570,8 @@ def main() -> None:
     if command == "serve" and getattr(args, "transport", None):
         config.transport = str(args.transport).strip().lower()
         config.validate()
+    if command in {"serve", "edit-graph", "view-graph", "ui", "graph-studio", "open-studio"}:
+        _print_startup_banner(config, args)
     log_stream = sys.stderr if config.transport == "stdio" else sys.stdout
     configure_logging(config.log_level, stream=log_stream)
     LOGGER.info("waggle_startup")

--- a/src/waggle/server.py
+++ b/src/waggle/server.py
@@ -4077,9 +4077,17 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
-    parser.add_argument("--quiet", action="store_true", help="Suppress startup banners and messages.")
+    parser.add_argument(
+        "--quiet", dest="global_quiet", action="store_true", help="Suppress startup banners and messages."
+    )
+    quiet_parent = argparse.ArgumentParser(add_help=False)
+    quiet_parent.add_argument("--quiet", action="store_true", help="Suppress startup banners and messages.")
     subparsers = parser.add_subparsers(dest="command")
-    serve = subparsers.add_parser("serve", help="Run the MCP server using the configured stdio or HTTP transport.")
+    serve = subparsers.add_parser(
+        "serve",
+        parents=[quiet_parent],
+        help="Run the MCP server using the configured stdio or HTTP transport.",
+    )
     serve.add_argument(
         "--transport",
         choices=["stdio", "http"],
@@ -4088,6 +4096,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     graph_editor = subparsers.add_parser(
         "edit-graph",
+        parents=[quiet_parent],
         help="Launch the visual graph editor in a browser window.",
         description=(
             "Start the Waggle HTTP app for local graph editing and open /graph in the browser by default. "
@@ -4100,6 +4109,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     graph_viewer = subparsers.add_parser(
         "view-graph",
+        parents=[quiet_parent],
         help="Launch the visual graph viewer/editor in a browser window.",
         description="Alias for edit-graph. Starts the local graph UI and opens it in the browser by default.",
     )
@@ -4109,6 +4119,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     graph_ui = subparsers.add_parser(
         "ui",
+        parents=[quiet_parent],
         help="Launch the local graph UI in the browser.",
         description="Alias for edit-graph. Starts the localhost Graph Studio and opens it by default.",
     )
@@ -4118,6 +4129,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     graph_studio = subparsers.add_parser(
         "graph-studio",
+        parents=[quiet_parent],
         help="Alias for the local Graph Studio browser UI.",
         description="Alias for ui/edit-graph. Starts the localhost Graph Studio and opens it by default.",
     )
@@ -4127,6 +4139,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     open_studio = subparsers.add_parser(
         "open-studio",
+        parents=[quiet_parent],
         help="Alias for graph-studio.",
         description="Alias for graph-studio/ui/edit-graph. Starts the localhost Graph Studio and opens it by default.",
     )
@@ -6505,7 +6518,7 @@ def _run_init() -> int:
     return 0
 
 
-def _print_startup_banner(config: AppConfig, args: argparse.Namespace | None = None) -> None:
+def print_startup_banner(config: AppConfig, args: argparse.Namespace | None = None) -> None:
     if os.environ.get("WAGGLE_BANNER", "").lower() == "false":
         return
     if args is not None and getattr(args, "quiet", False):
@@ -6539,6 +6552,7 @@ def main() -> None:
     _assert_runtime_feature_parity()
     parser = _build_parser()
     args = _normalize_pull_strategy_args(parser.parse_args())
+    args.quiet = getattr(args, "global_quiet", False) or getattr(args, "quiet", False)
     command = args.command or "serve"
 
     # Commands that should work before full backend/app initialization.
@@ -6571,7 +6585,7 @@ def main() -> None:
         config.transport = str(args.transport).strip().lower()
         config.validate()
     if command in {"serve", "edit-graph", "view-graph", "ui", "graph-studio", "open-studio"}:
-        _print_startup_banner(config, args)
+        print_startup_banner(config, args)
     log_stream = sys.stderr if config.transport == "stdio" else sys.stdout
     configure_logging(config.log_level, stream=log_stream)
     LOGGER.info("waggle_startup")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2217,22 +2217,9 @@ class TestHookToolsFromArgs:
             _run_setup(args)
 
 
-def test_parser_accepts_quiet_flag() -> None:
-    parser = _build_parser()
-    args = parser.parse_args(["--quiet", "serve"])
-    assert args.quiet is True
-    assert args.command == "serve"
-
-    args_default = parser.parse_args(["serve"])
-    assert args_default.quiet is False
-
-
-def test_startup_banner_tty_prints_correctly(capsys, monkeypatch):
-    import sys
-
-    from waggle.server import __version__, _print_startup_banner
-
-    config = AppConfig(
+@pytest.fixture
+def banner_config() -> AppConfig:
+    return AppConfig(
         backend="sqlite",
         transport="stdio",
         model_name="all-MiniLM-L6-v2",
@@ -2253,10 +2240,36 @@ def test_startup_banner_tty_prints_correctly(capsys, monkeypatch):
         neo4j_database="",
     )
 
+
+def test_parser_accepts_quiet_flag() -> None:
+    parser = _build_parser()
+
+    # Check top-level quiet flag
+    args = parser.parse_args(["--quiet", "serve"])
+    args.quiet = getattr(args, "global_quiet", False) or getattr(args, "quiet", False)
+    assert args.quiet is True
+    assert args.command == "serve"
+
+    # Check subcommand quiet flag
+    args_sub = parser.parse_args(["serve", "--quiet"])
+    args_sub.quiet = getattr(args_sub, "global_quiet", False) or getattr(args_sub, "quiet", False)
+    assert args_sub.quiet is True
+    assert args_sub.command == "serve"
+
+    args_default = parser.parse_args(["serve"])
+    args_default.quiet = getattr(args_default, "global_quiet", False) or getattr(args_default, "quiet", False)
+    assert args_default.quiet is False
+
+
+def test_startup_banner_tty_prints_correctly(capsys, monkeypatch, banner_config):
+    import sys
+
+    from waggle.server import __version__, print_startup_banner
+
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     monkeypatch.delenv("WAGGLE_BANNER", raising=False)
 
-    _print_startup_banner(config)
+    print_startup_banner(banner_config)
 
     captured = capsys.readouterr()
     assert f"Waggle MCP {__version__}" in captured.out
@@ -2267,108 +2280,45 @@ def test_startup_banner_tty_prints_correctly(capsys, monkeypatch):
     assert "  Tenant:     local-default" in captured.out
 
 
-def test_startup_banner_no_tty_suppresses(capsys, monkeypatch):
+def test_startup_banner_no_tty_suppresses(capsys, monkeypatch, banner_config):
     import sys
 
-    from waggle.server import _print_startup_banner
-
-    config = AppConfig(
-        backend="sqlite",
-        transport="stdio",
-        model_name="all-MiniLM-L6-v2",
-        db_path="/tmp/waggle.db",
-        default_tenant_id="local-default",
-        http_host="127.0.0.1",
-        http_port=8080,
-        log_level="INFO",
-        rate_limit_rpm=120,
-        write_rate_limit_rpm=60,
-        max_concurrent_requests=8,
-        max_payload_bytes=1024 * 1024,
-        request_timeout_seconds=30,
-        export_dir=None,
-        neo4j_uri="",
-        neo4j_username="",
-        neo4j_password="",
-        neo4j_database="",
-    )
+    from waggle.server import print_startup_banner
 
     monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
     monkeypatch.delenv("WAGGLE_BANNER", raising=False)
 
-    _print_startup_banner(config)
+    print_startup_banner(banner_config)
 
     captured = capsys.readouterr()
     assert captured.out == ""
 
 
-def test_startup_banner_quiet_suppresses(capsys, monkeypatch):
+def test_startup_banner_quiet_suppresses(capsys, monkeypatch, banner_config):
     import argparse
     import sys
 
-    from waggle.server import _print_startup_banner
-
-    config = AppConfig(
-        backend="sqlite",
-        transport="stdio",
-        model_name="all-MiniLM-L6-v2",
-        db_path="/tmp/waggle.db",
-        default_tenant_id="local-default",
-        http_host="127.0.0.1",
-        http_port=8080,
-        log_level="INFO",
-        rate_limit_rpm=120,
-        write_rate_limit_rpm=60,
-        max_concurrent_requests=8,
-        max_payload_bytes=1024 * 1024,
-        request_timeout_seconds=30,
-        export_dir=None,
-        neo4j_uri="",
-        neo4j_username="",
-        neo4j_password="",
-        neo4j_database="",
-    )
+    from waggle.server import print_startup_banner
 
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     monkeypatch.delenv("WAGGLE_BANNER", raising=False)
 
     args = argparse.Namespace(quiet=True)
-    _print_startup_banner(config, args)
+    print_startup_banner(banner_config, args)
 
     captured = capsys.readouterr()
     assert captured.out == ""
 
 
-def test_startup_banner_env_suppresses(capsys, monkeypatch):
+def test_startup_banner_env_suppresses(capsys, monkeypatch, banner_config):
     import sys
 
-    from waggle.server import _print_startup_banner
-
-    config = AppConfig(
-        backend="sqlite",
-        transport="stdio",
-        model_name="all-MiniLM-L6-v2",
-        db_path="/tmp/waggle.db",
-        default_tenant_id="local-default",
-        http_host="127.0.0.1",
-        http_port=8080,
-        log_level="INFO",
-        rate_limit_rpm=120,
-        write_rate_limit_rpm=60,
-        max_concurrent_requests=8,
-        max_payload_bytes=1024 * 1024,
-        request_timeout_seconds=30,
-        export_dir=None,
-        neo4j_uri="",
-        neo4j_username="",
-        neo4j_password="",
-        neo4j_database="",
-    )
+    from waggle.server import print_startup_banner
 
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     monkeypatch.setenv("WAGGLE_BANNER", "false")
 
-    _print_startup_banner(config)
+    print_startup_banner(banner_config)
 
     captured = capsys.readouterr()
     assert captured.out == ""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2215,3 +2215,160 @@ class TestHookToolsFromArgs:
         )
         with pytest.raises(ValidationFailure):
             _run_setup(args)
+
+
+def test_parser_accepts_quiet_flag() -> None:
+    parser = _build_parser()
+    args = parser.parse_args(["--quiet", "serve"])
+    assert args.quiet is True
+    assert args.command == "serve"
+
+    args_default = parser.parse_args(["serve"])
+    assert args_default.quiet is False
+
+
+def test_startup_banner_tty_prints_correctly(capsys, monkeypatch):
+    import sys
+
+    from waggle.server import __version__, _print_startup_banner
+
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="all-MiniLM-L6-v2",
+        db_path="/tmp/waggle.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024 * 1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.delenv("WAGGLE_BANNER", raising=False)
+
+    _print_startup_banner(config)
+
+    captured = capsys.readouterr()
+    assert f"Waggle MCP {__version__}" in captured.out
+    assert "  Backend:    sqlite" in captured.out
+    assert "  Model:      all-MiniLM-L6-v2 (pytorch)" in captured.out
+    assert "  DB path:    /tmp/waggle.db" in captured.out
+    assert "  Transport:  stdio" in captured.out
+    assert "  Tenant:     local-default" in captured.out
+
+
+def test_startup_banner_no_tty_suppresses(capsys, monkeypatch):
+    import sys
+
+    from waggle.server import _print_startup_banner
+
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="all-MiniLM-L6-v2",
+        db_path="/tmp/waggle.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024 * 1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    monkeypatch.delenv("WAGGLE_BANNER", raising=False)
+
+    _print_startup_banner(config)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_startup_banner_quiet_suppresses(capsys, monkeypatch):
+    import argparse
+    import sys
+
+    from waggle.server import _print_startup_banner
+
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="all-MiniLM-L6-v2",
+        db_path="/tmp/waggle.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024 * 1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.delenv("WAGGLE_BANNER", raising=False)
+
+    args = argparse.Namespace(quiet=True)
+    _print_startup_banner(config, args)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_startup_banner_env_suppresses(capsys, monkeypatch):
+    import sys
+
+    from waggle.server import _print_startup_banner
+
+    config = AppConfig(
+        backend="sqlite",
+        transport="stdio",
+        model_name="all-MiniLM-L6-v2",
+        db_path="/tmp/waggle.db",
+        default_tenant_id="local-default",
+        http_host="127.0.0.1",
+        http_port=8080,
+        log_level="INFO",
+        rate_limit_rpm=120,
+        write_rate_limit_rpm=60,
+        max_concurrent_requests=8,
+        max_payload_bytes=1024 * 1024,
+        request_timeout_seconds=30,
+        export_dir=None,
+        neo4j_uri="",
+        neo4j_username="",
+        neo4j_password="",
+        neo4j_database="",
+    )
+
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setenv("WAGGLE_BANNER", "false")
+
+    _print_startup_banner(config)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""


### PR DESCRIPTION
## Summary

- **What changed?**
  - Added a `--quiet` global CLI flag to the main parser in [server.py](file:///e:/Waggle-mcp/src/waggle/server.py).
  - Implemented `_print_startup_banner` in [server.py](file:///e:/Waggle-mcp/src/waggle/server.py) to read config details from `AppConfig` and print a diagnostic banner to stdout when output is a TTY.
  - Added `--quiet` and invoked the banner in [server_only.py](file:///e:/Waggle-mcp/src/waggle/entrypoints/server_only.py).
  - Wrote 5 tests in [test_server.py](file:///e:/Waggle-mcp/tests/test_server.py) covering quiet flags, TTY check, env suppress, and formatting.

- **Why was it needed?**
  - Prior to this, `waggle-mcp serve` started silently or emitted logs first, giving no indication of settings like version, database location, backend, model, or transport. The new banner aids debugging and usability.

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

### Test report

Paste the output of `pytest -v` for the files you added or changed (not the full suite, just yours):

```text
tests/test_server.py::test_parser_accepts_quiet_flag PASSED              [ 95%]
tests/test_server.py::test_startup_banner_tty_prints_correctly PASSED    [ 96%]
tests/test_server.py::test_startup_banner_no_tty_suppresses PASSED       [ 97%]
tests/test_server.py::test_startup_banner_quiet_suppresses PASSED        [ 98%]
tests/test_server.py::test_startup_banner_env_suppresses          PASSED [100%]
```

Closes #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--quiet` option to reduce startup output.
  * Startup banners now appear only in interactive terminals and when banner display is enabled.

* **Bug Fixes**
  * Improved startup behavior so server and graph-related commands handle banner display consistently.

* **Tests**
  * Added coverage for the new quiet mode and banner display conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->