### PR TITLE
Fix oversized binary and Docker cache release failures

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -60,7 +60,8 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           # GitHub Actions layer cache — dramatically speeds up repeat builds
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # The image push is authoritative; a transient cache-service failure must not fail the release.
+          cache-to: type=gha,mode=max,ignore-error=true
           # Build for both amd64 and arm64 (Apple Silicon, AWS Graviton)
           platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -74,6 +74,27 @@ jobs:
             --onefile \
             --name "${{ matrix.executable_name }}" \
             --collect-all waggle \
+            --exclude-module sentence_transformers \
+            --exclude-module torch \
+            --exclude-module transformers \
+            --exclude-module sklearn \
+            --exclude-module scipy \
+            --exclude-module huggingface_hub \
+            --exclude-module tokenizers \
+            --exclude-module safetensors \
+            --exclude-module numpy.random \
+            --exclude-module numpy.fft \
+            --exclude-module numpy.testing \
+            --exclude-module numpy.f2py \
+            --exclude-module googleapiclient \
+            --exclude-module google_auth_httplib2 \
+            --exclude-module google.genai \
+            --exclude-module pyvis \
+            --exclude-module IPython \
+            --exclude-module jedi \
+            --exclude-module openai \
+            --exclude-module anthropic \
+            --exclude-module portkey_ai \
             src/waggle/entrypoints/cli.py
 
       - name: Smoke test binary

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ Python runtime, so plugin users do not need Python, `pipx`, a Waggle account, or
 an API key.
 
 ```bash
-curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.23/waggle-codex-marketplace-v0.1.23.zip -o waggle-codex-marketplace-v0.1.23.zip
-curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.23/waggle-codex-marketplace-v0.1.23.zip.sha256 -o waggle-codex-marketplace-v0.1.23.zip.sha256
-shasum -a 256 -c waggle-codex-marketplace-v0.1.23.zip.sha256
-unzip waggle-codex-marketplace-v0.1.23.zip
-codex plugin marketplace add "$(pwd)/waggle-codex-marketplace-v0.1.23"
+curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.24/waggle-codex-marketplace-v0.1.24.zip -o waggle-codex-marketplace-v0.1.24.zip
+curl -L https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/download/v0.1.24/waggle-codex-marketplace-v0.1.24.zip.sha256 -o waggle-codex-marketplace-v0.1.24.zip.sha256
+shasum -a 256 -c waggle-codex-marketplace-v0.1.24.zip.sha256
+unzip waggle-codex-marketplace-v0.1.24.zip
+codex plugin marketplace add "$(pwd)/waggle-codex-marketplace-v0.1.24"
 codex plugin add waggle@waggle
 ```
 

--- a/docs/codex-plugin-runtime.md
+++ b/docs/codex-plugin-runtime.md
@@ -119,7 +119,7 @@ publishing. `.sha256` files remain a manual verification fallback.
 
 The Codex plugin manifest version is intentionally separate from the GitHub
 release tag. The Codex skills release uses plugin version `0.1.3` and GitHub
-release tag `v0.1.23` for the complete marketplace bundle.
+release tag `v0.1.24` for the complete marketplace bundle.
 
 Earlier GitHub releases were trial releases while the Waggle repository was
 private. Do not align the plugin version to the GitHub tag unless the plugin

--- a/docs/install/codex-marketplace-release-checklist.md
+++ b/docs/install/codex-marketplace-release-checklist.md
@@ -7,7 +7,7 @@ users add with `codex plugin marketplace add`.
 ## Version Policy
 
 - Codex plugin version: `0.1.3`
-- GitHub release tag for the Codex skills bundle: `v0.1.23`
+- GitHub release tag for the Codex skills bundle: `v0.1.24`
 - These versions are intentionally separate. The GitHub tag follows the main
   repository release history, including earlier private-repository trial
   releases. The Codex plugin manifest version tracks the plugin surface itself.
@@ -36,7 +36,7 @@ Run these from the repository root:
 
 ```bash
 python3 scripts/build_codex_plugin_runtime.py --require-artifacts
-python3 scripts/package_codex_plugin.py --bundle-version v0.1.23 --output-dir dist/codex-plugin
+python3 scripts/package_codex_plugin.py --bundle-version v0.1.24 --output-dir dist/codex-plugin
 python3 -m pytest tests/test_package_codex_plugin.py tests/test_packaging_metadata.py -q
 ```
 
@@ -45,7 +45,7 @@ development checkout—and follow the public path exactly:
 
 1. Download the published marketplace ZIP and checksum.
 2. Verify and extract it into a new directory.
-3. Run `codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.23`.
+3. Run `codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.24`.
 4. Run `codex plugin add waggle@waggle`.
 5. Start a new Codex task in an unrelated existing repository.
 6. Confirm Codex exposes:
@@ -84,11 +84,11 @@ Also confirm a direct scoped round trip:
 
 Expected files:
 
