### PR TITLE
docs(deployment): explain SQLite backup expectations

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -269,6 +269,28 @@ Recommended practice:
 3. test restore into a staging environment
 4. document restore ownership and RTO/RPO expectations
 
+### SQLite backups
+
+For local-first `WAGGLE_BACKEND=sqlite` deployments, back up the database file at `WAGGLE_DB_PATH` (default `~/.waggle/waggle.db`).
+
+What to back up:
+
+- The main database file. Waggle runs SQLite in WAL mode, so recent writes live in the `-wal` and `-shm` sidecar files until a checkpoint. Copying only the `.db` file can therefore miss the latest transactions.
+
+When to stop writes:
+
+- Quiesce first: stop the `waggle-mcp` service before copying, or take a consistent snapshot while it runs with `sqlite3`'s backup API:
+
+```bash
+sqlite3 ~/.waggle/waggle.db ".backup '/backups/waggle-$(date +%F).db'"
+```
+
+Restore guidance:
+
+- Rebuild from a portable JSON backup with `import_graph_backup` (see the [full migration flow in the README](../../README.md#cross-client-handoffs--migration)).
+- Session-scoped `.abhi` checkpoints cover handoffs between machines, not a full database restore.
+- Test restore into a staging environment before production use (see the [hardening checklist](../security/hardening-checklist.md)).
+
 ## Upgrades
 
 Recommended upgrade flow:


### PR DESCRIPTION
## What

Adds a `### SQLite backups` subsection to `docs/deployment/production.md` for local-first `WAGGLE_BACKEND=sqlite` deployments.

## Why

Closes #666. The existing Backups section only covers the Neo4j production shape; there was no guidance for the default local SQLite backend.

## Changes

- Which files to back up: `WAGGLE_DB_PATH` (default `~/.waggle/waggle.db`), plus the WAL-mode `-wal` / `-shm` sidecar caveat.
- When to stop writes: quiesce the service, or take a consistent snapshot with `sqlite3 .backup`.
- Where the existing restore guidance lives: `import_graph_backup` full-migration flow, `.abhi` checkpoints, and the hardening checklist.

## How verified

- `python scripts/check_markdown_links.py` — all markdown links are valid (documentation-only change).