### PR TITLE
test(mcp): cover stable tool annotations

### DIFF
--- a/src/waggle/protocol/mcp/adapter.py
+++ b/src/waggle/protocol/mcp/adapter.py
@@ -19,6 +19,28 @@ from waggle.tools.results import WaggleToolResult
 
 from .surface import build_prompts, build_resources, get_prompt_result, read_resource_text
 
+_READ_ONLY_TOOLS = frozenset(
+    {
+        "aggregate_graph",
+        "debug_retrieval",
+        "dedup_candidates",
+        "get_context_window",
+        "get_node_history",
+        "get_related",
+        "get_stats",
+        "list_conflicts",
+        "list_context_scopes",
+        "list_context_windows",
+        "query_graph",
+        "timeline",
+    }
+)
+
+
+def _tool_annotations(name: str) -> types.ToolAnnotations:
+    """Return conservative MCP safety hints for the stable tool surface."""
+    return types.ToolAnnotations(readOnlyHint=name in _READ_ONLY_TOOLS)
+
 
 class WagglemcpAdapter:
     """Translates MCP SDK v2 handler calls into ``WaggleToolDispatcher`` calls.
@@ -52,6 +74,7 @@ class WagglemcpAdapter:
                 name=d.name,
                 description=d.description,
                 input_schema=d.input_schema,  # snake_case in SDK v2
+                annotations=_tool_annotations(d.name),
             )
             for d in self._dispatcher.list_tools()
         ]

--- a/tests/test_mcp_tool_surface.py
+++ b/tests/test_mcp_tool_surface.py
@@ -141,6 +141,19 @@ def test_tool_property_names_unchanged(mcp_surface):
         assert not removed, f"Tool '{name}' lost argument properties since fixture was taken: {sorted(removed)}"
 
 
+def test_representative_tools_retain_safety_annotations(mcp_surface):
+    """Read and write tools must remain distinguishable to MCP clients."""
+    import anyio
+
+    result = anyio.run(mcp_surface.on_list_tools, None, None)
+    tools = {tool.name: tool for tool in result.tools}
+
+    assert tools["query_graph"].annotations is not None
+    assert tools["query_graph"].annotations.read_only_hint is True
+    assert tools["store_node"].annotations is not None
+    assert tools["store_node"].annotations.read_only_hint is False
+
+
 # ── Resource list surface ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- emit conservative MCP readOnlyHint annotations from the v2 adapter
- lock representative read and write tool behavior with a focused surface test

## Validation
- 8 focused tests passed
- ruff check and format check passed

Closes #635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * MCP tools now clearly indicate which operations are read-only.
  * Tool listings provide explicit safety annotations for read and write actions.
* **Tests**
  * Added compatibility checks to verify correct safety annotations for representative query and storage tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->