### PR TITLE
Fix authentication bypass for protected HTTP routes

### DIFF
--- a/src/waggle/server/mcp.py
+++ b/src/waggle/server/mcp.py
@@ -14,12 +14,6 @@ try:
     from mcp.server.lowlevel.server import request_ctx
 except ImportError:
 
-    class _MissingRequestContext:
-        def get(self) -> Any:
-            raise LookupError
-
-    request_ctx = _MissingRequestContext()
-
 from waggle import __version__
 from waggle.config import AppConfig
 from waggle.embeddings import STATUS_READY

--- a/src/waggle/server/mcp.py
+++ b/src/waggle/server/mcp.py
@@ -13,6 +13,11 @@ from mcp.server.models import InitializationOptions
 try:
     from mcp.server.lowlevel.server import request_ctx
 except ImportError:
+    class _MissingRequestContext:
+        def get(self) -> Any:
+            raise LookupError
+
+    request_ctx = _MissingRequestContext()
 
 from waggle import __version__
 from waggle.config import AppConfig

--- a/src/waggle/server/routes.py
+++ b/src/waggle/server/routes.py
@@ -289,8 +289,9 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
         request: Request, required_scope: str, *, tenant_override: str = ""
     ) -> tuple[Any, Any | None]:
         graph, principal = _graph_from_request(request, tenant_override=tenant_override)
-        if principal is not None:
-            principal.require_scope(required_scope)
+        if principal is None:
+            raise AuthenticationError("Missing X-API-Key header.")
+        principal.require_scope(required_scope)
         return graph, principal
 
     def _build_scoped_abhi(graph: Any, scope: dict[str, str]) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/src/waggle/server/routes.py
+++ b/src/waggle/server/routes.py
@@ -247,8 +247,7 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
             admit_demo_scope(app_server._root_graph, demo_scope)
             graph = app_server._root_graph.for_tenant(demo_scope.tenant_id)
             ensure_demo_seed(graph, proposal_repository, demo_scope)
-            return graph, None
-        raw_api_key = request.headers.get("x-api-key", "").strip()
+            return graph, None        raw_api_key = request.headers.get("x-api-key", "").strip()
         if raw_api_key:
             principal = app_server._root_graph.authenticate_api_key(raw_api_key)
             return app_server._root_graph.for_tenant(principal.tenant_id), principal
@@ -287,7 +286,7 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
 
     def _require_http_scope(
         request: Request, required_scope: str, *, tenant_override: str = ""
-    ) -> tuple[Any, Any | None]:
+    ) -> tuple[Any, Any]:
         graph, principal = _graph_from_request(request, tenant_override=tenant_override)
         if principal is None:
             raise AuthenticationError("Missing X-API-Key header.")

--- a/src/waggle/server/routes.py
+++ b/src/waggle/server/routes.py
@@ -284,9 +284,7 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
             metadata=metadata or {},
         )
 
-    def _require_http_scope(
-        request: Request, required_scope: str, *, tenant_override: str = ""
-    ) -> tuple[Any, Any]:
+    def _require_http_scope(request: Request, required_scope: str, *, tenant_override: str = "") -> tuple[Any, Any]:
         graph, principal = _graph_from_request(request, tenant_override=tenant_override)
         if principal is None:
             raise AuthenticationError("Missing X-API-Key header.")

--- a/src/waggle/server/routes.py
+++ b/src/waggle/server/routes.py
@@ -247,7 +247,8 @@ def create_http_application(app_server: WaggleServer, config: AppConfig) -> Star
             admit_demo_scope(app_server._root_graph, demo_scope)
             graph = app_server._root_graph.for_tenant(demo_scope.tenant_id)
             ensure_demo_seed(graph, proposal_repository, demo_scope)
-            return graph, None        raw_api_key = request.headers.get("x-api-key", "").strip()
+            return graph, None
+        raw_api_key = request.headers.get("x-api-key", "").strip()
         if raw_api_key:
             principal = app_server._root_graph.authenticate_api_key(raw_api_key)
             return app_server._root_graph.for_tenant(principal.tenant_id), principal

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -18,6 +19,7 @@ from waggle.errors import (
     ValidationFailure,
 )
 from waggle.graph import MemoryGraph
+from waggle.metrics import MetricsRegistry
 from waggle.models import NodeType
 from waggle.rate_limit import RateLimiter
 from waggle.server import WaggleServer, create_http_application
@@ -350,6 +352,38 @@ def test_http_app_health_auth_and_metrics(tmp_path: Path) -> None:
 
     audit_events = graph.for_tenant("tenant-http").list_audit_events(limit=10, event_type="api_key.used")
     assert audit_events[0].api_key_id == created.record.api_key_id
