### PR TITLE
chore: enforce release metadata consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.Abhigyan-Shekhar/Waggle-mcp -->
+
 <p align="center">
   <strong>waggle-mcp</strong>
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "waggle-mcp"
-version = "0.1.0rc1"
+version = "0.1.22"
 description = "MCP server that gives LLMs persistent graph-structured memory"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/sync_release_metadata.py
+++ b/scripts/sync_release_metadata.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tomllib
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+MCP_NAME_MARKER = re.compile(r"<!--\s*mcp-name:\s*(?P<name>[^>]+?)\s*-->")
+
+
+def resolve_root(root: Path | None) -> Path:
+    return root if root is not None else Path(__file__).resolve().parents[1]
+
+
+def load_project_version(root: Path) -> str:
+    payload = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    version = payload.get("project", {}).get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("pyproject.toml [project].version must be a non-empty string")
+    return version
+
+
+def load_server_metadata(root: Path) -> dict[str, Any]:
+    payload = json.loads((root / "server.json").read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("server.json root must be an object")
+    return payload
+
+
+def find_readme_markers(readme: str) -> list[str]:
+    return [match.group("name").strip() for match in MCP_NAME_MARKER.finditer(readme)]
+
+
+def _semantic_issues(root: Path) -> list[str]:
+    project_version = load_project_version(root)
+    server = load_server_metadata(root)
+    issues: list[str] = []
+
+    server_version = server.get("version")
+    if server_version != project_version:
+        issues.append(f"server.json .version: expected {project_version}, found {server_version}")
+
+    packages = server.get("packages")
+    if not isinstance(packages, list):
+        raise ValueError("server.json .packages must be an array")
+    if not packages:
+        issues.append("server.json .packages must declare at least one package")
+    for index, package in enumerate(packages):
+        if not isinstance(package, dict):
+            raise ValueError(f"server.json .packages[{index}] must be an object")
+        package_version = package.get("version")
+        if package_version != project_version:
+            issues.append(
+                f"server.json .packages[{index}].version: expected {project_version}, found {package_version}"
+            )
+
+    name = server.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("server.json .name must be a non-empty string")
+    markers = find_readme_markers((root / "README.md").read_text(encoding="utf-8"))
+    if not markers:
+        issues.append(f"README.md: missing <!-- mcp-name: {name} -->")
+    elif len(markers) > 1:
+        issues.append(f"README.md: found {len(markers)} mcp-name markers; expected exactly one")
+    elif markers[0] != name:
+        issues.append(f"README.md mcp-name marker {markers[0]!r} does not match server.json .name {name!r}")
+    return issues
+
+
+def check_metadata(root: Path | None = None) -> list[str]:
+    repo_root = resolve_root(root)
+    try:
+        return _semantic_issues(repo_root)
+    except (OSError, UnicodeError, json.JSONDecodeError, tomllib.TOMLDecodeError, ValueError) as exc:
+        return [f"metadata validation failed: {exc}"]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check release metadata.")
+    parser.add_argument("--check", action="store_true", required=True, help="report drift without writing")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, *, root: Path | None = None) -> int:
+    _parser().parse_args(argv)
+    issues = check_metadata(root)
+    if issues:
+        print("Release metadata validation failed:")
+        for issue in issues:
+            print(f"- {issue}")
+        return 1
+    print("Release metadata is consistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_release_metadata.py
+++ b/scripts/sync_release_metadata.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import re
 import tomllib
@@ -9,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 MCP_NAME_MARKER = re.compile(r"<!--\s*mcp-name:\s*(?P<name>[^>]+?)\s*-->")
+VERSION_SENTINEL = "__WAGGLE_GENERATED_VERSION__"
 
 
 def resolve_root(root: Path | None) -> Path:
@@ -78,15 +80,95 @@ def check_metadata(root: Path | None = None) -> list[str]:
         return [f"metadata validation failed: {exc}"]
 
 
+def render_server_json(data: dict[str, Any]) -> bytes:
+    return (json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode()
+
+
+def set_generated_versions(data: dict[str, Any], version: str) -> None:
+    data["version"] = version
+    packages = data.get("packages")
+    if not isinstance(packages, list):
+        raise ValueError("server.json .packages must be an array")
+    if not packages:
+        raise ValueError("server.json .packages must declare at least one package")
+    for index, package in enumerate(packages):
+        if not isinstance(package, dict):
+            raise ValueError(f"server.json .packages[{index}] must be an object")
+        package["version"] = version
+
+
+def _changed_line_indexes(before: bytes, after: bytes) -> set[int]:
+    before_lines = before.splitlines(keepends=True)
+    after_lines = after.splitlines(keepends=True)
+    if len(before_lines) != len(after_lines):
+        raise ValueError("server.json rewrite would change the number of lines")
+    return {
+        index
+        for index, (old_line, new_line) in enumerate(zip(before_lines, after_lines, strict=True))
+        if old_line != new_line
+    }
+
+
+def build_server_candidate(original: bytes, data: dict[str, Any], version: str) -> bytes:
+    canonical_original = render_server_json(data)
+    if canonical_original != original:
+        raise ValueError("server.json is not in canonical two-space JSON format; refusing to rewrite unrelated bytes")
+
+    sentinel_data = copy.deepcopy(data)
+    set_generated_versions(sentinel_data, VERSION_SENTINEL)
+    allowed_lines = _changed_line_indexes(canonical_original, render_server_json(sentinel_data))
+
+    candidate_data = copy.deepcopy(data)
+    set_generated_versions(candidate_data, version)
+    candidate = render_server_json(candidate_data)
+    changed_lines = _changed_line_indexes(original, candidate)
+    unexpected_lines = changed_lines - allowed_lines
+    if unexpected_lines:
+        display_lines = ", ".join(str(index + 1) for index in sorted(unexpected_lines))
+        raise ValueError(f"server.json rewrite changed unrelated lines: {display_lines}")
+    return candidate
+
+
+def write_metadata(root: Path | None = None) -> list[str]:
+    repo_root = resolve_root(root)
+    try:
+        project_version = load_project_version(repo_root)
+        server_path = repo_root / "server.json"
+        readme_path = repo_root / "README.md"
+        server_original = server_path.read_bytes()
+        server = load_server_metadata(repo_root)
+        server_candidate = build_server_candidate(server_original, server, project_version)
+
+        name = server.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("server.json .name must be a non-empty string")
+        readme_original = readme_path.read_bytes()
+        readme_text = readme_original.decode()
+        markers = find_readme_markers(readme_text)
+        readme_candidate = readme_original
+        if not markers:
+            readme_candidate = f"<!-- mcp-name: {name} -->\n\n".encode() + readme_original
+
+        if server_candidate != server_original:
+            server_path.write_bytes(server_candidate)
+        if readme_candidate != readme_original:
+            readme_path.write_bytes(readme_candidate)
+        return check_metadata(repo_root)
+    except (OSError, UnicodeError, json.JSONDecodeError, tomllib.TOMLDecodeError, ValueError) as exc:
+        return [str(exc)]
+
+
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Check release metadata.")
-    parser.add_argument("--check", action="store_true", required=True, help="report drift without writing")
+    parser = argparse.ArgumentParser(description="Check or synchronize release metadata.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="report drift without writing")
+    mode.add_argument("--write", action="store_true", help="synchronize generated metadata")
     return parser
 
 
 def main(argv: Sequence[str] | None = None, *, root: Path | None = None) -> int:
-    _parser().parse_args(argv)
-    issues = check_metadata(root)
+    args = _parser().parse_args(argv)
+    issues = write_metadata(root) if args.write else check_metadata(root)
     if issues:
         print("Release metadata validation failed:")
         for issue in issues:

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Abhigyan-Shekhar/Waggle-mcp",
     "source": "github"
   },
-  "version": "0.1.8",
+  "version": "0.1.22",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "waggle-mcp",
-      "version": "0.1.8",
+      "version": "0.1.22",
       "transport": {
         "type": "stdio"
       },

--- a/tests/test_sync_release_metadata.py
+++ b/tests/test_sync_release_metadata.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from types import ModuleType
 
+import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
 NAME = "io.github.Abhigyan-Shekhar/Waggle-mcp"
@@ -140,3 +141,107 @@ def test_default_root_is_resolved_inside_each_call(tmp_path: Path, monkeypatch: 
         "server.json .version: expected 0.1.23, found 0.1.22",
         "server.json .packages[0].version: expected 0.1.23, found 0.1.22",
     ]
+
+
+def test_write_changes_only_generated_version_lines(tmp_path: Path) -> None:
+    write_repo(
+        tmp_path,
+        project_version="0.1.22",
+        server_version="0.1.8",
+        package_versions=("0.1.8", "0.1.7"),
+    )
+    server_path = tmp_path / "server.json"
+    before = server_path.read_bytes()
+    expected = before.replace(b'"version": "0.1.8"', b'"version": "0.1.22"')
+    expected = expected.replace(b'"version": "0.1.7"', b'"version": "0.1.22"')
+
+    assert sync_module().write_metadata(tmp_path) == []
+    assert server_path.read_bytes() == expected
+    assert b"Keep caf\xc3\xa9 metadata unchanged." in server_path.read_bytes()
+
+
+def test_write_inserts_missing_marker_from_server_name(tmp_path: Path) -> None:
+    write_repo(tmp_path, marker=None)
+    readme_path = tmp_path / "README.md"
+
+    assert sync_module().write_metadata(tmp_path) == []
+    assert readme_path.read_bytes() == f"<!-- mcp-name: {NAME} -->\n\n# Waggle\n".encode()
+
+
+def test_write_leaves_matching_marker_byte_identical(tmp_path: Path) -> None:
+    write_repo(tmp_path)
+    readme_path = tmp_path / "README.md"
+    before = readme_path.read_bytes()
+
+    assert sync_module().write_metadata(tmp_path) == []
+    assert readme_path.read_bytes() == before
+
+
+def test_write_never_overwrites_mismatched_marker(tmp_path: Path) -> None:
+    wrong_name = "io.github.someone-else/waggle-mcp"
+    write_repo(
+        tmp_path,
+        project_version="0.1.22",
+        server_version="0.1.8",
+        marker=wrong_name,
+    )
+    readme_path = tmp_path / "README.md"
+    readme_before = readme_path.read_bytes()
+
+    issues = sync_module().write_metadata(tmp_path)
+
+    assert readme_path.read_bytes() == readme_before
+    assert json.loads((tmp_path / "server.json").read_text())["version"] == "0.1.22"
+    assert len(issues) == 1
+    assert "does not match server.json .name" in issues[0]
+
+
+def test_write_never_overwrites_duplicate_markers(tmp_path: Path) -> None:
+    write_repo(tmp_path, server_version="0.1.8")
+    readme_path = tmp_path / "README.md"
+    readme_path.write_text(
+        readme_path.read_text(encoding="utf-8") + f"<!-- mcp-name: {NAME} -->\n",
+        encoding="utf-8",
+    )
+    readme_before = readme_path.read_bytes()
+
+    issues = sync_module().write_metadata(tmp_path)
+
+    assert readme_path.read_bytes() == readme_before
+    assert json.loads((tmp_path / "server.json").read_text())["version"] == "0.1.22"
+    assert issues == ["README.md: found 2 mcp-name markers; expected exactly one"]
+
+
+def test_write_refuses_noncanonical_json_without_touching_files(tmp_path: Path) -> None:
+    write_repo(tmp_path, project_version="0.1.22", server_version="0.1.8", marker=None)
+    server_path = tmp_path / "server.json"
+    readme_path = tmp_path / "README.md"
+    server_path.write_bytes(server_path.read_bytes().replace(b"\n", b"\r\n"))
+    before = {server_path: server_path.read_bytes(), readme_path: readme_path.read_bytes()}
+
+    issues = sync_module().write_metadata(tmp_path)
+
+    assert issues == ["server.json is not in canonical two-space JSON format; refusing to rewrite unrelated bytes"]
+    assert {path: path.read_bytes() for path in before} == before
+
+
+def test_write_cli_returns_one_when_marker_remains_unresolved(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    write_repo(tmp_path, server_version="0.1.8", marker="wrong/name")
+
+    assert sync_module().main(["--write"], root=tmp_path) == 1
+    assert "does not match server.json .name" in capsys.readouterr().out
+
+
+def test_write_cli_returns_zero_after_synchronizing(tmp_path: Path) -> None:
+    write_repo(tmp_path, server_version="0.1.8", marker=None)
+
+    assert sync_module().main(["--write"], root=tmp_path) == 0
+    assert sync_module().main(["--check"], root=tmp_path) == 0
+
+
+@pytest.mark.parametrize("argv", [[], ["--check", "--write"]])
+def test_cli_requires_exactly_one_mode(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        sync_module().main(argv)
+
+    assert exc_info.value.code == 2

--- a/tests/test_sync_release_metadata.py
+++ b/tests/test_sync_release_metadata.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from types import ModuleType
+
+from pytest import CaptureFixture, MonkeyPatch
+
+NAME = "io.github.Abhigyan-Shekhar/Waggle-mcp"
+
+
+def sync_module() -> ModuleType:
+    return importlib.import_module("scripts.sync_release_metadata")
+
+
+def write_repo(
+    root: Path,
+    *,
+    project_version: str = "0.1.22",
+    server_version: str = "0.1.22",
+    package_versions: tuple[str, ...] = ("0.1.22",),
+    marker: str | None = NAME,
+) -> None:
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "waggle-mcp"\nversion = "{project_version}"\n',
+        encoding="utf-8",
+    )
+    server = {
+        "$schema": "https://example.invalid/server.schema.json",
+        "name": NAME,
+        "description": "Keep café metadata unchanged.",
+        "version": server_version,
+        "packages": [
+            {
+                "registryType": "pypi",
+                "identifier": f"waggle-mcp-{index}",
+                "version": version,
+                "transport": {"type": "stdio"},
+            }
+            for index, version in enumerate(package_versions)
+        ],
+    }
+    (root / "server.json").write_text(
+        json.dumps(server, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    prefix = f"<!-- mcp-name: {marker} -->\n\n" if marker is not None else ""
+    (root / "README.md").write_text(prefix + "# Waggle\n", encoding="utf-8")
+
+
+def test_check_passes_for_consistent_metadata(tmp_path: Path) -> None:
+    write_repo(tmp_path)
+    module = sync_module()
+
+    assert module.check_metadata(tmp_path) == []
+    assert module.main(["--check"], root=tmp_path) == 0
+
+
+def test_check_reports_every_version_mismatch(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    write_repo(
+        tmp_path,
+        project_version="0.1.22",
+        server_version="0.1.8",
+        package_versions=("0.1.8", "0.1.7"),
+    )
+    module = sync_module()
+
+    assert module.main(["--check"], root=tmp_path) == 1
+    output = capsys.readouterr().out
+    assert "server.json .version: expected 0.1.22, found 0.1.8" in output
+    assert "server.json .packages[0].version: expected 0.1.22, found 0.1.8" in output
+    assert "server.json .packages[1].version: expected 0.1.22, found 0.1.7" in output
+
+
+def test_check_reports_missing_marker(tmp_path: Path) -> None:
+    write_repo(tmp_path, marker=None)
+
+    assert sync_module().check_metadata(tmp_path) == [f"README.md: missing <!-- mcp-name: {NAME} -->"]
+
+
+def test_check_reports_mismatched_marker(tmp_path: Path) -> None:
+    write_repo(tmp_path, marker="io.github.someone-else/waggle-mcp")
+
+    issues = sync_module().check_metadata(tmp_path)
+
+    assert len(issues) == 1
+    assert "does not match server.json .name" in issues[0]
+
+
+def test_check_reports_duplicate_markers(tmp_path: Path) -> None:
+    write_repo(tmp_path)
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        readme.read_text(encoding="utf-8") + f"<!-- mcp-name: {NAME} -->\n",
+        encoding="utf-8",
+    )
+
+    assert sync_module().check_metadata(tmp_path) == ["README.md: found 2 mcp-name markers; expected exactly one"]
+
+
+def test_check_rejects_empty_packages_array(tmp_path: Path) -> None:
+    write_repo(tmp_path, package_versions=())
+
+    assert sync_module().check_metadata(tmp_path) == ["server.json .packages must declare at least one package"]
+
+
+def test_check_reports_malformed_metadata(tmp_path: Path) -> None:
+    write_repo(tmp_path)
+    (tmp_path / "server.json").write_text("not json\n", encoding="utf-8")
+
+    issues = sync_module().check_metadata(tmp_path)
+
+    assert len(issues) == 1
+    assert issues[0].startswith("metadata validation failed:")
+
+
+def test_default_root_is_resolved_inside_each_call(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    write_repo(first, project_version="0.1.22", server_version="0.1.22")
+    write_repo(second, project_version="0.1.23", server_version="0.1.22")
+    module = sync_module()
+
+    monkeypatch.setattr(
+        module,
+        "__file__",
+        str(first / "scripts" / "sync_release_metadata.py"),
+    )
+    assert module.check_metadata() == []
+
+    monkeypatch.setattr(
+        module,
+        "__file__",
+        str(second / "scripts" / "sync_release_metadata.py"),
+    )
+    assert module.check_metadata() == [
+        "server.json .version: expected 0.1.23, found 0.1.22",
+        "server.json .packages[0].version: expected 0.1.23, found 0.1.22",
+    ]


### PR DESCRIPTION
## Summary

- add `scripts/sync_release_metadata.py` with read-only `--check` and guarded `--write` modes
- keep `pyproject.toml`, `server.json`, package versions, and the README MCP-name marker consistent
- reject an empty `server.json.packages` declaration
- add isolated `tmp_path` coverage for drift, exact writes, marker safety, CLI exits, and root resolution

## Needs owner confirmation before merge

- **Version proposal:** `0.1.22`. This is the smallest version newer than the latest tag, `v0.1.21`. It remains a proposal requiring owner confirmation.
- **Namespace:** preserved exactly as `io.github.Abhigyan-Shekhar/Waggle-mcp`, because that namespace is already published and active.

## Known live metadata issue — out of scope

The published MCP Registry entry declares PyPI package version `0.1.8`, while PyPI only has installable release `0.0.1`. This branch does not modify or publish remote registry or PyPI state.

## Verification

- `python -m pytest tests/test_sync_release_metadata.py -q` — 18 passed
- full deterministic suite — 924 passed, 7 skipped
- Ruff lint and format — passed
- mypy — passed
- real metadata `--check` — passed

## Scope

No workflows, release automation, Marketplace files, tags, releases, packages, or registry entries were changed or published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to validate and synchronize release metadata.
  * Added checks for version consistency, package metadata, and the README registry marker.
  * Added safe write support for correcting metadata inconsistencies.

* **Chores**
  * Updated the project and package versions to `0.1.22`.
  * Added the repository’s registry identifier to the README.

* **Tests**
  * Added comprehensive coverage for metadata validation, synchronization, error handling, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->