### PR TITLE
Fix pipx PATH setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,13 @@ This repository is the public Waggle product repo: Apache-2.0 licensed, availabl
 ```bash
 # Install globally (no venv needed)
 pipx install waggle-mcp
+pipx ensurepath
+```
 
+The first time you run `pipx ensurepath`, restart your terminal (or run
+`exec zsh -l` in zsh) so the updated `PATH` is loaded. Then finish setup:
+
+```bash
 # One-line setup — detects your MCP clients and writes config
 waggle-mcp setup --yes
 
@@ -53,7 +59,7 @@ waggle-mcp setup --yes
 waggle-mcp doctor
 ```
 
-*(No `pipx`? Run `brew install pipx && pipx ensurepath` first.)*
+*(No `pipx` on macOS? Run `brew install pipx` first.)*
 
 `setup --yes` detects Claude Code, Codex, Cursor, Gemini CLI, and Antigravity, writes the MCP config, and installs automatic memory hooks where supported. Restart your client and you're live.
 
@@ -521,8 +527,14 @@ Do not expose Waggle publicly without authentication.
 ### `waggle-mcp` not on PATH?
 
 ```bash
-pipx ensurepath   # then restart your terminal
+pipx ensurepath
+exec zsh -l                 # zsh; otherwise close and reopen the terminal
+command -v waggle-mcp
 ```
+
+If `pipx list` says Waggle is installed but `command -v` is still empty after
+the restart, rebuild the app link with `pipx reinstall waggle-mcp`. Updating
+`pipx` itself is not normally required.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,23 +43,23 @@ This repository is the public Waggle product repo: Apache-2.0 licensed, availabl
 ## Quick Start
 
 ```bash
+# macOS: install pipx if needed
+brew install pipx
+
 # Install globally (no venv needed)
 pipx install waggle-mcp
+
+# Add pipx apps to PATH
 pipx ensurepath
-```
 
-The first time you run `pipx ensurepath`, restart your terminal (or run
-`exec zsh -l` in zsh) so the updated `PATH` is loaded. Then finish setup:
-
-```bash
-# One-line setup — detects your MCP clients and writes config
+# Restart your terminal, then run:
 waggle-mcp setup --yes
 
 # Verify everything is healthy
 waggle-mcp doctor
 ```
 
-*(No `pipx` on macOS? Run `brew install pipx` first.)*
+*(No `pipx`? Run `brew install pipx && pipx ensurepath` first.)*
 
 `setup --yes` detects Claude Code, Codex, Cursor, Gemini CLI, and Antigravity, writes the MCP config, and installs automatic memory hooks where supported. Restart your client and you're live.
 
