### PR TITLE
test: add idempotency test for edge creation

### DIFF
--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -646,3 +646,47 @@ class TestEdgeQualityReport:
             assert "non-dict metadata" in caplog.text
             # Both edges should be kept because the default confidence is 1.0
             assert len(doc["edges"]) == 2
+
+# ---------------------------------------------------------------------------
+# Idempotency regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeIdempotency:
+    """Verify that repeated insertion of the same edge identifier does not duplicate state."""
+
+    def test_add_edge_idempotency(self, tmp_path: Path) -> None:
+        graph = make_graph(tmp_path)
+        a = graph.add_node(label="Node A", content="service A content", node_type=NodeType.FACT).node
+        b = graph.add_node(label="Node B", content="service B content", node_type=NodeType.FACT).node
+
+        # First edge insertion
+        graph.add_edge(
+            source_id=a.id,
+            target_id=b.id,
+            relationship=RelationType.RELATES_TO,
+            metadata={"edge_confidence": 0.8},
+        )
+
+        with graph._lock, graph._connect() as conn:
+            initial_count = conn.execute(
+                "SELECT COUNT(*) FROM edges WHERE tenant_id = ?",
+                (graph.tenant_id,),
+            ).fetchone()[0]
+
+        # Duplicate edge insertion (same source, target, relationship)
+        graph.add_edge(
+            source_id=a.id,
+            target_id=b.id,
+            relationship=RelationType.RELATES_TO,
+            metadata={"edge_confidence": 0.8},
+        )
+
+        # Assert total edge count does not increase
+        with graph._lock, graph._connect() as conn:
+            final_count = conn.execute(
+                "SELECT COUNT(*) FROM edges WHERE tenant_id = ?",
+                (graph.tenant_id,),
+            ).fetchone()[0]
+
+        assert final_count == initial_count, "Repeated insertion of the same edge must be idempotent"

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -647,6 +647,7 @@ class TestEdgeQualityReport:
             # Both edges should be kept because the default confidence is 1.0
             assert len(doc["edges"]) == 2
 
+
 # ---------------------------------------------------------------------------
 # Idempotency regression tests
 # ---------------------------------------------------------------------------
@@ -682,7 +683,6 @@ class TestEdgeIdempotency:
             metadata={"edge_confidence": 0.8},
         )
 
-        # Assert total edge count does not increase
         with graph._lock, graph._connect() as conn:
             final_count = conn.execute(
                 "SELECT COUNT(*) FROM edges WHERE tenant_id = ?",


### PR DESCRIPTION
## Summary

- What changed? Added a unit test `test_add_edge_idempotency` in `tests/test_edges.py` to verify edge creation behavior.
- Why was it needed? To ensure adding duplicate edges with the same target ID is idempotent and doesn't create redundant edge records.

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

### Test report

=================================================================== test session starts ====================================================================
platform darwin -- Python 3.11.4, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/sohakhan/Waggle-mcp/Waggle-mcp
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.14.2
collected 26 items / 25 deselected / 1 selected                                                                                                            

tests/test_edges.py .                                                                                                                                [100%]

============================================================= 1 passed, 25 deselected in 0.55s =============================================================

Test was successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate relationship entries so adding the same relationship more than once does not increase the stored relationship count.
* **Tests**
  * Added regression coverage to verify consistent behavior when duplicate relationships are inserted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->