### PR TITLE
Fix retired macOS Intel release runner

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -24,7 +24,8 @@ jobs:
             asset_name: waggle-mcp-darwin-arm64
             executable_name: waggle-mcp-darwin-arm64
             artifact_path: dist/waggle-mcp-darwin-arm64
-          - runner: macos-13
+          # macos-13 was retired; retain the x86_64 build on GitHub's supported Intel runner.
+          - runner: macos-15-intel
             asset_name: waggle-mcp-darwin-x64
             executable_name: waggle-mcp-darwin-x64
             artifact_path: dist/waggle-mcp-darwin-x64

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Python runtime, so plugin users do not need Python, `pipx`, a Waggle account, or
 an API key.
 
 ```bash
-curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.21/waggle-codex-marketplace-v0.1.21.zip -o waggle-codex-marketplace-v0.1.21.zip
-curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.21/waggle-codex-marketplace-v0.1.21.zip.sha256 -o waggle-codex-marketplace-v0.1.21.zip.sha256
-shasum -a 256 -c waggle-codex-marketplace-v0.1.21.zip.sha256
-unzip waggle-codex-marketplace-v0.1.21.zip
-codex plugin marketplace add "$(pwd)/waggle-codex-marketplace-v0.1.21"
+curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.22/waggle-codex-marketplace-v0.1.22.zip -o waggle-codex-marketplace-v0.1.22.zip
+curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.22/waggle-codex-marketplace-v0.1.22.zip.sha256 -o waggle-codex-marketplace-v0.1.22.zip.sha256
+shasum -a 256 -c waggle-codex-marketplace-v0.1.22.zip.sha256
+unzip waggle-codex-marketplace-v0.1.22.zip
+codex plugin marketplace add "$(pwd)/waggle-codex-marketplace-v0.1.22"
 codex plugin add waggle@waggle
 ```
 

--- a/docs/codex-plugin-runtime.md
+++ b/docs/codex-plugin-runtime.md
@@ -119,7 +119,7 @@ publishing. `.sha256` files remain a manual verification fallback.
 
 The Codex plugin manifest version is intentionally separate from the GitHub
 release tag. The Codex skills release uses plugin version `0.1.3` and GitHub
-release tag `v0.1.21` for the complete marketplace bundle.
+release tag `v0.1.22` for the complete marketplace bundle.
 
 Earlier GitHub releases were trial releases while the Waggle repository was
 private. Do not align the plugin version to the GitHub tag unless the plugin

--- a/docs/install/codex-marketplace-release-checklist.md
+++ b/docs/install/codex-marketplace-release-checklist.md
@@ -7,7 +7,7 @@ users add with `codex plugin marketplace add`.
 ## Version Policy
 
 - Codex plugin version: `0.1.3`
-- GitHub release tag for the Codex skills bundle: `v0.1.21`
+- GitHub release tag for the Codex skills bundle: `v0.1.22`
 - These versions are intentionally separate. The GitHub tag follows the main
   repository release history, including earlier private-repository trial
   releases. The Codex plugin manifest version tracks the plugin surface itself.
@@ -36,7 +36,7 @@ Run these from the repository root:
 
 ```bash
 python3 scripts/build_codex_plugin_runtime.py --require-artifacts
-python3 scripts/package_codex_plugin.py --bundle-version v0.1.21 --output-dir dist/codex-plugin
+python3 scripts/package_codex_plugin.py --bundle-version v0.1.22 --output-dir dist/codex-plugin
 python3 -m pytest tests/test_package_codex_plugin.py tests/test_packaging_metadata.py -q
 ```
 
@@ -45,7 +45,7 @@ development checkout—and follow the public path exactly:
 
 1. Download the published marketplace ZIP and checksum.
 2. Verify and extract it into a new directory.
-3. Run `codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.21`.
+3. Run `codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.22`.
 4. Run `codex plugin add waggle@waggle`.
 5. Start a new Codex task in an unrelated existing repository.
 6. Confirm Codex exposes:
@@ -84,11 +84,11 @@ Also confirm a direct scoped round trip:
 
 Expected files:
 