@@ -106,7 +106,7 @@ Choose the distribution that matches your client:
 | --- | --- | --- |
 | VS Code | Search for **Waggle: Local Memory for AI Agents** in the VS Code Marketplace, then run `Waggle: Enable for this Workspace`. | Run `Waggle: Doctor` from the Command Palette. |
 | Codex | Download the [v0.1.24 Codex marketplace bundle](https://github.com/Abhigyan-Shekhar/Waggle-mcp/releases/tag/v0.1.24), then run `codex plugin marketplace add <bundle-directory>` and `codex plugin add waggle@waggle`. | Start a new Codex task and ask it to run `get_stats`. |
-| Claude, Cursor, Gemini CLI, or another local MCP client | `pipx install waggle-mcp && waggle-mcp setup --yes` | Run `waggle-mcp doctor`, then restart the client. |
+| Claude, Cursor, Gemini CLI, or another local MCP client | `pipx install waggle-mcp`, then run `pipx ensurepath`, restart your terminal, and run `waggle-mcp setup --yes` | Run `waggle-mcp doctor`, then restart the client. |
 | Docker deployments | Pull `ghcr.io/abhigyan-shekhar/waggle-mcp:latest`. | Run the image's built-in `doctor` command. |
 
 Waggle is local-first: its default SQLite database is `~/.waggle/waggle.db`, and it does not require an account, API key, or cloud connection. Memory is exported, synced, or sent to a remote backend only when you explicitly configure that behavior.
@@ -135,6 +135,8 @@ Claude distribution:
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
+# Restart your terminal, then run:
 claude mcp add --transport stdio waggle -- waggle-mcp serve --transport stdio
 ```
 
@@ -375,7 +377,7 @@ Agent: [calls store_node() + store_edge(new_node → old_node, "contradicts")]
 
 ## Setting Up as an MCP Server
 
-> **One-time install:** `pipx install waggle-mcp` — no API key, no cloud account, no Docker required for local use.
+> **One-time install:** `pipx install waggle-mcp`, then run `pipx ensurepath` and restart your terminal before using `waggle-mcp`. No API key, no cloud account, no Docker required for local use.
 
 Shared JSON config for clients that accept `mcpServers` JSON:
 
@@ -527,14 +529,15 @@ Do not expose Waggle publicly without authentication.
 ### `waggle-mcp` not on PATH?
 
 ```bash
+# macOS/Linux
 pipx ensurepath
-exec zsh -l                 # zsh; otherwise close and reopen the terminal
+exec zsh -l
 command -v waggle-mcp
-```
 
-If `pipx list` says Waggle is installed but `command -v` is still empty after
-the restart, rebuild the app link with `pipx reinstall waggle-mcp`. Updating
-`pipx` itself is not normally required.
+# Windows PowerShell
+pipx ensurepath
+Get-Command waggle-mcp
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Recommended:
 - Codex: install the self-hosted Codex MCP plugin from the GitHub Release marketplace bundle
 - MCP clients: use [docs/install](./docs/install/README.md) and Smithery metadata in `smithery.yaml`
 - Claude: use [docs/install/claude-code.md](./docs/install/claude-code.md) or [docs/install/claude-desktop.md](./docs/install/claude-desktop.md)
-- Developers: `pipx install waggle-mcp`
+- Developers: follow [Quick Start](#quick-start) to run `pipx install waggle-mcp`, `pipx ensurepath`, and restart the terminal before setup
 
 ### Start here
 
@@ -531,11 +531,12 @@ Do not expose Waggle publicly without authentication.
 ```bash
 # macOS/Linux
 pipx ensurepath
-exec zsh -l
+# Close and reopen your terminal, then run:
 command -v waggle-mcp
 
 # Windows PowerShell
 pipx ensurepath
+# Close and reopen PowerShell, then run:
 Get-Command waggle-mcp
 ```
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -41,6 +41,12 @@ configuration:
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
+```
+
+Restart the terminal after the first `pipx ensurepath`, then run:
+
+```bash
 waggle-mcp doctor
 ```
 

--- a/docs/install/antigravity.md
+++ b/docs/install/antigravity.md
@@ -10,6 +10,12 @@ No cloud account. No API key. Local by default.
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
+```
+
+Restart the terminal after the first `pipx ensurepath`, then run:
+
+```bash
 waggle-mcp setup --yes --clients antigravity
 ```
 

--- a/docs/install/claude-code.md
+++ b/docs/install/claude-code.md
@@ -10,6 +10,12 @@ No cloud account. No API key. Local by default.
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
+```
+
+Restart the terminal after the first `pipx ensurepath`, then run:
+
+```bash
 claude mcp add --transport stdio waggle -- waggle-mcp serve --transport stdio
 ```
 

--- a/docs/install/claude-desktop.md
+++ b/docs/install/claude-desktop.md
@@ -10,6 +10,12 @@ No cloud account. No API key. Local by default.
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
+```
+
+Restart the terminal after the first `pipx ensurepath`, then run:
+
+```bash
 waggle-mcp setup --yes --clients claude-desktop
 ```
 

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -12,6 +12,12 @@ For direct Codex CLI or source-based MCP setup:
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
+```
+
+Restart the terminal after the first `pipx ensurepath`, then run:
+
+```bash
 waggle-mcp setup --yes
 ```
 

--- a/docs/install/cursor.md
+++ b/docs/install/cursor.md
@@ -10,6 +10,12 @@ No cloud account. No API key. Local by default.
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
+```
+
+Restart the terminal after the first `pipx ensurepath`, then run:
+
+```bash
 waggle-mcp setup --yes --clients cursor
 ```
 

--- a/docs/install/generic-mcp.md
+++ b/docs/install/generic-mcp.md
@@ -10,7 +10,10 @@ No cloud account. No API key. Local by default.
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
 ```
+
+Restart the terminal after the first `pipx ensurepath` before starting Waggle.
 
 ## Manual config
 

--- a/docs/install/smithery.md
+++ b/docs/install/smithery.md
@@ -12,7 +12,10 @@ Install Waggle first:
 
 ```bash
 pipx install waggle-mcp
+pipx ensurepath
 ```
+
+Restart the terminal after the first `pipx ensurepath` before starting Waggle.
 
 ## Manual config
 

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -2,7 +2,20 @@
 
 ## `waggle-mcp: command not found`
 
-Install with `pipx install waggle-mcp`, then run `pipx ensurepath` and restart your shell.
+The package may already be installed while pipx's app directory is missing from
+your shell's `PATH`. On zsh, repair and verify it with:
+
+```bash
+pipx ensurepath
+exec zsh -l
+command -v waggle-mcp
+waggle-mcp doctor
+```
+
+For another shell, close and reopen the terminal instead of running
+`exec zsh -l`. If `pipx list` shows `waggle-mcp` but `command -v waggle-mcp`
+is still empty, run `pipx reinstall waggle-mcp` to recreate its app link.
+Updating pipx itself is not normally required for this error.
 
 ## Python or `pipx` issues
 

--- a/docs/install/vscode.md
+++ b/docs/install/vscode.md
@@ -39,7 +39,9 @@ With the extension's binary install, `command` is the cached executable path und
 
 ## pipx fallback
 
-Set `waggle.installMethod` to `pipx` in VS Code settings if you already use `pipx install waggle-mcp`.
+Set `waggle.installMethod` to `pipx` in VS Code settings if you already use
+`pipx install waggle-mcp`. Run `pipx ensurepath` and restart the terminal and
+VS Code once so the pipx app directory is available on `PATH`.
 
 ## `waggle.mcpConfigScope`
 

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -33,8 +33,22 @@ def test_install_docs_put_pipx_app_directory_on_path() -> None:
 
     for doc_path in install_docs:
         contents = doc_path.read_text()
-        if "pipx install waggle-mcp" in contents:
-            assert "pipx ensurepath" in contents, f"Missing pipx PATH setup in {doc_path.relative_to(ROOT)}"
+        fenced_blocks = re.findall(r"```[^\n]*\n.*?\n```", contents, re.DOTALL)
+        prose = re.sub(r"```[^\n]*\n.*?\n```", "", contents, flags=re.DOTALL)
+        prose_blocks: list[str] = []
+        for block in re.split(r"\n\s*\n", prose):
+            if "pipx install waggle-mcp" not in block:
+                continue
+            if any(line.lstrip().startswith("|") for line in block.splitlines()):
+                prose_blocks.extend(line for line in block.splitlines() if "pipx install waggle-mcp" in line)
+            else:
+                prose_blocks.append(block)
+
+        install_flows = [block for block in [*fenced_blocks, *prose_blocks] if "pipx install waggle-mcp" in block]
+        for install_flow in install_flows:
+            assert "pipx ensurepath" in install_flow, (
+                f"Missing pipx PATH setup in an install flow in {doc_path.relative_to(ROOT)}"
+            )
 
 
 def test_dockerfile_uses_module_entrypoint_for_arg_passthrough() -> None:

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -19,6 +19,24 @@ def test_pyproject_uses_setuptools_src_layout() -> None:
     assert "cryptography>=45.0.0,<46.0.0" in pyproject["project"]["dependencies"]
 
 
+def test_pyproject_exposes_expected_console_scripts() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["scripts"] == {
+        "waggle-mcp": "waggle.server:main",
+        "waggle": "waggle.server:main",
+    }
+
+
+def test_install_docs_put_pipx_app_directory_on_path() -> None:
+    install_docs = [ROOT / "README.md", *(ROOT / "docs" / "install").glob("*.md")]
+
+    for doc_path in install_docs:
+        contents = doc_path.read_text()
+        if "pipx install waggle-mcp" in contents:
+            assert "pipx ensurepath" in contents, f"Missing pipx PATH setup in {doc_path.relative_to(ROOT)}"
+
+
 def test_dockerfile_uses_module_entrypoint_for_arg_passthrough() -> None:
     dockerfile = (ROOT / "Dockerfile").read_text()
 


### PR DESCRIPTION
## Summary

- add `pipx ensurepath` to every pipx-based Waggle installation flow
- require a terminal restart before invoking `waggle-mcp`
- document recovery with `pipx reinstall waggle-mcp` when an existing app link is missing
- add regression coverage for the packaged console scripts and install-guide PATH setup

## Root cause

`pipx install waggle-mcp` can succeed while the pipx application directory is not yet present in the user's shell `PATH`. The published package exposes the expected `waggle-mcp` console script, so upgrading pipx is not normally the fix; the shell must load the path written by `pipx ensurepath`.

## User impact

New users now receive the PATH step before they try to run Waggle. Existing users who see `zsh: command not found: waggle-mcp` get an exact repair and verification sequence.

## Validation

- `pytest -q tests/test_packaging_metadata.py` — 14 passed
- `python3 scripts/check_distribution.py` — passed
- `ruff check tests/test_packaging_metadata.py` — passed
- `ruff format --check tests/test_packaging_metadata.py` — passed
- `git diff --check origin/main...HEAD` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides with PATH setup, terminal restart, and post-install configuration steps.
  * Added macOS guidance for installing pipx and clarified VS Code restart requirements.
  * Expanded troubleshooting for missing commands with platform-specific verification, repair, and reinstall instructions.

* **Tests**
  * Added checks confirming expected command-line tools and required PATH setup guidance across installation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->