-- `waggle-codex-marketplace-v0.1.23.zip`
-- `waggle-codex-marketplace-v0.1.23.zip.sha256`
-- `waggle-codex-plugin-v0.1.23.zip`
-- `waggle-codex-plugin-v0.1.23.zip.sha256`
-- `waggle-codex-release-v0.1.23.json`
+- `waggle-codex-marketplace-v0.1.24.zip`
+- `waggle-codex-marketplace-v0.1.24.zip.sha256`
+- `waggle-codex-plugin-v0.1.24.zip`
+- `waggle-codex-plugin-v0.1.24.zip.sha256`
+- `waggle-codex-release-v0.1.24.json`
 
 The marketplace zip is the primary user-facing artifact. The bare plugin zip is
 for debugging, audits, and future installer compatibility.
@@ -118,15 +118,15 @@ Because the runtime is unsigned:
   directory listing or signed native installer.
 - State that the default install path has no required hosting or certificate
   cost.
-- Link users to the `v0.1.23` GitHub release.
+- Link users to the `v0.1.24` GitHub release.
 - Tell users to download the marketplace zip, extract it, and run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.23
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.24
 codex plugin add waggle@waggle
 ```
 
 - State clearly that `v0.1.16` and `v0.1.19` were partial releases and should
   not be used as Codex marketplace install sources.
 - State clearly that the plugin version shown in Codex is `0.1.3`, while the
-  GitHub release tag is `v0.1.23`.
+  GitHub release tag is `v0.1.24`.

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -93,26 +93,26 @@ binary is stale or missing, reinstall or upgrade the Waggle Codex plugin.
 
 Tagged Waggle releases publish two Codex plugin assets. The current Codex
 marketplace artifacts are published on the
-[`v0.1.23` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.23):
+[`v0.1.24` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.24):
 
-- `waggle-codex-marketplace-v0.1.23.zip`: a complete local marketplace root that
+- `waggle-codex-marketplace-v0.1.24.zip`: a complete local marketplace root that
   can be added with `codex plugin marketplace add`
 - `waggle-codex-plugin-<tag>.zip`: the bare `plugins/waggle` plugin folder
 - `waggle-codex-release-<tag>.json`: release metadata for audit and support
 
 > `v0.1.16` and `v0.1.19` were partial releases and should not be used as Codex
-> marketplace install sources. Use `v0.1.23` instead.
+> marketplace install sources. Use `v0.1.24` instead.
 
 The Codex plugin version is intentionally separate from the GitHub release tag.
-The plugin manifest reports `0.1.3`; `v0.1.23` is the GitHub release tag for
+The plugin manifest reports `0.1.3`; `v0.1.24` is the GitHub release tag for
 the marketplace bundle containing the Codex memory skills.
 
 For the easiest install path, download and extract the marketplace bundle
-from the [`v0.1.23` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.23),
+from the [`v0.1.24` release](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.24),
 then run:
 
 ```bash
-codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.23
+codex plugin marketplace add /path/to/waggle-codex-marketplace-v0.1.24
 ```
 
 After that, refresh the plugin directory in Codex and install `Waggle` from the

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -39,10 +39,15 @@ def test_release_workflows_use_current_entrypoints_and_versioned_image() -> None
     assert "src/waggle/server.py" not in binary_workflow
     assert '"${{ matrix.artifact_path }}" doctor --help' in binary_workflow
     assert '"${{ matrix.artifact_path }}" doctor\n' not in binary_workflow
+    from scripts.build_codex_plugin_runtime import HEAVY_EXCLUDES
+
+    for module in HEAVY_EXCLUDES:
+        assert f"--exclude-module {module}" in binary_workflow
     assert "image-version: ${{ steps.meta.outputs.version }}" in image_workflow
     assert "VERSION=${{ steps.meta.outputs.version }}" in image_workflow
     assert "${{ needs.build-and-push.outputs.image-version }}" in image_workflow
     assert "--entrypoint python" in image_workflow
+    assert "cache-to: type=gha,mode=max,ignore-error=true" in image_workflow
 
 
 def test_codex_onedir_runtime_has_separate_size_budget() -> None:
@@ -128,8 +133,8 @@ def test_codex_release_docs_record_intentional_version_split_and_unsigned_policy
 
     for text in [codex_guide, runtime_guide, checklist]:
         assert "0.1.3" in text
-        assert "v0.1.23" in text
-        assert "v0.1.22" not in text
+        assert "v0.1.24" in text
+        assert "v0.1.23" not in text
 
     assert "intentionally unsigned" in codex_guide
     assert "intentionally unsigned" in runtime_guide


### PR DESCRIPTION
## Summary
- exclude heavyweight optional ML and integration modules from standalone binaries using the same portable-runtime policy already used by the Codex bundle
- keep deterministic and fast-mode CLI behavior while bringing the Linux release asset below GitHub’s 2 GiB limit
- make GitHub Actions cache export non-fatal after Docker images have successfully pushed
- advance release references to v0.1.24

## Validation
- git diff --check
- YAML parsing for both release workflows
- python3 -m pytest tests/test_packaging_metadata.py -q (12 passed)

This addresses both v0.1.23 failures: oversized Linux release asset and transient Docker cache export failure.