### PR TITLE
docs: add telemetry opt-out example

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,21 @@
+# Telemetry and Local Logging
+
+Waggle is local-first and does not send telemetry by default. Local operation keeps memory data on the user's machine unless the user explicitly exports, syncs, or shares it.
+
+## Telemetry opt-out
+
+No telemetry is enabled by default, so there is no telemetry service to opt out of for normal local operation.
+
+To minimize application log output, set the logging level to `ERROR` before starting Waggle:
+
+```bash
+export WAGGLE_LOG_LEVEL=ERROR
+
+
+``
+This controls the verbosity of Waggle's local application logs. It does not disable local memory storage or delete existing logs or database data.
+## What remains available locally
+Reducing application logging does not disable Waggle's local memory database. Memory data continues to be stored locally using the configured WAGGLE_DB_PATH, which defaults to ~/.waggle/waggle.db.
+Local application logs may still contain operational information needed for debugging and health checks, depending on the configured log level.
+For more information about local-first storage and privacy, see the project's security documentation.
+``

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -6,16 +6,24 @@ Waggle is local-first and does not send telemetry by default. Local operation ke
 
 No telemetry is enabled by default, so there is no telemetry service to opt out of for normal local operation.
 
-To minimize application log output, set the logging level to `ERROR` before starting Waggle:
-
+To minimize application log output, set the logging level to ERROR before starting Waggle:
 ```bash
 export WAGGLE_LOG_LEVEL=ERROR
+```
 
-
-``
 This controls the verbosity of Waggle's local application logs. It does not disable local memory storage or delete existing logs or database data.
+
 ## What remains available locally
-Reducing application logging does not disable Waggle's local memory database. Memory data continues to be stored locally using the configured WAGGLE_DB_PATH, which defaults to ~/.waggle/waggle.db.
+
+Reducing application logging does not disable Waggle's local memory database. Memory data continues 
+to be stored locally using the configured WAGGLE_DB_PATH. When WAGGLE_DB_PATH is not set
+directly, Waggle first checks mcp_servers.waggle.env.WAGGLE_DB_PATH in ~/.codex/config.toml, then
+falls back to ~/.waggle/waggle.db.
+
 Local application logs may still contain operational information needed for debugging and health checks, depending on the configured log level.
+
 For more information about local-first storage and privacy, see the project's security documentation.
-``
+
+
+
+


### PR DESCRIPTION
Summary-
Added docs/telemetry.md with a clear example for reducing Waggle application log verbosity using WAGGLE_LOG_LEVEL=ERROR.

The documentation also explains that:
Telemetry is not enabled by default.
Setting the logging level to ERROR only reduces application log output.
Local memory/database storage is not disabled or deleted.

Testing-
git diff --cached --check — passed
Verified the documentation file with cat docs/telemetry.md
Verified the working tree was clean with git status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on Waggle’s local-first telemetry behavior.
  * Clarified that telemetry is disabled by default.
  * Documented options for reducing local log output and configuring database storage.
  * Explained that local memory and operational logs remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->