### PR TITLE
docs: sync Codex release references

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "waggle",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Persistent graph-backed conversational memory for Codex.",
   "author": {
     "name": "Abhigyan Shekhar"

--- a/README.md
+++ b/README.md
@@ -406,9 +406,9 @@ users download the marketplace zip from GitHub Releases, add it to Codex, and
 the bundled MCP runtime runs on their own machine.
 
 The easiest install path is the Codex app plugin marketplace bundle published
-on the [`v0.1.17` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.17):
-download `waggle-codex-marketplace-v0.1.17.zip`, extract it, then run
-`codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.17` and
+on the [`v0.1.18` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.18):
+download `waggle-codex-marketplace-v0.1.18.zip`, extract it, then run
+`codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.18` and
 install `Waggle` from the added marketplace. The runtime is intentionally
 unsigned, so macOS Gatekeeper or Windows SmartScreen may show a first-run
 warning; verify the checksum or GitHub attestation before approving it.

--- a/docs/codex-plugin-runtime.md
+++ b/docs/codex-plugin-runtime.md
@@ -110,8 +110,8 @@ publishing. `.sha256` files remain a manual verification fallback.
 ## Versioning
 
 The Codex plugin manifest version is intentionally separate from the GitHub
-release tag. The current plugin version is `0.1.1`; the current public GitHub
-release tag for the complete Codex marketplace bundle is `v0.1.17`.
+release tag. The current plugin version is `0.1.2`; the current public GitHub
+release tag for the complete Codex marketplace bundle is `v0.1.18`.
 
 Earlier GitHub releases were trial releases while the Waggle repository was
 private. Do not align the plugin version to the GitHub tag unless the plugin

--- a/docs/install/codex-marketplace-release-checklist.md
+++ b/docs/install/codex-marketplace-release-checklist.md
@@ -6,8 +6,8 @@ users add with `codex plugin marketplace add`.
 
 ## Version Policy
 
-- Codex plugin version: `0.1.1`
-- GitHub release tag used for the current public Codex bundle: `v0.1.17`
+- Codex plugin version: `0.1.2`
+- GitHub release tag used for the current public Codex bundle: `v0.1.18`
 - These versions are intentionally separate. The GitHub tag follows the main
   repository release history, including earlier private-repository trial
   releases. The Codex plugin manifest version tracks the plugin surface itself.
@@ -36,7 +36,7 @@ Run these from the repository root:
 
 ```bash
 python3 scripts/build_codex_plugin_runtime.py --require-artifacts
-python3 scripts/package_codex_plugin.py --bundle-version v0.1.17 --output-dir dist/codex-plugin
+python3 scripts/package_codex_plugin.py --bundle-version v0.1.18 --output-dir dist/codex-plugin
 python3 -m pytest tests/test_package_codex_plugin.py tests/test_packaging_metadata.py -q
 ```
 
@@ -57,11 +57,11 @@ Also confirm a basic memory round trip:
 
 Expected files:
 
-- `waggle-codex-marketplace-v0.1.17.zip`
-- `waggle-codex-marketplace-v0.1.17.zip.sha256`
-- `waggle-codex-plugin-v0.1.17.zip`
-- `waggle-codex-plugin-v0.1.17.zip.sha256`
-- `waggle-codex-release-v0.1.17.json`
+- `waggle-codex-marketplace-v0.1.18.zip`
+- `waggle-codex-marketplace-v0.1.18.zip.sha256`
+- `waggle-codex-plugin-v0.1.18.zip`
+- `waggle-codex-plugin-v0.1.18.zip.sha256`
+- `waggle-codex-release-v0.1.18.json`
 
 The marketplace zip is the primary user-facing artifact. The bare plugin zip is
 for debugging, audits, and future installer compatibility.
@@ -91,14 +91,14 @@ Because the runtime is unsigned:
   directory listing or signed native installer.
 - State that the default install path has no required hosting or certificate
   cost.
-- Link users to the `v0.1.17` GitHub release.
+- Link users to the `v0.1.18` GitHub release.
 - Tell users to download the marketplace zip, extract it, and run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.17
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.18
 ```
 
 - State clearly that `v0.1.16` was a partial trial release and should not be
   used as a Codex marketplace install source.
-- State clearly that the plugin version shown in Codex is `0.1.1`, while the
-  GitHub release tag is `v0.1.17`.
+- State clearly that the plugin version shown in Codex is `0.1.2`, while the
+  GitHub release tag is `v0.1.18`.

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -93,27 +93,27 @@ binary is stale or missing, reinstall or upgrade the Waggle Codex plugin.
 
 Tagged Waggle releases publish two Codex plugin assets. The current Codex
 marketplace artifacts are published on the
-[`v0.1.17` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.17):
+[`v0.1.18` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.18):
 
-- `waggle-codex-marketplace-v0.1.17.zip`: a complete local marketplace root that
+- `waggle-codex-marketplace-v0.1.18.zip`: a complete local marketplace root that
   can be added with `codex plugin marketplace add`
 - `waggle-codex-plugin-<tag>.zip`: the bare `plugins/waggle` plugin folder
 - `waggle-codex-release-<tag>.json`: release metadata for audit and support
 
 > `v0.1.16` was a partial release and should not be used as a Codex
-> marketplace install source. Use `v0.1.17` instead.
+> marketplace install source. Use `v0.1.18` instead.
 
 The Codex plugin version is intentionally separate from the GitHub release tag.
-The plugin manifest currently reports `0.1.1`; `v0.1.17` is the GitHub release
+The plugin manifest currently reports `0.1.2`; `v0.1.18` is the GitHub release
 tag for the public marketplace bundle after earlier private-repository trial
 releases.
 
 For the easiest install path, download and extract the marketplace bundle
-from the [`v0.1.17` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.17),
+from the [`v0.1.18` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.18),
 then run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.17
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.18
 ```
 
 After that, refresh the plugin directory in Codex and install `Waggle` from the

--- a/plugins/waggle/.codex-plugin/plugin.json
+++ b/plugins/waggle/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "waggle",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Persistent graph-backed conversational memory for Codex.",
   "author": {
     "name": "Abhigyan Shekhar"

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -104,8 +104,8 @@ def test_codex_release_docs_record_intentional_version_split_and_unsigned_policy
     checklist = (ROOT / "docs" / "install" / "codex-marketplace-release-checklist.md").read_text()
 
     for text in [codex_guide, runtime_guide, checklist]:
-        assert "0.1.1" in text
-        assert "v0.1.17" in text
+        assert "0.1.2" in text
+        assert "v0.1.18" in text
 
     assert "intentionally unsigned" in codex_guide
     assert "intentionally unsigned" in runtime_guide


### PR DESCRIPTION
## Summary
- update Codex install docs/checklist from v0.1.17 to v0.1.18
- bump Codex plugin manifests from 0.1.1 to 0.1.2 to match the published v0.1.18 release manifest
- update packaging metadata test expectations

## Verification
- gh release view v0.1.18 confirms published marketplace/plugin zips, checksums, release manifest, VSIX, and MCPB assets
- gh run list confirms the v0.1.18 Codex plugin runtime workflow completed successfully
- python3 -m pytest tests/test_package_codex_plugin.py tests/test_packaging_metadata.py -q

## Notes
- source-clone packaging still requires CI/runtime artifacts under plugins/waggle/runtime/* before scripts/package_codex_plugin.py can produce local bundles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Codex plugin release to version 0.1.2.
  * Updated marketplace installation guidance to release v0.1.18.
* **Documentation**
  * Refreshed installation instructions, upgrade guidance, release links, artifact names, and version references.
  * Updated the release checklist with the latest packaging and announcement details.
* **Tests**
  * Updated release metadata validation for the new plugin and marketplace versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->