### PR TITLE
fix(abhi): bound archive member imports

### DIFF
--- a/src/waggle/abhi.py
+++ b/src/waggle/abhi.py
@@ -68,6 +68,10 @@ ABHI_MANIFEST_MEMBER = "manifest.json"
 ABHI_SIGNATURE_MEMBER = "signatures/content.ed25519"
 ABHI_PUBLIC_KEY_MEMBER = "signatures/public_key.pem"
 ABHI_DETERMINISTIC_ZIP_TIMESTAMP = (2000, 1, 1, 0, 0, 0)
+ABHI_MAX_MEMBER_PAYLOAD_BYTES = 512 * 1024 * 1024
+ABHI_MAX_ENCRYPTED_MEMBER_BYTES = (ABHI_MAX_MEMBER_PAYLOAD_BYTES * 4 // 3) + (2 * 1024 * 1024)
+ABHI_MAX_MANIFEST_BYTES = 4 * 1024 * 1024
+ABHI_MAX_SIGNATURE_BYTES = 1024 * 1024
 
 ABHI_MERGE_STRATEGIES = (
     "contradict",
@@ -220,14 +224,66 @@ def _decrypt_bytes(payload: dict[str, Any], *, passphrase: str) -> bytes:
         raise ValidationFailure("Could not decrypt .abhi payload. Check the passphrase.") from exc
 
 
+def _format_byte_limit(value: int) -> str:
+    mib = value / (1024 * 1024)
+    return f"{mib:.1f} MiB"
+
+
+def _coerce_manifest_member_size(member_name: str, value: Any) -> int:
+    try:
+        size = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValidationFailure(f"{member_name} has an invalid manifest size.") from exc
+    if size < 0:
+        raise ValidationFailure(f"{member_name} has an invalid negative manifest size.")
+    return size
+
+
+def _read_archive_member_bounded(archive: zipfile.ZipFile, member_name: str, *, max_size: int) -> bytes:
+    try:
+        member_info = archive.getinfo(member_name)
+    except KeyError:
+        return b""
+
+    if member_info.file_size > max_size:
+        raise ValidationFailure(
+            f"{member_name} is too large to import "
+            f"({member_info.file_size} bytes, limit {_format_byte_limit(max_size)})."
+        )
+    return archive.read(member_name)
+
+
 def _read_member(archive: zipfile.ZipFile, manifest: dict[str, Any], member_name: str, *, passphrase: str) -> bytes:
     metadata = dict(manifest.get("members", {}).get(member_name, {}))
-    if member_name not in archive.namelist():
+    declared_size = None
+    if "size" in metadata:
+        declared_size = _coerce_manifest_member_size(member_name, metadata.get("size"))
+        if declared_size > ABHI_MAX_MEMBER_PAYLOAD_BYTES:
+            raise ValidationFailure(
+                f"{member_name} declares an oversized payload "
+                f"({declared_size} bytes, limit {_format_byte_limit(ABHI_MAX_MEMBER_PAYLOAD_BYTES)})."
+            )
+
+    raw = _read_archive_member_bounded(
+        archive,
+        member_name,
+        max_size=ABHI_MAX_ENCRYPTED_MEMBER_BYTES if metadata.get("encrypted") else ABHI_MAX_MEMBER_PAYLOAD_BYTES,
+    )
+    if raw == b"":
         return b""
-    raw = archive.read(member_name)
     if metadata.get("encrypted"):
         payload = json.loads(raw.decode("utf-8"))
-        return _decrypt_bytes(payload, passphrase=passphrase)
+        decrypted = _decrypt_bytes(payload, passphrase=passphrase)
+        if len(decrypted) > ABHI_MAX_MEMBER_PAYLOAD_BYTES:
+            raise ValidationFailure(
+                f"{member_name} decrypted to an oversized payload "
+                f"({len(decrypted)} bytes, limit {_format_byte_limit(ABHI_MAX_MEMBER_PAYLOAD_BYTES)})."
+            )
+        if declared_size is not None and len(decrypted) != declared_size:
+            raise ValidationFailure(f"{member_name} size does not match the manifest.")
+        return decrypted
+    if declared_size is not None and len(raw) != declared_size:
+        raise ValidationFailure(f"{member_name} size does not match the manifest.")
     return raw
 
 
@@ -711,7 +767,11 @@ def load_abhi_document(input_path: str | Path, passphrase: str = "") -> dict[str
     with zipfile.ZipFile(zip_source, "r") as archive:
         if ABHI_MANIFEST_MEMBER not in archive.namelist():
             raise ValidationFailure(f"{source} is missing {ABHI_MANIFEST_MEMBER}.")
-        manifest = json.loads(archive.read(ABHI_MANIFEST_MEMBER).decode("utf-8"))
+        manifest = json.loads(
+            _read_archive_member_bounded(archive, ABHI_MANIFEST_MEMBER, max_size=ABHI_MAX_MANIFEST_BYTES).decode(
+                "utf-8"
+            )
+        )
         _assert_supported_schema_version(str(manifest.get("schema_version", "")))
         document = {
             "manifest": manifest,
@@ -725,8 +785,12 @@ def load_abhi_document(input_path: str | Path, passphrase: str = "") -> dict[str
             ),
         }
         if manifest.get("signatures", {}).get("present"):
-            document["signature"] = archive.read(ABHI_SIGNATURE_MEMBER)
-            document["public_key_pem"] = archive.read(ABHI_PUBLIC_KEY_MEMBER)
+            document["signature"] = _read_archive_member_bounded(
+                archive, ABHI_SIGNATURE_MEMBER, max_size=ABHI_MAX_SIGNATURE_BYTES
+            )
+            document["public_key_pem"] = _read_archive_member_bounded(
+                archive, ABHI_PUBLIC_KEY_MEMBER, max_size=ABHI_MAX_SIGNATURE_BYTES
+            )
         return _with_compat_views(document)
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -12,6 +12,7 @@ import networkx as nx
 import numpy as np
 import pytest
 
+import waggle.abhi as abhi_module
 from waggle.abhi import (
     ABHI_MAGIC,
     diff_abhi_files,
@@ -2208,6 +2209,65 @@ def test_abhi_v1_file_round_trips_through_load(tmp_path: Path) -> None:
     write_abhi_document(_minimal_snapshot(), output_path=out)
     doc = load_abhi_document(out)
     assert "manifest" in doc
+
+
+def test_abhi_read_member_rejects_zip_bomb_metadata_before_read() -> None:
+    class BombArchive:
+        def getinfo(self, member_name: str):
+            return type("ZipInfoStub", (), {"file_size": abhi_module.ABHI_MAX_MEMBER_PAYLOAD_BYTES + 1})()
+
+        def read(self, member_name: str) -> bytes:
+            raise AssertionError("oversized member should be rejected before decompression")
+
+    manifest = {"members": {abhi_module.ABHI_NODES_MEMBER: {}}}
+    with pytest.raises(ValidationFailure, match="too large to import"):
+        abhi_module._read_member(BombArchive(), manifest, abhi_module.ABHI_NODES_MEMBER, passphrase="")
+
+
+def test_abhi_load_rejects_manifest_declared_oversized_member(tmp_path: Path) -> None:
+    archive_path = tmp_path / "oversized.zip"
+    abhi_path = tmp_path / "oversized.abhi"
+    manifest = {
+        "schema_version": abhi_module.ABHI_SPEC_VERSION,
+        "tenant": "test",
+        "agent_id": "",
+        "project": "",
+        "session_id": "",
+        "embedding_model_id": "",
+        "embedding_dim": 0,
+        "encryption": {"enabled": False, "algorithm": ""},
+        "signatures": {"algorithm": "ed25519", "present": False},
+        "scope": "all",
+        "includes_embeddings": False,
+        "export_context": {},
+        "counts": {"transcripts": 0, "nodes": 0, "edges": 0, "context_windows": 0},
+        "members": {
+            abhi_module.ABHI_NODES_MEMBER: {
+                "size": abhi_module.ABHI_MAX_MEMBER_PAYLOAD_BYTES + 1,
+                "encrypted": False,
+            }
+        },
+        "ui": {},
+        "repos": [],
+        "context_window_edges": [],
+        "content_hash": "sha256:0",
+    }
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for member in (
+            abhi_module.ABHI_TRANSCRIPTS_MEMBER,
+            abhi_module.ABHI_NODES_MEMBER,
+            abhi_module.ABHI_EDGES_MEMBER,
+            abhi_module.ABHI_CONTEXT_WINDOWS_MEMBER,
+        ):
+            archive.writestr(abhi_module._deterministic_zip_info(member), b"")
+        archive.writestr(
+            abhi_module._deterministic_zip_info(abhi_module.ABHI_MANIFEST_MEMBER),
+            abhi_module._canonical_json(manifest),
+        )
+    abhi_path.write_bytes(ABHI_MAGIC + archive_path.read_bytes())
+
+    with pytest.raises(ValidationFailure, match="declares an oversized payload"):
+        load_abhi_document(abhi_path)
 
 
 def test_abhi_legacy_v0_bare_zip_still_loads(tmp_path: Path, caplog) -> None:


### PR DESCRIPTION
## Summary

Adds bounded reads for `.abhi` ZIP archive members before decompression.

## Changes

- Checks ZIP central-directory `file_size` before reading archive members.
- Checks manifest-declared data member sizes before loading payloads.
- Bounds manifest, signature, and public-key member reads.
- Validates decrypted/plaintext member sizes and manifest size consistency.
- Adds regression tests for oversized ZIP metadata and manifest-declared oversized payloads.

## Validation

- `/Users/abhigyanshekhar/Desktop/MCP/.venv/bin/python -m pytest tests/test_graph.py -k abhi`
- `/Users/abhigyanshekhar/Desktop/MCP/.venv/bin/python -m ruff check src/waggle/abhi.py tests/test_graph.py`
- `/Users/abhigyanshekhar/Desktop/MCP/.venv/bin/python -m py_compile src/waggle/abhi.py tests/test_graph.py`
- `git diff --check`