+
+
+def test_http_graph_snapshot_requires_api_key_before_route_handler(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    graph = make_graph(tmp_path)
+    config = make_http_config(tmp_path)
+
+    async def run_until_cancelled(*_args: object, **_kwargs: object) -> None:
+        await asyncio.Event().wait()
+
+    app_server = SimpleNamespace(
+        graph=graph,
+        _root_graph=graph,
+        config=config,
+        metrics=MetricsRegistry(),
+        server=SimpleNamespace(run=run_until_cancelled),
+        initialization_options=lambda: None,
+        validate_startup=lambda: None,
+    )
+    app = create_http_application(app_server, app_server.config)
+
+    def fail_if_called(**_kwargs: object) -> dict[str, object]:
+        raise AssertionError("protected graph route continued without authentication")
+
+    monkeypatch.setattr(graph, "get_graph_snapshot", fail_if_called)
+
+    with TestClient(app) as client:
+        response = client.get("/api/graph")
+
+    assert response.status_code == 401
+    assert response.json()["error"] == "authentication_failed"
 
 
 def test_http_app_rate_limit_and_payload_limit(tmp_path: Path) -> None:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -475,6 +475,7 @@ def test_http_graph_delete_edge_requires_graph_write_scope(tmp_path: Path) -> No
 
 def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
     graph = make_graph(tmp_path)
+    graph.tenant_id = "tenant-http"
     insert_transcript_record(
         graph,
         project="studio",
@@ -492,6 +493,8 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
         text="Stored transcript provenance as memory.",
     )
     app_server = WaggleServer(graph=graph, config=make_http_config(tmp_path))
+    created = graph.create_api_key("tenant-http", "http-test")
+    headers = {"X-API-Key": created.raw_api_key}
     app = create_http_application(app_server, app_server.config)
 
     with TestClient(app) as client:
@@ -514,15 +517,16 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
                 "node_type": "note",
                 "project": "studio",
             },
+            headers=headers,
         )
         assert created_node.status_code == 200
         node_id = created_node.json()["id"]
 
-        snapshot = client.get("/api/graph", params={"project": "studio"})
+        snapshot = client.get("/api/graph", params={"project": "studio"}, headers=headers)
         assert snapshot.status_code == 200
         assert len(snapshot.json()["nodes"]) == 1
 
-        abhi_preview = client.get("/api/graph/abhi", params={"project": "studio"})
+        abhi_preview = client.get("/api/graph/abhi", params={"project": "studio"}, headers=headers)
         assert abhi_preview.status_code == 200
         assert "schema" in abhi_preview.json()
         assert abhi_preview.json()["validation"]["valid"] is True
@@ -536,6 +540,7 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
                 "viewport": {"center_x": 140, "center_y": 280},
                 "selected_nodes": [node_id],
             },
+            headers=headers,
         )
         assert saved_ui.status_code == 200
         assert saved_ui.json()["positions"][node_id] == {"x": 140, "y": 280}
@@ -557,14 +562,14 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
                 "edges": [],
                 "ui": {"positions": {node_id: {"x": 220, "y": 120}}, "selected_nodes": [node_id]},
             },
+            headers=headers,
         )
         assert restored.status_code == 200
         assert restored.json()["nodes"][0]["label"] == "HTTP Node Restored"
 
         updated_node = client.patch(
             f"/api/graph/nodes/{node_id}",
-            json={"label": "HTTP Node Updated", "content": "Edited in browser."},
-        )
+            json={"label": "HTTP Node Updated", "content": "Edited in browser."}, headers=headers)
         assert updated_node.status_code == 200
         assert updated_node.json()["label"] == "HTTP Node Updated"
 
@@ -576,6 +581,7 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
                 "node_type": "note",
                 "project": "studio",
             },
+            headers=headers,
         )
         second_id = second_node.json()["id"]
 
@@ -587,6 +593,7 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
                 "relationship": "relates_to",
                 "weight": 1.0,
             },
+            headers=headers,
         )
         assert created_edge.status_code == 200
         edge_id = created_edge.json()["id"]
@@ -599,37 +606,38 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
                 "relationship": "depends_on",
                 "weight": 0.5,
             },
+            headers=headers,
         )
         assert updated_edge.status_code == 200
         assert updated_edge.json()["relationship"] == "depends_on"
 
         query_result = client.post(
             "/api/graph/query",
-            json={"project": "studio", "query": "FIND nodes WHERE type='note' AND content CONTAINS 'browser'"},
+            json={"project": "studio", "query": "FIND nodes WHERE type='note' AND content CONTAINS 'browser'"}, headers=headers
         )
         assert query_result.status_code == 200
         assert len(query_result.json()["nodes"]) == 1
 
-        transcripts = client.get("/api/graph/transcripts", params={"project": "studio"})
+        transcripts = client.get("/api/graph/transcripts", params={"project": "studio"}, headers=headers)
         assert transcripts.status_code == 200
         assert transcripts.json()["records"]
 
-        transcript_search = client.get("/api/graph/transcripts", params={"project": "studio", "query": "provenance"})
+        transcript_search = client.get("/api/graph/transcripts", params={"project": "studio", "query": "provenance"}, headers=headers)
         assert transcript_search.status_code == 200
         assert transcript_search.json()["hits"]
 
         retrieval_debug = client.post(
             "/api/graph/retrieval-debug",
-            json={"project": "studio", "query": "browser provenance", "max_nodes": 4, "max_depth": 1},
+            json={"project": "studio", "query": "browser provenance", "max_nodes": 4, "max_depth": 1}, headers=headers
         )
         assert retrieval_debug.status_code == 200
         assert "fusion_hits" in retrieval_debug.json()
 
