### PR TITLE
docs(rlm): add environment-variable quick reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Conflicts or superseded context:
 | `WAGGLE_RECURSIVE_CONTEXT_DEFAULT_DEPTH` | `2` | Graph expansion depth |
 | `WAGGLE_RECURSIVE_CONTEXT_INCLUDE_EVIDENCE` | `true` | Include transcript evidence |
 
+For the complete list of environment variables and configuration details, see [Environment variables](docs/environment_variables.md).
+
 **Tool aliases:** `recursive_context`, `assemble_context`, `rlm_context` all resolve to `build_context`.
 
 ---


### PR DESCRIPTION
## Summary
Added a link from the RLM environment-variable quick reference to the full environment variables documentation.

- What changed?
- Added a documentation link in README.md below the RLM environment-variable quick-reference table.
- Why was it needed?
- This makes it easier for users to access the full environment variable configuration documentation from the RLM quick reference.

## Testing

- [ ] `WAGGLE_MODEL=deterministic pytest -q`
- [ ] `ruff check src/ tests/`
- [ ] `ruff format --check src/ tests/`

### Test report

Not run — documentation-only change to README.md.
```text
<paste here>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to the complete environment variable and configuration reference.
  * Improved discoverability of available configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->