### PR TITLE
docs: add Windows path quoting examples for MCP configs

### DIFF
--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -139,6 +139,64 @@ $env:PYTHONUTF8 = "1"
 $env:WAGGLE_DB_PATH = "$env:APPDATA\waggle\waggle.db"
 ```
 
+### Quoting paths with spaces in MCP client configs
+
+MCP clients read JSON config files literally. Shell quoting rules from PowerShell or
+`cmd.exe` do not apply inside `claude_desktop_config.json`, `mcp.json`, or
+`.vscode/mcp.json`. This matters when Python, your project folder, or
+`WAGGLE_DB_PATH` contains spaces (for example `C:\Program Files\...` or
+`C:\E Drive\in progress 2\...`).
+
+**Rules for JSON config files:**
+
+- Put the executable in `"command"` and flags in `"args"`; do not join them into one shell string.
+- Escape backslashes in JSON strings by doubling them: `\\`.
+- Forward slashes also work on Windows and are often easier to read in JSON:
+  `C:/Users/Amir/AppData/Roaming/waggle/waggle.db`.
+- Do not rely on `~` in JSON on Windows; use a full path or set `WAGGLE_DB_PATH`
+  through your shell before launching the client.
+
+**Example: local venv under a path with spaces**
+
+```json
+{
+  "mcpServers": {
+    "waggle": {
+      "command": "C:/E Drive/in progress 2/Waggle-mcp/.venv/Scripts/python.exe",
+      "args": ["-m", "waggle.server", "serve", "--transport", "stdio"],
+      "env": {
+        "WAGGLE_BACKEND": "sqlite",
+        "WAGGLE_DB_PATH": "C:/Users/Amir/AppData/Roaming/waggle/waggle.db",
+        "WAGGLE_DEFAULT_TENANT_ID": "local-default",
+        "WAGGLE_MODEL": "all-MiniLM-L6-v2"
+      }
+    }
+  }
+}
+```
+
+**Test the command outside the client first**
+
+PowerShell:
+
+```powershell
+& "C:\E Drive\in progress 2\Waggle-mcp\.venv\Scripts\python.exe" -m waggle.server serve --transport stdio
+```
+
+`cmd.exe`:
+
+```cmd
+"C:\E Drive\in progress 2\Waggle-mcp\.venv\Scripts\python.exe" -m waggle.server serve --transport stdio
+```
+
+If the manual command starts but the MCP client fails, compare your JSON `command`
+and `args` against the working shell invocation. A missing quote or single backslash
+in JSON is the most common cause.
+
+When `waggle-mcp` is already on `PATH` (for example after `pipx install waggle-mcp`),
+the simple config in [generic-mcp.md](./generic-mcp.md) is usually enough because the
+command name has no spaces.
+
 ### Enable verbose logs on Windows
 
 ```powershell


### PR DESCRIPTION
## Summary

- Adds a Windows troubleshooting subsection for quoting paths with spaces in MCP client JSON configs (`claude_desktop_config.json`, `mcp.json`, `.vscode/mcp.json`).
- Documents JSON escaping rules, a full example config for a spaced project path, and PowerShell/`cmd.exe` commands to test the server outside the client.

Fixes #631

## Test plan

- [x] `python scripts/check_markdown_links.py` passes
- [ ] Maintainer review for accuracy of Windows JSON and shell examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows troubleshooting guidance for configuring MCP clients when file paths contain spaces.
  * Clarified JSON quoting, executable and argument placement, backslash escaping, and path formatting.
  * Included configuration examples and PowerShell and Command Prompt validation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->