### PR TITLE
test(server): preserve stdout in quiet mode

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1669,6 +1669,29 @@ def test_cli_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
     assert f"waggle-mcp {waggle.__version__}" in captured.out
 
 
+def test_quiet_mode_preserves_machine_readable_stdout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WAGGLE_DB_PATH", str(tmp_path / "waggle.db"))
+    monkeypatch.setenv("WAGGLE_MODEL", "deterministic")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["waggle-mcp", "--quiet", "list-api-keys", "--tenant-id", "test-tenant"],
+    )
+
+    from waggle.server.cli import main
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    captured = capsys.readouterr()
+
+    assert excinfo.value.code == 0
+    payload = json.loads(captured.out)
+    assert payload == []
+
 def test_store_node_reports_deduplication(tmp_path: Path) -> None:
     app = make_app(tmp_path)
 


### PR DESCRIPTION
## Summary

- Added a CLI-level regression test for `--quiet` mode.
- Verifies that machine-readable JSON output from `list-api-keys` remains available and parseable on stdout when quiet mode is enabled.

Closes #652

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

### Test report

```text
1088 passed, 7 skipped, 1 failed

The single failure was unrelated to this change:
tests/test_registry_readiness.py::test_stdio_smoke_initializes_installed_command_without_protocol_noise

Reason: `shutil.which("waggle-mcp")` returned `None` because the CLI executable was not available on PATH.

Focused test:
tests/test_server.py::test_quiet_mode_preserves_machine_readable_stdout PASSED

1 passed