### PR TITLE
test(rate-limit): cover reset after expiry

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -21,6 +21,31 @@ async def test_rate_limiter_read_limit():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("is_write", [False, True], ids=["read", "write"])
+async def test_exhausted_bucket_accepts_requests_after_window_expires(
+    monkeypatch: pytest.MonkeyPatch, is_write: bool
+) -> None:
+    now = 100.0
+    monkeypatch.setattr("waggle.rate_limit.time.monotonic", lambda: now)
+    limiter = RateLimiter(
+        requests_per_minute=2,
+        write_requests_per_minute=2,
+        max_concurrent_requests=5,
+    )
+
+    await limiter.check_rate("test_user_reset", is_write=is_write)
+    await limiter.check_rate("test_user_reset", is_write=is_write)
+    with pytest.raises(RateLimitExceededError):
+        await limiter.check_rate("test_user_reset", is_write=is_write)
+
+    now += 60.001
+    await limiter.check_rate("test_user_reset", is_write=is_write)
+
+    bucket = limiter._write_windows if is_write else limiter._request_windows
+    assert list(bucket["test_user_reset"]) == [now]
+
+
+@pytest.mark.asyncio
 async def test_rate_limiter_read_write_independence():
     limiter = RateLimiter(
         requests_per_minute=2,


### PR DESCRIPTION
## Summary

- Add deterministic clock-based regression coverage for rate-limit buckets after their 60-second window expires.
- Exercise both read and write buckets, including initial exhaustion, post-expiry admission, and removal of stale timestamps.

Fixes #636

## Testing

- [x] `WAGGLE_MODEL=deterministic pytest -q`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`

### Test report

```text
tests/test_rate_limit.py::test_exhausted_bucket_accepts_requests_after_window_expires[read] PASSED
tests/test_rate_limit.py::test_exhausted_bucket_accepts_requests_after_window_expires[write] PASSED
2 passed, 11 deselected in 0.02s
```

Additional validation:

- `WAGGLE_MODEL=deterministic pytest -q`: 1134 passed, 7 skipped
- `python scripts/check_markdown_links.py`: all links valid
- `python scripts/sync_version.py --check`: all files at 0.1.25
- Mutation check: disabling expired-entry cleanup makes both new cases fail

## Implementation notes

The test patches the monotonic clock used by `RateLimiter`, fills a bucket to its configured limit, confirms the next request is rejected, advances beyond the window, and verifies a new request succeeds with only the fresh timestamp retained. Parameterizing `is_write` covers both bucket maps through the same production boundary.

## AI assistance disclosure

This contribution was implemented and validated with Codex. I reviewed the issue, repository guidance, code, test behavior, and final diff and can explain the implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that rate-limited requests are accepted again after the rate-limit window expires.
  * Confirmed the behavior for both read and write requests.
  * Verified that expired rate-limit buckets retain only the timestamp from the newly accepted request.
  * Added explanatory documentation to clarify rate-limit expiration scenarios and expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->