-- `waggle-codex-marketplace-v0.1.21.zip`
-- `waggle-codex-marketplace-v0.1.21.zip.sha256`
-- `waggle-codex-plugin-v0.1.21.zip`
-- `waggle-codex-plugin-v0.1.21.zip.sha256`
-- `waggle-codex-release-v0.1.21.json`
+- `waggle-codex-marketplace-v0.1.22.zip`
+- `waggle-codex-marketplace-v0.1.22.zip.sha256`
+- `waggle-codex-plugin-v0.1.22.zip`
+- `waggle-codex-plugin-v0.1.22.zip.sha256`
+- `waggle-codex-release-v0.1.22.json`
 
 The marketplace zip is the primary user-facing artifact. The bare plugin zip is
 for debugging, audits, and future installer compatibility.
@@ -118,15 +118,15 @@ Because the runtime is unsigned:
   directory listing or signed native installer.
 - State that the default install path has no required hosting or certificate
   cost.
-- Link users to the `v0.1.21` GitHub release.
+- Link users to the `v0.1.22` GitHub release.
 - Tell users to download the marketplace zip, extract it, and run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.21
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.22
 codex plugin add waggle@waggle
 ```
 
 - State clearly that `v0.1.16` and `v0.1.19` were partial releases and should
   not be used as Codex marketplace install sources.
 - State clearly that the plugin version shown in Codex is `0.1.3`, while the
-  GitHub release tag is `v0.1.21`.
+  GitHub release tag is `v0.1.22`.

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -93,26 +93,26 @@ binary is stale or missing, reinstall or upgrade the Waggle Codex plugin.
 
 Tagged Waggle releases publish two Codex plugin assets. The current Codex
 marketplace artifacts are published on the
-[`v0.1.21` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.21):
+[`v0.1.22` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.22):
 
-- `waggle-codex-marketplace-v0.1.21.zip`: a complete local marketplace root that
+- `waggle-codex-marketplace-v0.1.22.zip`: a complete local marketplace root that
   can be added with `codex plugin marketplace add`
 - `waggle-codex-plugin-<tag>.zip`: the bare `plugins/waggle` plugin folder
 - `waggle-codex-release-<tag>.json`: release metadata for audit and support
 
 > `v0.1.16` and `v0.1.19` were partial releases and should not be used as Codex
-> marketplace install sources. Use `v0.1.21` instead.
+> marketplace install sources. Use `v0.1.22` instead.
 
 The Codex plugin version is intentionally separate from the GitHub release tag.
-The plugin manifest reports `0.1.3`; `v0.1.21` is the GitHub release tag for
+The plugin manifest reports `0.1.3`; `v0.1.22` is the GitHub release tag for
 the marketplace bundle containing the Codex memory skills.
 
 For the easiest install path, download and extract the marketplace bundle
-from the [`v0.1.21` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.21),
+from the [`v0.1.22` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.22),
 then run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.21
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.22
 ```
 
 After that, refresh the plugin directory in Codex and install `Waggle` from the

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -127,7 +127,7 @@ def test_codex_release_docs_record_intentional_version_split_and_unsigned_policy
 
     for text in [codex_guide, runtime_guide, checklist]:
         assert "0.1.3" in text
-        assert "v0.1.21" in text
+        assert "v0.1.22" in text
 
     assert "intentionally unsigned" in codex_guide
     assert "intentionally unsigned" in runtime_guide


### PR DESCRIPTION
## Summary
- replace the retired macos-13 runner with the supported macos-15-intel runner
- advance release installation references to v0.1.22 so the corrected Intel binary can be published

## Validation
- git diff --check
- YAML parsing of the release-binaries workflow
- python3 -m pytest tests/test_packaging_metadata.py -q (12 passed)

This fixes the stranded Intel binary job from v0.1.21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Codex marketplace installation instructions to release v0.1.22.
  * Refreshed download links, checksums, artifact names, extraction steps, installation paths, and release checklist guidance.
  * Updated runtime documentation and release references while retaining plugin version 0.1.3.

* **Build Improvements**
  * Updated macOS Intel binary builds to use a supported runner, helping maintain reliable release artifact generation.

* **Tests**
  * Updated packaging validation to verify the latest Codex release references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->