### PR TITLE
ci: validate MCP registry readiness

### DIFF
--- a/.github/workflows/registry-readiness.yml
+++ b/.github/workflows/registry-readiness.yml
@@ -1,0 +1,92 @@
+name: Registry readiness
+
+on:
+  pull_request:
+    paths:
+      - "server.json"
+      - "pyproject.toml"
+      - "README.md"
+      - "scripts/sync_release_metadata.py"
+      - "scripts/check_registry_readiness.py"
+      - "tests/test_registry_readiness.py"
+      - ".github/workflows/registry-readiness.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate server.json and installed distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install validation and build tools
+        run: python -m pip install "build>=1.2.2" "jsonschema>=4.23.0"
+
+      - name: Fetch declared registry schema
+        shell: bash
+        run: |
+          schema_url="$(python -c 'import json; print(json.load(open("server.json"))["$schema"])')"
+          curl --fail --location --retry 3 --silent --show-error \
+            --output "$RUNNER_TEMP/server.schema.json" \
+            "$schema_url"
+
+      - name: Parse and validate server.json
+        run: >-
+          python scripts/check_registry_readiness.py schema
+          --schema "$RUNNER_TEMP/server.schema.json"
+
+      - name: Check release metadata drift
+        run: python scripts/sync_release_metadata.py --check
+
+      - name: Check package name and console entry point
+        run: python scripts/check_registry_readiness.py project
+
+      - name: Build wheel and source distribution
+        run: python -m build --outdir "$RUNNER_TEMP/dist"
+
+      - name: Verify wheel embeds README and mcp-name marker
+        shell: bash
+        run: >-
+          python scripts/check_registry_readiness.py wheel
+          --wheel "$RUNNER_TEMP"/dist/*.whl
+          --readme README.md
+
+      - name: Install wheel into a fresh virtual environment
+        shell: bash
+        run: |
+          python -m venv "$RUNNER_TEMP/registry-venv"
+          "$RUNNER_TEMP/registry-venv/bin/python" -m pip install \
+            "$RUNNER_TEMP"/dist/*.whl
+
+      - name: Run installed doctor offline
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
+          WAGGLE_BACKEND: sqlite
+          WAGGLE_DB_PATH: ${{ runner.temp }}/doctor-waggle.db
+          WAGGLE_DEFAULT_TENANT_ID: registry-smoke
+          WAGGLE_MODEL: deterministic
+          WAGGLE_STARTUP_MODE: fast
+          WAGGLE_TRANSPORT: stdio
+        run: >-
+          "$RUNNER_TEMP/registry-venv/bin/waggle-mcp" doctor --json
+
+      - name: Smoke-test installed MCP server over stdio
+        run: >-
+          "$RUNNER_TEMP/registry-venv/bin/python"
+          scripts/check_registry_readiness.py stdio
+          --command "$RUNNER_TEMP/registry-venv/bin/waggle-mcp"
+          --work-dir "$RUNNER_TEMP/stdio-smoke"

--- a/docs/superpowers/plans/2026-08-10-server-json-registry-readiness.md
+++ b/docs/superpowers/plans/2026-08-10-server-json-registry-readiness.md
@@ -1,0 +1,80 @@
+# server.json Registry Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Waggle's `server.json` accurate for local-first stdio installs and add CI that proves the registry manifest, Python distribution, installed CLI, and MCP stdio startup are release-ready without publishing.
+
+**Architecture:** Keep GitHub Actions orchestration declarative and put repository-specific validation in a focused Python script with separate schema, project metadata, combined manifest, built-wheel README, and installed-command stdio subcommands. The workflow fetches the released schema named by `server.json`, calls Track 1's metadata checker, builds into runner-temporary storage, installs into a fresh temporary virtual environment, and runs all installed-artifact checks there.
+
+**Tech Stack:** Python 3.11, `jsonschema`, `tomllib`, `zipfile`, MCP Python SDK, PyPA `build`, GitHub Actions.
+
+## Global Constraints
+
+- Branch from local `codex/sync-release-metadata`; do not push or open a PR before Track 1 merges.
+- Preserve `server.json` `.name`, `.version`, and `packages[].version` exactly.
+- Registry transport remains stdio only; no remote/HTTP manifest entry.
+- The job has `contents: read` and never publishes or writes to the repository tree.
+- Every database, build output, and virtual environment used by smoke tests lives under a temporary directory.
+- Before eventual publication, rebase onto merged `main` and rerun every verification command from scratch.
+
+---
+
+### Task 1: Registry-readiness validation helpers
+
+**Files:**
+- Create: `scripts/check_registry_readiness.py`
+- Create: `tests/test_registry_readiness.py`
+
+**Interfaces:**
+- Produces: `check_schema(manifest_path: Path, schema_path: Path) -> list[str]`, `check_project_metadata(root: Path) -> list[str]`, `check_manifest(root: Path, schema_path: Path) -> list[str]`, `check_wheel(wheel_path: Path, readme_path: Path) -> list[str]`, async `smoke_stdio(command: Path, work_dir: Path) -> list[str]`, and matching CLI subcommands.
+- Consumes: `server.json`, `pyproject.toml`, `README.md`, an explicitly downloaded JSON schema, one built wheel, and one installed `waggle-mcp` executable.
+
+- [ ] Write tests that fail because the helper module does not exist. Cover valid metadata; schema errors; package-name drift; missing `waggle-mcp` entry point; wheel description/marker absence; exact README embedding; and stdio initialization using a real temporary executable fixture.
+- [ ] Run `WAGGLE_MODEL=deterministic .venv/bin/python -m pytest tests/test_registry_readiness.py -q` and confirm the missing-module failure.
+- [ ] Implement only the helper functions and CLI needed by the tests. Aggregate actionable errors and return exit status 1 on validation failure.
+- [ ] Re-run the focused tests and confirm they pass.
+- [ ] Run Ruff and mypy over the new helper and tests.
+
+### Task 2: Correct the registry manifest
+
+**Files:**
+- Modify: `server.json`
+
+**Interfaces:**
+- Consumes: released schema `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` confirmed from the official Registry's `CurrentSchemaVersion` on 2026-08-10.
+- Produces: a schema-valid local-first manifest whose PyPI package matches `[project].name` and whose command exists in `[project.scripts]`.
+
+- [ ] Add title `Waggle` and refine the description to persistent, local-first, graph-backed conversational memory.
+- [ ] Remove only `WAGGLE_API_KEY_ENVIRONMENT` from `environmentVariables`; retain transport, backend, DB path, default tenant, and model settings.
+- [ ] Run the manifest helper against the released schema copy and confirm it passes.
+- [ ] Run `python scripts/sync_release_metadata.py --check` and confirm Track 1 metadata still passes.
+
+### Task 3: Least-privilege registry-readiness workflow
+
+**Files:**
+- Create: `.github/workflows/registry-readiness.yml`
+
+**Interfaces:**
+- Consumes: the Task 1 CLI and Track 1 `scripts/sync_release_metadata.py --check`.
+- Produces: a pull-request-only job filtered to release metadata paths, with `contents: read` and no publishing capability.
+
+- [ ] Add triggers for `server.json`, `pyproject.toml`, `README.md`, `scripts/sync_release_metadata.py`, `scripts/check_registry_readiness.py`, and the workflow itself.
+- [ ] Set up Python 3.11, install `build` plus `jsonschema`, fetch the exact schema URI declared by the manifest into `${RUNNER_TEMP}`, and run the manifest helper.
+- [ ] Run Track 1 drift checking, build wheel/sdist under `${RUNNER_TEMP}`, and run wheel README inspection.
+- [ ] Create `${RUNNER_TEMP}/registry-venv`, install the built wheel, run deterministic/offline `waggle-mcp doctor` with a temporary SQLite path, and run the stdio helper against that installed command.
+- [ ] Validate YAML syntax locally and audit the workflow for `contents: read`, temporary-only paths, bounded network use, and absence of publish commands.
+
+### Task 4: Local dry run and branch handoff
+
+**Files:**
+- Modify only if verification exposes a Track 2 defect.
+
+**Interfaces:**
+- Consumes: completed Tasks 1-3.
+- Produces: fresh command output, clean Track 2 commits, and a PR description that includes the known broken live PyPI listing plus the rebase/reverification gate.
+
+- [ ] Run focused tests, the complete offline deterministic suite, Ruff, formatting, mypy, and Track 1 drift checking.
+- [ ] Download the released schema anew and run manifest validation.
+- [ ] Build wheel/sdist into a fresh temporary directory; inspect the wheel; create a fresh virtual environment; install the wheel; run offline doctor; and perform the stdio smoke test.
+- [ ] Review `git diff` against `codex/sync-release-metadata`, confirm no Track 1 files were unintentionally changed, and commit Track 2 changes only.
+- [ ] Prepare—but do not publish—the branch name, PR title, and PR description. Record that after Track 1 merges this branch must be rebased onto `main` and the entire verification sequence rerun before push/PR.

--- a/scripts/check_registry_readiness.py
+++ b/scripts/check_registry_readiness.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import tomllib
+from collections.abc import Sequence
+from email.parser import Parser
+from pathlib import Path
+from typing import Any
+from zipfile import BadZipFile, ZipFile
+
+import jsonschema
+
+MCP_NAME_MARKER = re.compile(r"<!--\s*mcp-name:\s*(?P<name>[^>]+?)\s*-->")
+
+
+def _exception_summary(exc: BaseException) -> str:
+    if isinstance(exc, BaseExceptionGroup):
+        return " | ".join(_exception_summary(nested) for nested in exc.exceptions)
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path.name} root must be an object")
+    return payload
+
+
+def _schema_error_path(error: jsonschema.ValidationError) -> str:
+    parts: list[str] = []
+    for item in error.absolute_path:
+        if isinstance(item, int):
+            parts[-1] = f"{parts[-1]}[{item}]"
+        else:
+            parts.append(str(item))
+    return ".".join(parts) or "root"
+
+
+def check_schema(manifest_path: Path, schema_path: Path) -> list[str]:
+    try:
+        manifest = _read_json_object(manifest_path)
+        schema = _read_json_object(schema_path)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        return [f"schema inputs could not be loaded: {exc}"]
+
+    declared_schema = manifest.get("$schema")
+    schema_id = schema.get("$id")
+    if declared_schema != schema_id:
+        return [f"server.json $schema {declared_schema!r} does not match registry schema $id {schema_id!r}"]
+
+    try:
+        validator_type = jsonschema.validators.validator_for(schema)
+        validator_type.check_schema(schema)
+    except jsonschema.SchemaError as exc:
+        return [f"registry schema is invalid: {exc.message}"]
+
+    return [
+        f"server.json {_schema_error_path(error)}: {error.message}"
+        for error in sorted(validator_type(schema).iter_errors(manifest), key=lambda item: list(item.absolute_path))
+    ]
+
+
+def check_project_metadata(root: Path) -> list[str]:
+    try:
+        manifest = _read_json_object(root / "server.json")
+        pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, tomllib.TOMLDecodeError, ValueError) as exc:
+        return [f"project metadata could not be loaded: {exc}"]
+
+    project = pyproject.get("project")
+    if not isinstance(project, dict):
+        return ["pyproject.toml must declare [project]"]
+    project_name = project.get("name")
+    if not isinstance(project_name, str) or not project_name:
+        return ["pyproject.toml [project].name must be a non-empty string"]
+
+    issues: list[str] = []
+    packages = manifest.get("packages")
+    if not isinstance(packages, list):
+        return ["server.json packages must be an array"]
+    pypi_packages = [
+        package for package in packages if isinstance(package, dict) and package.get("registryType") == "pypi"
+    ]
+    if not pypi_packages:
+        issues.append("server.json must declare a PyPI package")
+    for package in pypi_packages:
+        identifier = package.get("identifier")
+        if identifier != project_name:
+            issues.append(
+                f"server.json PyPI package {identifier!r} does not match pyproject.toml [project].name {project_name!r}"
+            )
+
+    scripts = project.get("scripts")
+    if not isinstance(scripts, dict) or not isinstance(scripts.get("waggle-mcp"), str):
+        issues.append("pyproject.toml [project.scripts] must declare waggle-mcp")
+    return issues
+
+
+def check_manifest(root: Path, schema_path: Path) -> list[str]:
+    schema_issues = check_schema(root / "server.json", schema_path)
+    return schema_issues or check_project_metadata(root)
+
+
+def _normalized_description(value: str) -> str:
+    return value.replace("\r\n", "\n").rstrip("\n")
+
+
+def check_wheel(wheel_path: Path, readme_path: Path) -> list[str]:
+    try:
+        readme = readme_path.read_text(encoding="utf-8")
+        markers = MCP_NAME_MARKER.findall(readme)
+        if len(markers) != 1:
+            return [f"README.md must contain exactly one mcp-name marker; found {len(markers)}"]
+        marker = f"<!-- mcp-name: {markers[0].strip()} -->"
+        with ZipFile(wheel_path) as archive:
+            metadata_members = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+            if len(metadata_members) != 1:
+                return [f"wheel must contain exactly one .dist-info/METADATA file; found {len(metadata_members)}"]
+            metadata_text = archive.read(metadata_members[0]).decode("utf-8")
+    except (OSError, UnicodeError, BadZipFile) as exc:
+        return [f"wheel metadata could not be loaded: {exc}"]
+
+    description = Parser().parsestr(metadata_text).get_payload()
+    if not isinstance(description, str):
+        return ["wheel METADATA description must be plain text"]
+    issues: list[str] = []
+    if _normalized_description(description) != _normalized_description(readme):
+        issues.append("wheel METADATA description does not exactly match README.md")
+    if marker not in description:
+        issues.append(f"wheel METADATA description is missing {marker}")
+    return issues
+
+
+async def _run_stdio_smoke(command: Path, work_dir: Path) -> list[str]:
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    if not command.is_file():
+        return [f"installed command does not exist: {command}"]
+    work_dir.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+            "WAGGLE_BACKEND": "sqlite",
+            "WAGGLE_BANNER": "false",
+            "WAGGLE_DB_PATH": str(work_dir / "stdio-smoke.db"),
+            "WAGGLE_DEFAULT_TENANT_ID": "registry-smoke",
+            "WAGGLE_MODEL": "deterministic",
+            "WAGGLE_STARTUP_MODE": "fast",
+            "WAGGLE_TRANSPORT": "stdio",
+        }
+    )
+    server = StdioServerParameters(
+        command=str(command),
+        args=["serve", "--transport", "stdio", "--quiet"],
+        cwd=str(work_dir),
+        env=env,
+    )
+    try:
+        async with (
+            stdio_client(server) as (read_stream, write_stream),
+            ClientSession(read_stream, write_stream) as session,
+        ):
+            initialized = await session.initialize()
+            if initialized.server_info.name != "waggle":
+                return [f"stdio server name was {initialized.server_info.name!r}, expected 'waggle'"]
+            tools = await session.list_tools()
+            if "store_node" not in {tool.name for tool in tools.tools}:
+                return ["stdio server did not advertise the store_node tool"]
+    except Exception as exc:
+        return [f"stdio protocol smoke test failed: {_exception_summary(exc)}"]
+    return []
+
+
+async def smoke_stdio(command: Path, work_dir: Path) -> list[str]:
+    try:
+        return await asyncio.wait_for(_run_stdio_smoke(command, work_dir), timeout=30.0)
+    except TimeoutError:
+        return ["stdio protocol smoke test timed out after 30 seconds"]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate MCP Registry release readiness.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    schema = subparsers.add_parser("schema", help="validate server.json against a downloaded registry schema")
+    schema.add_argument("--manifest", type=Path, default=Path("server.json"))
+    schema.add_argument("--schema", type=Path, required=True)
+
+    project = subparsers.add_parser("project", help="validate registry package and Python entry-point metadata")
+    project.add_argument("--root", type=Path, default=Path.cwd())
+
+    manifest = subparsers.add_parser("manifest", help="run both schema and project metadata validation")
+    manifest.add_argument("--root", type=Path, default=Path.cwd())
+    manifest.add_argument("--schema", type=Path, required=True)
+
+    wheel = subparsers.add_parser("wheel", help="validate the built wheel's embedded README")
+    wheel.add_argument("--wheel", type=Path, required=True)
+    wheel.add_argument("--readme", type=Path, default=Path("README.md"))
+
+    stdio = subparsers.add_parser("stdio", help="smoke-test an installed waggle-mcp command over stdio")
+    stdio.add_argument("--command", type=Path, required=True)
+    stdio.add_argument("--work-dir", type=Path, required=True)
+    return parser
+
+
+def _print_result(issues: list[str]) -> int:
+    if issues:
+        print("Registry readiness validation failed:")
+        for issue in issues:
+            print(f"- {issue}")
+        return 1
+    print("Registry readiness validation passed.")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "schema":
+        return _print_result(check_schema(args.manifest, args.schema))
+    if args.command == "project":
+        return _print_result(check_project_metadata(args.root))
+    if args.command == "manifest":
+        return _print_result(check_manifest(args.root, args.schema))
+    if args.command == "wheel":
+        return _print_result(check_wheel(args.wheel, args.readme))
+    return _print_result(asyncio.run(smoke_stdio(args.command, args.work_dir)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.json
+++ b/server.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Abhigyan-Shekhar/Waggle-mcp",
-  "description": "Persistent graph-backed conversational memory for AI agents.",
+  "title": "Waggle",
+  "description": "Persistent, local-first, graph-backed conversational memory for AI agents.",
   "repository": {
     "url": "https://github.com/Abhigyan-Shekhar/Waggle-mcp",
     "source": "github"
@@ -43,13 +44,6 @@
           "isRequired": false,
           "format": "string",
           "default": "local-default"
-        },
-        {
-          "name": "WAGGLE_API_KEY_ENVIRONMENT",
-          "description": "Generated API key prefix environment: test/local for non-production or live for production.",
-          "isRequired": false,
-          "format": "string",
-          "default": "test"
         },
         {
           "name": "WAGGLE_MODEL",

--- a/tests/test_registry_readiness.py
+++ b/tests/test_registry_readiness.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pytest
+
+from scripts.check_registry_readiness import (
+    check_manifest,
+    check_project_metadata,
+    check_schema,
+    check_wheel,
+    smoke_stdio,
+)
+
+NAME = "io.github.Abhigyan-Shekhar/Waggle-mcp"
+MARKER = f"<!-- mcp-name: {NAME} -->"
+
+
+def write_repository_fixture(root: Path) -> Path:
+    (root / "README.md").write_text(f"{MARKER}\n\n# Waggle\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        """[project]
+name = "waggle-mcp"
+version = "0.1.22"
+
+[project.scripts]
+waggle-mcp = "waggle.server:main"
+""",
+        encoding="utf-8",
+    )
+    (root / "server.json").write_text(
+        json.dumps(
+            {
+                "$schema": "https://example.invalid/server.schema.json",
+                "name": NAME,
+                "title": "Waggle",
+                "description": "Persistent, local-first, graph-backed conversational memory.",
+                "version": "0.1.22",
+                "packages": [
+                    {
+                        "registryType": "pypi",
+                        "identifier": "waggle-mcp",
+                        "version": "0.1.22",
+                        "transport": {"type": "stdio"},
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    schema_path = root / "server.schema.json"
+    schema_path.write_text(
+        json.dumps(
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.invalid/server.schema.json",
+                "type": "object",
+                "required": ["$schema", "name", "title", "packages"],
+                "properties": {
+                    "title": {"const": "Waggle"},
+                    "packages": {"type": "array", "minItems": 1},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return schema_path
+
+
+def write_wheel_fixture(path: Path, readme: str) -> None:
+    metadata = (
+        f"Metadata-Version: 2.4\nName: waggle-mcp\nVersion: 0.1.22\nDescription-Content-Type: text/markdown\n\n{readme}"
+    )
+    with ZipFile(path, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr("waggle_mcp-0.1.22.dist-info/METADATA", metadata)
+
+
+def test_manifest_check_accepts_schema_valid_consistent_metadata(tmp_path: Path) -> None:
+    schema_path = write_repository_fixture(tmp_path)
+
+    assert check_manifest(tmp_path, schema_path) == []
+
+
+def test_schema_and_project_checks_can_run_as_separate_ordered_ci_steps(tmp_path: Path) -> None:
+    schema_path = write_repository_fixture(tmp_path)
+
+    assert check_schema(tmp_path / "server.json", schema_path) == []
+    assert check_project_metadata(tmp_path) == []
+
+
+def test_schema_cli_does_not_require_mcp_sdk(tmp_path: Path) -> None:
+    schema_path = write_repository_fixture(tmp_path)
+    script = Path(__file__).resolve().parents[1] / "scripts" / "check_registry_readiness.py"
+    code = (
+        "import runpy, sys; "
+        "sys.modules['mcp'] = None; "
+        f"sys.argv = [{str(script)!r}, 'schema', '--manifest', {str(tmp_path / 'server.json')!r}, "
+        f"'--schema', {str(schema_path)!r}]; "
+        f"runpy.run_path({str(script)!r}, run_name='__main__')"
+    )
+
+    completed = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Registry readiness validation passed." in completed.stdout
+
+
+def test_manifest_check_reports_schema_validation_path(tmp_path: Path) -> None:
+    schema_path = write_repository_fixture(tmp_path)
+    manifest_path = tmp_path / "server.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["title"] = "Not Waggle"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    assert check_manifest(tmp_path, schema_path) == ["server.json title: 'Waggle' was expected"]
+
+
+def test_schema_check_rejects_downloaded_schema_with_wrong_identity(tmp_path: Path) -> None:
+    schema_path = write_repository_fixture(tmp_path)
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema["$id"] = "https://example.invalid/different.schema.json"
+    schema_path.write_text(json.dumps(schema), encoding="utf-8")
+
+    assert check_schema(tmp_path / "server.json", schema_path) == [
+        "server.json $schema 'https://example.invalid/server.schema.json' does not match "
+        "registry schema $id 'https://example.invalid/different.schema.json'"
+    ]
+
+
+def test_manifest_check_reports_pypi_project_name_drift(tmp_path: Path) -> None:
+    schema_path = write_repository_fixture(tmp_path)
+    manifest_path = tmp_path / "server.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["packages"][0]["identifier"] = "different-package"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    assert check_manifest(tmp_path, schema_path) == [
+        "server.json PyPI package 'different-package' does not match pyproject.toml [project].name 'waggle-mcp'"
+    ]
+
+
+def test_manifest_check_requires_declared_waggle_mcp_entry_point(tmp_path: Path) -> None:
+    schema_path = write_repository_fixture(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "waggle-mcp"\nversion = "0.1.22"\n',
+        encoding="utf-8",
+    )
+
+    assert check_manifest(tmp_path, schema_path) == ["pyproject.toml [project.scripts] must declare waggle-mcp"]
+
+
+def test_wheel_check_accepts_exact_embedded_readme_and_marker(tmp_path: Path) -> None:
+    readme_path = tmp_path / "README.md"
+    readme = f"{MARKER}\n\n# Waggle\n"
+    readme_path.write_text(readme, encoding="utf-8")
+    wheel_path = tmp_path / "waggle_mcp-0.1.22-py3-none-any.whl"
+    write_wheel_fixture(wheel_path, readme)
+
+    assert check_wheel(wheel_path, readme_path) == []
+
+
+def test_wheel_check_reports_missing_marker_and_readme_drift(tmp_path: Path) -> None:
+    readme_path = tmp_path / "README.md"
+    readme_path.write_text(f"{MARKER}\n\n# Waggle\n", encoding="utf-8")
+    wheel_path = tmp_path / "waggle_mcp-0.1.22-py3-none-any.whl"
+    write_wheel_fixture(wheel_path, "# Different description\n")
+
+    assert check_wheel(wheel_path, readme_path) == [
+        "wheel METADATA description does not exactly match README.md",
+        f"wheel METADATA description is missing {MARKER}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stdio_smoke_initializes_installed_command_without_protocol_noise(tmp_path: Path) -> None:
+    executable = Path(sys.executable).with_name("waggle-mcp")
+    assert executable.is_file()
+
+    assert await smoke_stdio(executable, tmp_path) == []


### PR DESCRIPTION
## Summary

- correct `server.json` title and local-first description, and remove the deployment-only API-key environment declaration
- add registry-readiness validation for the official schema, project metadata and entrypoint, built-wheel README metadata, and installed stdio operation
- add a least-privilege pull-request workflow that builds and validates the wheel and source distribution without publishing

## Validation

- full suite: `937 passed, 7 skipped in 109.94s`
- Ruff check: passed
- Ruff format check: `170 files already formatted`
- mypy: `Success: no issues found in 2 source files`
- release metadata consistency: passed
- official registry schema validation: passed
- project metadata/entrypoint validation: passed
- wheel metadata/README validation: passed
- package build: built `waggle_mcp-0.1.25-py3-none-any.whl` and `waggle_mcp-0.1.25.tar.gz`
- clean wheel installation: passed
- installed `waggle-mcp doctor --json`: 6 ok, 0 warn, 0 fail
- installed stdio MCP smoke test: passed
- `git diff --check origin/main..HEAD`: passed

## Known issue

The live MCP Registry entry still declares PyPI version 0.1.8 while PyPI release history only contains 0.0.1. This pre-existing listing issue is outside this PR's scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry-readiness validation for schema compatibility, project metadata, release packages, and installed command behavior.
  * Added checks for wheel metadata, embedded README content, entry points, and MCP stdio startup.
  * Updated the server listing with the “Waggle” title and local-first persistence description.

* **Bug Fixes**
  * Removed an unnecessary package environment variable from the server listing.

* **Chores**
  * Added automated pull request checks and comprehensive readiness test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->