-        diff_result = client.get("/api/graph/diff", params={"since": "24h"})
+        diff_result = client.get("/api/graph/diff", params={"since": "24h"}, headers=headers)
         assert diff_result.status_code == 200
         assert len(diff_result.json()["added_nodes"]) >= 2
 
-        exported_abhi = client.get("/api/graph/export", params={"format": "abhi", "project": "studio"})
+        exported_abhi = client.get("/api/graph/export", params={"format": "abhi", "project": "studio"}, headers=headers)
         assert exported_abhi.status_code == 200
         assert exported_abhi.content.startswith(b"WGL\x01")
         assert exported_abhi.headers["content-disposition"] == 'attachment; filename="waggle-memory.abhi"'
@@ -637,7 +645,7 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
 
         import_preview = client.post(
             "/api/graph/abhi/preview-import",
-            json={"format": "abhi", "content_base64": exported_abhi_b64},
+            json={"format": "abhi", "content_base64": exported_abhi_b64}, headers=headers
         )
         assert import_preview.status_code == 200
         assert import_preview.json()["validation"]["valid"] is True
@@ -645,15 +653,15 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
 
         abhi_diff = client.post(
             "/api/graph/abhi/diff",
-            json={"content_a_base64": exported_abhi_b64, "content_b_base64": exported_abhi_b64},
+            json={"content_a_base64": exported_abhi_b64, "content_b_base64": exported_abhi_b64}, headers=headers
         )
         assert abhi_diff.status_code == 200
         assert "diff" in abhi_diff.json()
 
-        deleted_edge = client.delete(f"/api/graph/edges/{edge_id}")
+        deleted_edge = client.delete(f"/api/graph/edges/{edge_id}", headers=headers)
         assert deleted_edge.status_code == 200
 
-        deleted_node = client.delete(f"/api/graph/nodes/{second_id}")
+        deleted_node = client.delete(f"/api/graph/nodes/{second_id}", headers=headers)
         assert deleted_node.status_code == 200
 
     audit_events = graph.list_audit_events(limit=50)
@@ -668,6 +676,8 @@ def test_http_graph_editor_routes_and_crud(tmp_path: Path) -> None:
 def test_http_admin_retention_and_audit_endpoints(tmp_path: Path) -> None:
     graph = make_graph(tmp_path)
     app_server = WaggleServer(graph=graph, config=make_http_config(tmp_path, backend="sqlite", transport="http"))
+    created = graph.create_api_key("workspace-a", "http-admin-test")
+    headers = {"X-API-Key": created.raw_api_key}
     app = create_http_application(app_server, app_server.config)
 
     with TestClient(app) as client:
@@ -679,25 +689,25 @@ def test_http_admin_retention_and_audit_endpoints(tmp_path: Path) -> None:
                 "retention_days": 90,
                 "prune_interval_hours": 24,
             },
+            headers=headers,
         )
         assert update.status_code == 200
         assert update.json()["enabled"] is True
 
-        status = client.get("/api/admin/retention", params={"tenant_id": "workspace-a"})
+        status = client.get("/api/admin/retention", params={"tenant_id": "workspace-a"}, headers=headers)
         assert status.status_code == 200
         assert status.json()["retention_days"] == 90
 
-        prune = client.post("/api/admin/retention/prune", json={"tenant_id": "workspace-a", "batch_size": 1000})
+        prune = client.post("/api/admin/retention/prune", json={"tenant_id": "workspace-a", "batch_size": 1000}, headers=headers)
         assert prune.status_code == 200
         assert prune.json()["status"] in {"completed", "skipped"}
 
-        runs = client.get("/api/admin/retention/runs", params={"tenant_id": "workspace-a", "limit": 10})
+        runs = client.get("/api/admin/retention/runs", params={"tenant_id": "workspace-a", "limit": 10}, headers=headers)
         assert runs.status_code == 200
         assert runs.json()
 
         audit = client.get(
-            "/api/admin/audit-events", params={"tenant_id": "workspace-a", "type": "retention.policy.updated"}
-        )
+            "/api/admin/audit-events", params={"tenant_id": "workspace-a", "type": "retention.policy.updated"}, headers=headers)
         assert audit.status_code == 200
         assert audit.json()[0]["event_type"] == "retention.policy.updated"
 


### PR DESCRIPTION
## Summary

This PR fixes an authentication bypass affecting protected HTTP routes.

Previously, `_require_http_scope()` only enforced scope checks when a principal was present. If a request omitted the `X-API-Key` header, the request could continue without authentication.

## Changes

- Require an authenticated principal before enforcing scopes.
- Raise `AuthenticationError` when `X-API-Key` is missing on protected HTTP routes.

## Testing

- Ran the existing server test suite:

```text
python -m pytest tests/test_server.py

89 passed
```text
Fixes #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests missing an API key are now rejected with a clear 401 authentication error.
  * Protected API routes now consistently enforce authentication before processing requests.
  * Authenticated requests continue to be checked against required access permissions.
  * Authentication behavior is more consistent across graph, retention, and audit endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->