### PR TITLE
[codex] Update README contributing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For self-hosted production review and security posture:
 
 ## Repository Docs
 
-Internal contributors can use the docs in this repo as the source of truth:
+Use these docs to install, evaluate, and contribute to Waggle:
 
 - [Contributing guide](./CONTRIBUTING.md)
 - [Repository map](./docs/repository-map.md)
@@ -842,4 +842,6 @@ Run `waggle-mcp doctor` first — it usually identifies the actual failure mode.
 
 ## Contributing
 
-This repository is maintained privately. Internal contributors can use the docs in this repo as the source of truth.
+If Waggle is useful, please star the repo to help more developers find it. Before opening an issue or pull request, install the latest package from [PyPI](https://pypi.org/project/waggle-mcp/) and confirm the behavior with the published build.
+
+To contribute, fork the repository and follow the setup, testing, style, and pull request guidelines in [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- Replace private-maintainer contributing copy in the README with public contributor guidance.
- Ask readers to star the repo, install and verify the published PyPI package, fork the repo, and follow `CONTRIBUTING.md`.
- Remove internal-only wording from the README repository docs section.

## Why
The README rendered a private-maintenance message even though the repo already has a public `CONTRIBUTING.md` workflow and PyPI package.

## Validation
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance in the README to better direct readers to installation, evaluation, and contribution resources.
  * Added clearer pre-contribution steps, including verifying behavior against the latest published package before opening issues or pull requests.
  * Kept existing fork-and-follow contribution guidance in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->