### PR TITLE
Fix v0.1.20 release workflows

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -14,6 +14,8 @@ jobs:
   build-and-push:
     name: Build & push pre-baked image
     runs-on: ubuntu-latest
+    outputs:
+      image-version: ${{ steps.meta.outputs.version }}
 
     steps:
       - name: Checkout source
@@ -50,6 +52,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           # GitHub Actions layer cache — dramatically speeds up repeat builds
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -65,16 +69,17 @@ jobs:
     steps:
       - name: Pull published image
         run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/waggle-mcp:${{ github.ref_name }}
+          docker pull ghcr.io/${{ github.repository_owner }}/waggle-mcp:${{ needs.build-and-push.outputs.image-version }}
 
       - name: Verify tool listing responds instantly (fast mode)
         run: |
           # Fast mode must respond within 5 s with zero ML overhead
           timeout 5 docker run --rm \
+            --entrypoint python \
             -e WAGGLE_STARTUP_MODE=fast \
             -e WAGGLE_TRANSPORT=stdio \
-            ghcr.io/${{ github.repository_owner }}/waggle-mcp:${{ github.ref_name }} \
-            python -c "
+            ghcr.io/${{ github.repository_owner }}/waggle-mcp:${{ needs.build-and-push.outputs.image-version }} \
+            -c "
           from waggle.config import AppConfig
           from waggle.server import WaggleServer
           import os

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -73,7 +73,7 @@ jobs:
             --onefile \
             --name "${{ matrix.executable_name }}" \
             --collect-all waggle \
-            src/waggle/server.py
+            src/waggle/entrypoints/cli.py
 
       - name: Smoke test binary
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,17 @@ ENV PIP_NO_CACHE_DIR=1
 
 WORKDIR /build
 
-# 1) Copy only dependency metadata first so Docker layer caching is preserved
+# 1) Copy package metadata and source before installation. Setuptools inspects
+# the configured src layout while preparing the editable wheel.
 COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
 
-# 2) Install dependencies before copying source code
+# 2) Install the package and its runtime dependencies
 RUN pip install --upgrade pip && \
     pip install torch --index-url https://download.pytorch.org/whl/cpu && \
     pip install ".[neo4j]"
 
-# 3) Copy source code (changes here won't bust the dep layer)
-COPY src ./src
-
-# 4) Pre-download the embedding model so it is baked into the image layer
+# 3) Pre-download the embedding model so it is baked into the image layer
 RUN HF_HOME=/root/.cache/huggingface \
     SENTENCE_TRANSFORMERS_HOME=/root/.cache/sentence-transformers \
     python -c "from sentence_transformers import SentenceTransformer; \

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Python runtime, so plugin users do not need Python, `pipx`, a Waggle account, or
 an API key.
 
 ```bash
-curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.19/waggle-codex-marketplace-v0.1.19.zip -o waggle-codex-marketplace-v0.1.19.zip
-curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.19/waggle-codex-marketplace-v0.1.19.zip.sha256 -o waggle-codex-marketplace-v0.1.19.zip.sha256
-shasum -a 256 -c waggle-codex-marketplace-v0.1.19.zip.sha256
-unzip waggle-codex-marketplace-v0.1.19.zip
-codex plugin marketplace add "$(pwd)/waggle-codex-marketplace-v0.1.19"
+curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.20/waggle-codex-marketplace-v0.1.20.zip -o waggle-codex-marketplace-v0.1.20.zip
+curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.20/waggle-codex-marketplace-v0.1.20.zip.sha256 -o waggle-codex-marketplace-v0.1.20.zip.sha256
+shasum -a 256 -c waggle-codex-marketplace-v0.1.20.zip.sha256
+unzip waggle-codex-marketplace-v0.1.20.zip
+codex plugin marketplace add "$(pwd)/waggle-codex-marketplace-v0.1.20"
 codex plugin add waggle@waggle
 ```
 

--- a/docs/codex-plugin-runtime.md
+++ b/docs/codex-plugin-runtime.md
@@ -82,7 +82,8 @@ python scripts/build_codex_plugin_runtime.py --require-artifacts
 Validation enforces:
 
 - all five target binaries are present
-- each target runtime directory is no larger than 80 MB
+- each launcher executable is no larger than 80 MiB
+- each onedir runtime directory is no larger than 192 MiB
 - Unix runtimes keep executable permissions after packaging
 - `--server-info` starts within 10 seconds and emits compatibility metadata when
   `--probe` is run on a native runner
@@ -118,7 +119,7 @@ publishing. `.sha256` files remain a manual verification fallback.
 
 The Codex plugin manifest version is intentionally separate from the GitHub
 release tag. The Codex skills release uses plugin version `0.1.3` and GitHub
-release tag `v0.1.19` for the complete marketplace bundle.
+release tag `v0.1.20` for the complete marketplace bundle.
 
 Earlier GitHub releases were trial releases while the Waggle repository was
 private. Do not align the plugin version to the GitHub tag unless the plugin

