### PR TITLE
docs: explain validation error responses

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -23,7 +23,8 @@ structured content includes:
 }
 ```
 
-The equivalent HTTP error response uses the same code and message fields:
+The equivalent HTTP error response preserves the same code and message values,
+using `error` for the code and `message` for the diagnostic text:
 
 ```json
 {
@@ -32,7 +33,8 @@ The equivalent HTTP error response uses the same code and message fields:
 }
 ```
 
-Use `error_code` for programmatic handling and `message` for diagnostics.
+Use `error_code` for programmatic handling in MCP structured results and `error`
+in HTTP responses. Use `message` for diagnostics.
 
 ## Production evaluation docs
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,6 +2,38 @@
 
 This page keeps the lower-level operational and configuration material out of the top-level README.
 
+## Error responses
+
+Waggle exposes typed, recoverable errors for expected failures such as invalid
+tool arguments, authentication failures, and rate limits. The canonical error
+codes and their HTTP-equivalent status codes are defined in
+[`src/waggle/errors.py`](../src/waggle/errors.py).
+
+For MCP tool calls, expected failures are returned as tool results with
+`isError: true` rather than as uncaught exceptions. For example, calling
+`query_graph` without its required `query` argument returns a result whose
+structured content includes:
+
+```json
+{
+  "error": "Invalid arguments for tool 'query_graph': 'query' is a required property",
+  "error_type": "ValidationFailure",
+  "error_code": "validation_failed",
+  "status_code": 400
+}
+```
+
+The equivalent HTTP error response uses the same code and message fields:
+
+```json
+{
+  "error": "validation_failed",
+  "message": "Invalid arguments for tool 'query_graph': 'query' is a required property"
+}
+```
+
+Use `error_code` for programmatic handling and `message` for diagnostics.
+
 ## Production evaluation docs
 
 For self-hosted production planning:


### PR DESCRIPTION
## Summary

- document the shared, typed error contract and link its canonical definitions
- add a representative `query_graph` validation failure for MCP and its HTTP-equivalent response

Fixes #626

## Testing

- [x] `python3 scripts/check_markdown_links.py`
- [x] `WAGGLE_MODEL=deterministic python3 -m pytest -q tests/test_mcp_v2_adapter.py::test_call_tool_validation_failure_returns_is_error tests/test_errors.py`

### Test report

```text
All markdown links are valid.
11 passed
```

This is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for typed, recoverable Waggle errors.
  * Documented canonical error codes and HTTP-equivalent status codes.
  * Added examples for MCP tool failures and validation errors in MCP and HTTP responses.
  * Clarified the usage of `error_code`, `error`, and `message` fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->