### PR TITLE
Fix release binary doctor smoke test

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -83,7 +83,6 @@ jobs:
         run: |
           "${{ matrix.artifact_path }}" --help
           "${{ matrix.artifact_path }}" doctor --help
-          "${{ matrix.artifact_path }}" doctor
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Python runtime, so plugin users do not need Python, `pipx`, a Waggle account, or
 an API key.
 
 ```bash
-curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.20/waggle-codex-marketplace-v0.1.20.zip -o waggle-codex-marketplace-v0.1.20.zip
-curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.20/waggle-codex-marketplace-v0.1.20.zip.sha256 -o waggle-codex-marketplace-v0.1.20.zip.sha256
-shasum -a 256 -c waggle-codex-marketplace-v0.1.20.zip.sha256
-unzip waggle-codex-marketplace-v0.1.20.zip
-codex plugin marketplace add "$(pwd)/waggle-codex-marketplace-v0.1.20"
+curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.21/waggle-codex-marketplace-v0.1.21.zip -o waggle-codex-marketplace-v0.1.21.zip
+curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.21/waggle-codex-marketplace-v0.1.21.zip.sha256 -o waggle-codex-marketplace-v0.1.21.zip.sha256
+shasum -a 256 -c waggle-codex-marketplace-v0.1.21.zip.sha256
+unzip waggle-codex-marketplace-v0.1.21.zip
+codex plugin marketplace add "$(pwd)/waggle-codex-marketplace-v0.1.21"
 codex plugin add waggle@waggle
 ```
 

--- a/docs/codex-plugin-runtime.md
+++ b/docs/codex-plugin-runtime.md
@@ -119,7 +119,7 @@ publishing. `.sha256` files remain a manual verification fallback.
 
 The Codex plugin manifest version is intentionally separate from the GitHub
 release tag. The Codex skills release uses plugin version `0.1.3` and GitHub
-release tag `v0.1.20` for the complete marketplace bundle.
+release tag `v0.1.21` for the complete marketplace bundle.
 
 Earlier GitHub releases were trial releases while the Waggle repository was
 private. Do not align the plugin version to the GitHub tag unless the plugin

--- a/docs/install/codex-marketplace-release-checklist.md
+++ b/docs/install/codex-marketplace-release-checklist.md
@@ -7,7 +7,7 @@ users add with `codex plugin marketplace add`.
 ## Version Policy
 
 - Codex plugin version: `0.1.3`
-- GitHub release tag for the Codex skills bundle: `v0.1.20`
+- GitHub release tag for the Codex skills bundle: `v0.1.21`
 - These versions are intentionally separate. The GitHub tag follows the main
   repository release history, including earlier private-repository trial
   releases. The Codex plugin manifest version tracks the plugin surface itself.
@@ -36,7 +36,7 @@ Run these from the repository root:
 
 ```bash
 python3 scripts/build_codex_plugin_runtime.py --require-artifacts
-python3 scripts/package_codex_plugin.py --bundle-version v0.1.20 --output-dir dist/codex-plugin
+python3 scripts/package_codex_plugin.py --bundle-version v0.1.21 --output-dir dist/codex-plugin
 python3 -m pytest tests/test_package_codex_plugin.py tests/test_packaging_metadata.py -q
 ```
 
@@ -45,7 +45,7 @@ development checkout—and follow the public path exactly:
 
 1. Download the published marketplace ZIP and checksum.
 2. Verify and extract it into a new directory.
-3. Run `codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.20`.
+3. Run `codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.21`.
 4. Run `codex plugin add waggle@waggle`.
 5. Start a new Codex task in an unrelated existing repository.
 6. Confirm Codex exposes:
@@ -84,11 +84,11 @@ Also confirm a direct scoped round trip:
 
 Expected files:
 
-- `waggle-codex-marketplace-v0.1.20.zip`
-- `waggle-codex-marketplace-v0.1.20.zip.sha256`
-- `waggle-codex-plugin-v0.1.20.zip`
-- `waggle-codex-plugin-v0.1.20.zip.sha256`
-- `waggle-codex-release-v0.1.20.json`
+- `waggle-codex-marketplace-v0.1.21.zip`
+- `waggle-codex-marketplace-v0.1.21.zip.sha256`
+- `waggle-codex-plugin-v0.1.21.zip`
+- `waggle-codex-plugin-v0.1.21.zip.sha256`
+- `waggle-codex-release-v0.1.21.json`
 
 The marketplace zip is the primary user-facing artifact. The bare plugin zip is
 for debugging, audits, and future installer compatibility.
