### PR TITLE
fix: persist conflict records in merged ABHI documents

### DIFF
--- a/src/waggle/abhi.py
+++ b/src/waggle/abhi.py
@@ -497,6 +497,7 @@ def build_abhi_document(
     low_confidence_threshold: float = 0.7,
     strict_export: bool = False,
     include_deps: bool = False,
+    conflict_records: list[MergeConflictRecord] | None = None,
 ) -> dict[str, Any]:
     redact_patterns = redact_patterns or []
     filtered = _scope_filter(
@@ -607,6 +608,7 @@ def build_abhi_document(
         "ui": deepcopy(filtered.get("ui", {})),
         "repos": repos,
         "context_window_edges": context_window_edges,
+        "conflict_records": [rec.model_dump(mode="json") for rec in (conflict_records or [])],
     }
     document = {
         "manifest": manifest,
@@ -768,6 +770,7 @@ def write_abhi_document(
     low_confidence_threshold: float = 0.7,
     strict_export: bool = False,
     include_deps: bool = False,
+    conflict_records: list[MergeConflictRecord] | None = None,
 ) -> AbhiExportResult:
     destination = Path(output_path).expanduser()
     destination.parent.mkdir(parents=True, exist_ok=True)
@@ -785,6 +788,7 @@ def write_abhi_document(
         low_confidence_threshold=low_confidence_threshold,
         strict_export=strict_export,
         include_deps=include_deps,
+        conflict_records=conflict_records,
     )
     manifest = document["manifest"]
     # Write the ZIP to a temp file first, then stream magic + ZIP to the final
@@ -1580,7 +1584,12 @@ def merge_abhi_documents(
             contradict_edges_added=len(contradict_edges),
         )
 
-    exported = write_abhi_document(merged_snapshot, output_path=output_path, passphrase=passphrase)
+    exported = write_abhi_document(
+        merged_snapshot,
+        output_path=output_path,
+        passphrase=passphrase,
+        conflict_records=conflict_records,
+    )
 
     # Hash verification
     hash_verified = False


### PR DESCRIPTION
## Summary

- Merged ABHI documents dropped conflict records, so conflicts were never persisted and resolve always failed. Thread conflict_records through build/write and expose them in the manifest.

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q` (targeted suites)

### Test report

```text
47 passed in 2.53s (test_ingest_transcript_handoff)
```
