### PR TITLE
test(cli): cover doctor help output

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1669,6 +1669,17 @@ def test_cli_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
     assert f"waggle-mcp {waggle.__version__}" in captured.out
 
 
+def test_cli_doctor_help_exits_zero_and_lists_fix_option(capsys: pytest.CaptureFixture[str]) -> None:
+    parser = _build_parser()
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["doctor", "--help"])
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 0
+    assert "--fix" in captured.out
+
+
 def test_store_node_reports_deduplication(tmp_path: Path) -> None:
     app = make_app(tmp_path)
 


### PR DESCRIPTION
## Summary

Added a test for the `doctor --help` command.

The test checks that:
- `--help` exits with code 0
- `--fix` is present in the help output

## Testing

- `pytest tests/test_server.py -k "cli_doctor_help or cli_version_flag"` — 2 passed
- `ruff check tests/test_server.py` — passed
- `git diff --check` — passed

Closes #667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that the `doctor --help` command runs successfully and displays the `--fix` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->