--- a/docs/install/codex-marketplace-release-checklist.md
+++ b/docs/install/codex-marketplace-release-checklist.md
@@ -7,7 +7,7 @@ users add with `codex plugin marketplace add`.
 ## Version Policy
 
 - Codex plugin version: `0.1.3`
-- GitHub release tag for the Codex skills bundle: `v0.1.19`
+- GitHub release tag for the Codex skills bundle: `v0.1.20`
 - These versions are intentionally separate. The GitHub tag follows the main
   repository release history, including earlier private-repository trial
   releases. The Codex plugin manifest version tracks the plugin surface itself.
@@ -36,7 +36,7 @@ Run these from the repository root:
 
 ```bash
 python3 scripts/build_codex_plugin_runtime.py --require-artifacts
-python3 scripts/package_codex_plugin.py --bundle-version v0.1.19 --output-dir dist/codex-plugin
+python3 scripts/package_codex_plugin.py --bundle-version v0.1.20 --output-dir dist/codex-plugin
 python3 -m pytest tests/test_package_codex_plugin.py tests/test_packaging_metadata.py -q
 ```
 
@@ -45,7 +45,7 @@ development checkout—and follow the public path exactly:
 
 1. Download the published marketplace ZIP and checksum.
 2. Verify and extract it into a new directory.
-3. Run `codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.19`.
+3. Run `codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.20`.
 4. Run `codex plugin add waggle@waggle`.
 5. Start a new Codex task in an unrelated existing repository.
 6. Confirm Codex exposes:
@@ -84,11 +84,11 @@ Also confirm a direct scoped round trip:
 
 Expected files:
 
-- `waggle-codex-marketplace-v0.1.19.zip`
-- `waggle-codex-marketplace-v0.1.19.zip.sha256`
-- `waggle-codex-plugin-v0.1.19.zip`
-- `waggle-codex-plugin-v0.1.19.zip.sha256`
-- `waggle-codex-release-v0.1.19.json`
+- `waggle-codex-marketplace-v0.1.20.zip`
+- `waggle-codex-marketplace-v0.1.20.zip.sha256`
+- `waggle-codex-plugin-v0.1.20.zip`
+- `waggle-codex-plugin-v0.1.20.zip.sha256`
+- `waggle-codex-release-v0.1.20.json`
 
 The marketplace zip is the primary user-facing artifact. The bare plugin zip is
 for debugging, audits, and future installer compatibility.
@@ -118,15 +118,15 @@ Because the runtime is unsigned:
   directory listing or signed native installer.
 - State that the default install path has no required hosting or certificate
   cost.
-- Link users to the `v0.1.19` GitHub release.
+- Link users to the `v0.1.20` GitHub release.
 - Tell users to download the marketplace zip, extract it, and run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.19
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.20
 codex plugin add waggle@waggle
 ```
 
-- State clearly that `v0.1.16` was a partial trial release and should not be
-  used as a Codex marketplace install source.
+- State clearly that `v0.1.16` and `v0.1.19` were partial releases and should
+  not be used as Codex marketplace install sources.
 - State clearly that the plugin version shown in Codex is `0.1.3`, while the
-  GitHub release tag is `v0.1.19`.
+  GitHub release tag is `v0.1.20`.

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -93,26 +93,26 @@ binary is stale or missing, reinstall or upgrade the Waggle Codex plugin.
 
 Tagged Waggle releases publish two Codex plugin assets. The current Codex
 marketplace artifacts are published on the
-[`v0.1.19` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.19):
+[`v0.1.20` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.20):
 
-- `waggle-codex-marketplace-v0.1.19.zip`: a complete local marketplace root that
+- `waggle-codex-marketplace-v0.1.20.zip`: a complete local marketplace root that
   can be added with `codex plugin marketplace add`
 - `waggle-codex-plugin-<tag>.zip`: the bare `plugins/waggle` plugin folder
 - `waggle-codex-release-<tag>.json`: release metadata for audit and support
 
-> `v0.1.16` was a partial release and should not be used as a Codex
-> marketplace install source. Use `v0.1.19` instead.
+> `v0.1.16` and `v0.1.19` were partial releases and should not be used as Codex
+> marketplace install sources. Use `v0.1.20` instead.
 
 The Codex plugin version is intentionally separate from the GitHub release tag.
-The plugin manifest reports `0.1.3`; `v0.1.19` is the GitHub release tag for
+The plugin manifest reports `0.1.3`; `v0.1.20` is the GitHub release tag for
 the marketplace bundle containing the Codex memory skills.
 
 For the easiest install path, download and extract the marketplace bundle
-from the [`v0.1.19` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.19),
+from the [`v0.1.20` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.20),
 then run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.19
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.20
 ```
 
 After that, refresh the plugin directory in Codex and install `Waggle` from the

