### PR TITLE
fix(retrieval): bind CandidateT to a Protocol requiring .ts in rank_t…

### DIFF
--- a/src/waggle/retrieval/rankers/temporal.py
+++ b/src/waggle/retrieval/rankers/temporal.py
@@ -1,24 +1,32 @@
 """Temporal ranking with topic gating for latest/oldest graph queries."""
 
 from __future__ import annotations
-
+# AFTER
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal, TypeVar
+from typing import Generic, Literal, Protocol, TypeVar
 
 from waggle.retrieval.scorers.topic_relevance import TopicScore, score_topic_relevance
 
 TOPIC_THRESHOLD = 0.35
 TemporalDirection = Literal["latest", "oldest"]
-CandidateT = TypeVar("CandidateT")
+
+
+class HasTimestamp(Protocol):
+    """Structural type for anything rank_temporal can sort by time."""
+
+    ts: datetime | str
+
+
+CandidateT = TypeVar("CandidateT", bound=HasTimestamp)
 
 
 @dataclass(frozen=True)
-class RankedTemporalCandidate:
+class RankedTemporalCandidate(Generic[CandidateT]):
     """A temporal candidate paired with its topic score."""
 
-    candidate: object
+    candidate: CandidateT
     topic_score: TopicScore
     timestamp: datetime
 
@@ -57,7 +65,7 @@ def rank_temporal(
         raise ValueError("direction must be 'latest' or 'oldest'.")
 
     ranked = [
-        RankedTemporalCandidate(
+        RankedTemporalCandidate[CandidateT](
             candidate=candidate,
             topic_score=score_topic_relevance(
                 query,


### PR DESCRIPTION
## Summary
Fixes #712 — `rank_temporal()` accepted candidates without a `.ts`
attribute due to an unbound generic type, causing a runtime
`AttributeError` instead of a static type error.

## Bug details
- **File:** `src/waggle/retrieval/rankers/temporal.py`
- **Function:** `rank_temporal()`

| # | Issue | Location |
|---|---|---|
| 1 | `CandidateT = TypeVar("CandidateT")` was unbound — nothing declared that candidates must have `.ts` | line 14 |
| 2 | `candidate.ts` accessed unconditionally with no static guarantee it exists → `AttributeError` risk at runtime for any caller passing the wrong shape | line 67 |
| 3 | `RankedTemporalCandidate.candidate` typed as bare `object`, erasing the candidate's real type | line 21 |
| 4 | Consequence of #3: the function's declared return type `list[CandidateT]` didn't actually match what was returned (mypy: `List comprehension has incompatible type List[object]; expected List[CandidateT]`) | line 98 |

## Fix
- Added a `HasTimestamp` Protocol requiring `ts: datetime | str`.
- Bound `CandidateT` to it: `TypeVar("CandidateT", bound=HasTimestamp)`.
- Made `RankedTemporalCandidate` generic (`Generic[CandidateT]`) with `candidate: CandidateT` instead of `object`.
- Updated the instantiation site to `RankedTemporalCandidate[CandidateT](...)`.

## Testing
- `python3 -m pytest tests/test_temporal.py -v` → all 4 existing tests pass unchanged (confirms no behavior change).
- Added a throwaway negative check: calling `rank_temporal` with a candidate missing `.ts` now fails at type-check time (`error: Value of type variable "CandidateT" of "rank_temporal" cannot be "NoTimestamp" [type-var]`), instead of only at runtime.
- `py_compile`, `pyflakes`, and `mypy --ignore-missing-imports` all pass clean on the changed file.

## Risk
None — purely a type-annotation change, no runtime logic touched. Existing callers with valid candidates are unaffected.

Closes #712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved temporal ranking type safety and consistency.
  * Preserved candidate types through temporal ranking results.
  * Added timestamp requirements for supported candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->