@@ -118,15 +118,15 @@ Because the runtime is unsigned:
   directory listing or signed native installer.
 - State that the default install path has no required hosting or certificate
   cost.
-- Link users to the `v0.1.20` GitHub release.
+- Link users to the `v0.1.21` GitHub release.
 - Tell users to download the marketplace zip, extract it, and run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.20
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.21
 codex plugin add waggle@waggle
 ```
 
 - State clearly that `v0.1.16` and `v0.1.19` were partial releases and should
   not be used as Codex marketplace install sources.
 - State clearly that the plugin version shown in Codex is `0.1.3`, while the
-  GitHub release tag is `v0.1.20`.
+  GitHub release tag is `v0.1.21`.

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -93,26 +93,26 @@ binary is stale or missing, reinstall or upgrade the Waggle Codex plugin.
 
 Tagged Waggle releases publish two Codex plugin assets. The current Codex
 marketplace artifacts are published on the
-[`v0.1.20` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.20):
+[`v0.1.21` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.21):
 
-- `waggle-codex-marketplace-v0.1.20.zip`: a complete local marketplace root that
+- `waggle-codex-marketplace-v0.1.21.zip`: a complete local marketplace root that
   can be added with `codex plugin marketplace add`
 - `waggle-codex-plugin-<tag>.zip`: the bare `plugins/waggle` plugin folder
 - `waggle-codex-release-<tag>.json`: release metadata for audit and support
 
 > `v0.1.16` and `v0.1.19` were partial releases and should not be used as Codex
-> marketplace install sources. Use `v0.1.20` instead.
+> marketplace install sources. Use `v0.1.21` instead.
 
 The Codex plugin version is intentionally separate from the GitHub release tag.
-The plugin manifest reports `0.1.3`; `v0.1.20` is the GitHub release tag for
+The plugin manifest reports `0.1.3`; `v0.1.21` is the GitHub release tag for
 the marketplace bundle containing the Codex memory skills.
 
 For the easiest install path, download and extract the marketplace bundle
-from the [`v0.1.20` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.20),
+from the [`v0.1.21` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.21),
 then run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.20
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.21
 ```
 
 After that, refresh the plugin directory in Codex and install `Waggle` from the

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -36,6 +36,8 @@ def test_release_workflows_use_current_entrypoints_and_versioned_image() -> None
 
     assert "src/waggle/entrypoints/cli.py" in binary_workflow
     assert "src/waggle/server.py" not in binary_workflow
+    assert '"${{ matrix.artifact_path }}" doctor --help' in binary_workflow
+    assert '"${{ matrix.artifact_path }}" doctor\n' not in binary_workflow
     assert "image-version: ${{ steps.meta.outputs.version }}" in image_workflow
     assert "VERSION=${{ steps.meta.outputs.version }}" in image_workflow
     assert "${{ needs.build-and-push.outputs.image-version }}" in image_workflow
@@ -125,7 +127,7 @@ def test_codex_release_docs_record_intentional_version_split_and_unsigned_policy
 
     for text in [codex_guide, runtime_guide, checklist]:
         assert "0.1.3" in text
-        assert "v0.1.20" in text
+        assert "v0.1.21" in text
 
     assert "intentionally unsigned" in codex_guide
     assert "intentionally unsigned" in runtime_guide


### PR DESCRIPTION
## What changed

Updates the legacy binary release smoke check to run `doctor --help` instead of `doctor`.

## Why

The binary itself built successfully for v0.1.20, but `doctor` correctly reports a nonzero status on a fresh CI runner with no MCP config or database directory. The release smoke test should verify that the command is packaged and callable, not require a configured user environment.

## Validation

- Focused packaging tests: `21 passed`
- Ruff and diff checks passed
- The v0.1.20 Codex runtime-and-bundle workflow completed successfully for all five platforms.