--- a/scripts/build_codex_plugin_runtime.py
+++ b/scripts/build_codex_plugin_runtime.py
@@ -15,6 +15,7 @@ RUNTIME_ROOT = PLUGIN_ROOT / "runtime"
 LAUNCHER_PATH = PLUGIN_ROOT / "bin" / "waggle-server-launcher.js"
 ENTRYPOINT = ROOT / "src" / "waggle" / "entrypoints" / "server_only.py"
 MAX_BINARY_BYTES = 80 * 1024 * 1024
+MAX_RUNTIME_DIRECTORY_BYTES = 192 * 1024 * 1024
 STARTUP_TIMEOUT_SECONDS = 10.0
 BUILD_TIMEOUT_SECONDS = 600.0
 BUNDLE_MODE = "onedir"
@@ -172,8 +173,11 @@ def validate_layout(require_artifacts: bool, probe: bool, verify_signatures: boo
         if size > MAX_BINARY_BYTES:
             failures.append(f"{binary.relative_to(ROOT)} is {size} bytes; limit is {MAX_BINARY_BYTES}")
         target_size = _path_size(target_dir)
-        if target_size > MAX_BINARY_BYTES:
-            failures.append(f"{target_dir.relative_to(ROOT)} is {target_size} bytes; limit is {MAX_BINARY_BYTES}")
+        if target_size > MAX_RUNTIME_DIRECTORY_BYTES:
+            failures.append(
+                f"{target_dir.relative_to(ROOT)} is {target_size} bytes; "
+                f"limit is {MAX_RUNTIME_DIRECTORY_BYTES}"
+            )
 
         if probe and target == current_target:
             started_at = time.monotonic()

--- a/src/waggle/entrypoints/cli.py
+++ b/src/waggle/entrypoints/cli.py
@@ -1,0 +1,6 @@
+"""Standalone entrypoint for the full Waggle command-line interface."""
+
+from waggle.server.cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -27,6 +27,26 @@ def test_dockerfile_uses_module_entrypoint_for_arg_passthrough() -> None:
     assert "HF_HOME=/app/.cache/huggingface" in dockerfile
     assert "SENTENCE_TRANSFORMERS_HOME=/app/.cache/sentence-transformers" in dockerfile
     assert "SentenceTransformer('all-MiniLM-L6-v2')" in dockerfile
+    assert dockerfile.index("COPY src ./src") < dockerfile.index('pip install ".[neo4j]"')
+
+
+def test_release_workflows_use_current_entrypoints_and_versioned_image() -> None:
+    binary_workflow = (ROOT / ".github" / "workflows" / "release-binaries.yml").read_text()
+    image_workflow = (ROOT / ".github" / "workflows" / "publish-image.yml").read_text()
+
+    assert "src/waggle/entrypoints/cli.py" in binary_workflow
+    assert "src/waggle/server.py" not in binary_workflow
+    assert "image-version: ${{ steps.meta.outputs.version }}" in image_workflow
+    assert "VERSION=${{ steps.meta.outputs.version }}" in image_workflow
+    assert "${{ needs.build-and-push.outputs.image-version }}" in image_workflow
+    assert "--entrypoint python" in image_workflow
+
+
+def test_codex_onedir_runtime_has_separate_size_budget() -> None:
+    from scripts.build_codex_plugin_runtime import MAX_BINARY_BYTES, MAX_RUNTIME_DIRECTORY_BYTES
+
+    assert MAX_BINARY_BYTES == 80 * 1024 * 1024
+    assert MAX_RUNTIME_DIRECTORY_BYTES == 192 * 1024 * 1024
 
 
 def test_smithery_uses_packaged_cli_entrypoint() -> None:
@@ -105,7 +125,7 @@ def test_codex_release_docs_record_intentional_version_split_and_unsigned_policy
 
     for text in [codex_guide, runtime_guide, checklist]:
         assert "0.1.3" in text
-        assert "v0.1.19" in text
+        assert "v0.1.20" in text
 
     assert "intentionally unsigned" in codex_guide
     assert "intentionally unsigned" in runtime_guide


### PR DESCRIPTION
## What changed

Repairs release automation exposed by the partial v0.1.19 publication.

- Copies the `src/` layout before Docker package installation and passes the generated image version into build labels and smoke tests.
- Builds legacy release binaries through a dedicated full-CLI entrypoint rather than the removed `src/waggle/server.py`.
- Keeps the 80 MiB executable guardrail while allowing the documented 192 MiB onedir runtime layout.
- Advances Codex marketplace documentation to v0.1.20 and marks v0.1.19 as partial.

## Why

v0.1.19 published only extension assets: the container build could not find `src/`, the legacy binaries referenced a removed entrypoint, and Codex onedir artifacts exceeded the former one-file size limit.

## Validation

- `906 passed, 7 skipped`
- Focused packaging tests: `21 passed`
- Ruff, workflow YAML parsing, diff checks
- Full CLI entrypoint `--help` and `doctor --help` smoke tests

The cross-platform release builds remain validated by the tag-triggered workflow after merge.